### PR TITLE
Added indicator for vanilla toggle sprint

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -39,7 +39,11 @@ public class SkyblockerConfig implements ConfigData {
         @ConfigEntry.Category("bars")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
         public Bars bars = new Bars();
-      
+
+        @ConfigEntry.Category("sprint")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
+        public SprintHud sprinthud = new SprintHud();
+
         @ConfigEntry.Category("itemList")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
         public ItemList itemList = new ItemList();
@@ -59,6 +63,11 @@ public class SkyblockerConfig implements ConfigData {
     public static class Bars {
         public boolean enableBars = true;
     }
+
+    public static class SprintHud {
+        public boolean enableSprintHud = false;
+    }
+
     public static class RichPresence {
         public boolean enableRichPresence = false;
         @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/InGameHudMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/InGameHudMixin.java
@@ -6,6 +6,7 @@ import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import me.xmrvizzy.skyblocker.skyblock.FancyStatusBars;
 import me.xmrvizzy.skyblocker.skyblock.HotbarSlotLock;
 import me.xmrvizzy.skyblocker.skyblock.StatusBarTracker;
+import me.xmrvizzy.skyblocker.skyblock.ToggleHud;
 import me.xmrvizzy.skyblocker.skyblock.dungeon.DungeonMap;
 import me.xmrvizzy.skyblocker.utils.Utils;
 import net.fabricmc.api.EnvType;
@@ -102,5 +103,12 @@ public abstract class InGameHudMixin extends DrawableHelper {
     private void renderMountHealth(MatrixStack matrices, CallbackInfo ci) {
         if (Utils.isOnSkyblock && SkyblockerConfig.get().general.bars.enableBars)
             ci.cancel();
+    }
+
+    @Inject(method="render", at=@At("HEAD"))
+    public void render(MatrixStack matrices, float tickDelta, CallbackInfo ci) {
+        if (SkyblockerConfig.get().general.sprinthud.enableSprintHud) {
+            ToggleHud.render(matrices);
+        }
     }
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/ToggleHud.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/ToggleHud.java
@@ -1,0 +1,20 @@
+package me.xmrvizzy.skyblocker.skyblock;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.math.MatrixStack;
+
+public class ToggleHud {
+    static final MinecraftClient mc = MinecraftClient.getInstance();
+
+    public static void render(MatrixStack matrices) {
+        final int height = mc.getWindow().getScaledHeight();
+        final int widthcenter = mc.getWindow().getScaledWidth() / 2;
+
+
+        if (mc.options.sprintKey.isPressed() && mc.options.sprintToggled) {
+            mc.textRenderer.drawWithShadow(matrices, "✦", widthcenter - 102F, height-13F, 16777215);
+        } else if (mc.options.sprintKey.isPressed() && !mc.options.sprintToggled) {
+            mc.textRenderer.drawWithShadow(matrices, "✧", widthcenter - 102F, height-13F, 16777215);
+        }
+    }
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -8,6 +8,8 @@
   "text.autoconfig.skyblocker.category.general": "General",
   "text.autoconfig.skyblocker.option.general.bars": "Health, Mana, Defence & XP Bars",
   "text.autoconfig.skyblocker.option.general.bars.enableBars": "Enable Bars",
+  "text.autoconfig.skyblocker.option.general.sprinthud": "Vanilla Toggle Sprint indicator",
+  "text.autoconfig.skyblocker.option.general.sprinthud.enableSprintHud": "Enable Toggle Sprint HUD",
   "text.autoconfig.skyblocker.option.general.quicknav": "Quicknav",
   "text.autoconfig.skyblocker.option.general.quicknav.enableQuicknav": "Enable Quicknav",
   "text.autoconfig.skyblocker.option.general.backpackPreviewWithoutShift": "View backpack preview without holding Shift",

--- a/src/main/resources/assets/skyblocker/lang/ru_ru.json
+++ b/src/main/resources/assets/skyblocker/lang/ru_ru.json
@@ -6,6 +6,8 @@
   "text.autoconfig.skyblocker.category.general": "Основные",
   "text.autoconfig.skyblocker.option.general.bars": "Полоски здоровья, маны, защиты и опыта",
   "text.autoconfig.skyblocker.option.general.bars.enableBars": "Включить полоски",
+  "text.autoconfig.skyblocker.option.general.sprinthud": "Индикатор переключения спринта",
+  "text.autoconfig.skyblocker.option.general.sprinthud.enableSprintHud": "Включить отображение спринта",
 
   "text.autoconfig.skyblocker.category.locations": "Локации",
   "text.autoconfig.skyblocker.option.locations.dungeons": "Катакомбы",


### PR DESCRIPTION
Changes
- added indicator (✦) for when sprint is toggled
- added indicator (✧) for when sprint is not toggled but sprinting
- all of this can be disabled in the config
- added en_us and ru_ru locale for the config screen text (Russian translated by @cephetir)