### PR TITLE
1.19.1 update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 org.gradle.jvmargs=-Xmx1G -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US
 
 # Fabric Properties (https://fabricmc.net/versions.html)
-minecraft_version=1.19.1-rc2
-yarn_mappings=1.19.1-rc2+build.1
+minecraft_version=1.19.1
+yarn_mappings=1.19.1+build.3
 loader_version=0.14.6
 
 #Fabric api
-fabric_version=0.58.0+1.19.1
+fabric_version=0.58.5+1.19.1
 
 # Dependencies
 ## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)
 clothconfig_version=7.0.65
 ## Mod Menu (https://www.curseforge.com/minecraft/mc-mods/modmenu/files)
-mod_menu_version=4.0.0-beta.4
+mod_menu_version=4.0.5
 
 # Mod Properties
 mod_version = 1.8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 org.gradle.jvmargs=-Xmx1G -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US
 
 # Fabric Properties (https://fabricmc.net/versions.html)
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
+minecraft_version=1.19.1-pre4
+yarn_mappings=1.19.1-pre4+build.4
 loader_version=0.14.6
 
 #Fabric api
-fabric_version=0.55.1+1.19
+fabric_version=0.57.2+1.19.1
 
 # Dependencies
 ## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 org.gradle.jvmargs=-Xmx1G -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US
 
 # Fabric Properties (https://fabricmc.net/versions.html)
-minecraft_version=1.19.1-pre4
-yarn_mappings=1.19.1-pre4+build.4
+minecraft_version=1.19.1-rc2
+yarn_mappings=1.19.1-rc2+build.1
 loader_version=0.14.6
 
 #Fabric api
-fabric_version=0.57.2+1.19.1
+fabric_version=0.58.0+1.19.1
 
 # Dependencies
 ## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)
@@ -19,4 +19,4 @@ mod_version = 1.8.1
 maven_group = me.xmrvizzy
 archives_base_name = skyblocker
 modrinth_id=y6DuFGwJ
-suported_version=1.19.x
+suported_version=1.19.1

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ChatHudListenerMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ChatHudListenerMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatHud;
 import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.network.message.MessageSignatureData;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,8 +23,8 @@ public class ChatHudListenerMixin {
     @Final
     private MinecraftClient client;
 
-    @Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/hud/MessageIndicator;)V", at = @At("HEAD"), cancellable = true)
-    public void onMessage(Text message, MessageIndicator indicator, CallbackInfo ci) {
+    @Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V", at = @At("HEAD"), cancellable = true)
+    public void onMessage(Text message, MessageSignatureData signature, int ticks, MessageIndicator indicator, boolean refresh, CallbackInfo ci) {
         if (!Utils.isOnSkyblock)
             return;
         String asString = message.getString();

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ChatHudListenerMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ChatHudListenerMixin.java
@@ -4,10 +4,9 @@ import me.xmrvizzy.skyblocker.chat.ChatFilterResult;
 import me.xmrvizzy.skyblocker.chat.ChatMessageListener;
 import me.xmrvizzy.skyblocker.utils.Utils;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.hud.ChatHudListener;
+import net.minecraft.client.gui.hud.ChatHud;
+import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.network.message.MessageSender;
-import net.minecraft.network.message.MessageType;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,17 +15,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.UUID;
-
-@Mixin(ChatHudListener.class)
+@Mixin(ChatHud.class)
 public class ChatHudListenerMixin {
 
     @Shadow
     @Final
     private MinecraftClient client;
 
-    @Inject(method = "onChatMessage", at = @At("HEAD"), cancellable = true)
-    public void onMessage(MessageType type, Text message, MessageSender sender, CallbackInfo ci) {
+    @Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/hud/MessageIndicator;)V", at = @At("HEAD"), cancellable = true)
+    public void onMessage(Text message, MessageIndicator indicator, CallbackInfo ci) {
         if (!Utils.isOnSkyblock)
             return;
         String asString = message.getString();

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/Reparty.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/Reparty.java
@@ -30,7 +30,7 @@ public class Reparty extends ChatPatternListener {
             dispatcher.register(ClientCommandManager.literal("rp").executes(context -> {
                 if (!Utils.isOnSkyblock || this.repartying || client.player == null) return 0;
                 this.repartying = true;
-                client.player.sendChatMessage("/p list");
+                client.player.sendChatMessage("/p list", Text.of("/p list"));
                 return 0;
             }));
         });
@@ -77,6 +77,6 @@ public class Reparty extends ChatPatternListener {
     }
 
     private void sendCommand(ClientPlayerEntity player, String command, int delay) {
-        skyblocker.scheduler.schedule(() -> player.sendChatMessage(command), delay * BASE_DELAY);
+        skyblocker.scheduler.schedule(() -> player.sendChatMessage(command, Text.of(command)), delay * BASE_DELAY);
     }
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/quicknav/QuickNavButton.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/quicknav/QuickNavButton.java
@@ -60,7 +60,7 @@ public class QuickNavButton extends ClickableWidget {
     public void onClick(double mouseX, double mouseY) {
         if (!this.toggled) {
             this.toggled = true;
-            CLIENT.player.sendChatMessage(command);
+            CLIENT.player.sendChatMessage(command, Text.of(command));
         }
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
     "fabricloader": ">=0.14.6",
     "fabric": "*",
 	"cloth-config2": "*",
-    "minecraft": ["1.19.x"]
+    "minecraft": ["~1.19.1-beta.4"]
   },
   "custom": {
     "modmenu": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
     "fabricloader": ">=0.14.6",
     "fabric": "*",
 	"cloth-config2": "*",
-    "minecraft": ["~1.19.1-rc.2"]
+    "minecraft": [">=1.19.1"]
   },
   "custom": {
     "modmenu": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
     "fabricloader": ">=0.14.6",
     "fabric": "*",
 	"cloth-config2": "*",
-    "minecraft": ["~1.19.1-beta.4"]
+    "minecraft": ["~1.19.1-rc.2"]
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
Currently, skyblocker 1.8.1 crashes when opening the interface on Minecraft 1.19.1-pre4 (and therefore, 1.19.1 too), which is why an update is needed

Edit: haven't ran into any issues yet, I think this works