### PR TITLE
Fix trivia solver glitch

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/Trivia.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/Trivia.java
@@ -16,7 +16,7 @@ public class Trivia extends ChatPatternListener {
     private List<String> solutions = Collections.emptyList();
 
     public Trivia() {
-        super("^ +(?:([A-Za-z' ]*\\?)|§6 ([ⓐⓑⓒ]) §a([a-zA-Z0-9 ]+))$");
+        super("^ +(?:([A-Za-z,' ]*\\?)|§6 ([ⓐⓑⓒ]) §a([a-zA-Z0-9 ]+))$");
     }
 
     @Override
@@ -64,6 +64,7 @@ public class Trivia extends ChatPatternListener {
         answers.put("What is the status of Goldor?", new String[]{"The Wither Lords"});
         answers.put("What is the status of Storm?", new String[]{"The Wither Lords"});
         answers.put("What is the status of Necron?", new String[]{"The Wither Lords"});
+        answers.put("What is the status of Maxor, Storm, Goldor and Necron?", new String[]{"The Wither Lords"});
         answers.put("How many total Fairy Souls are there?", new String[]{"238 Fairy Souls"});
         answers.put("How many Fairy Souls are there in Spider's Den?", new String[]{"19 Fairy Souls"});
         answers.put("How many Fairy Souls are there in The End?", new String[]{"12 Fairy Souls"});

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/Trivia.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/Trivia.java
@@ -40,13 +40,14 @@ public class Trivia extends ChatPatternListener {
     }
 
     private void updateSolutions(String question) {
-        if (question.equals("What SkyBlock year is it?")) {
+        String trimmedQuestion = question.trim();
+        if (trimmedQuestion.equals("What SkyBlock year is it?")) {
             long currentTime = System.currentTimeMillis() / 1000L;
             long diff = currentTime - 1560276000;
             int year = (int) (diff / 446400 + 1);
             solutions = Collections.singletonList("Year " + year);
         } else {
-            solutions = Arrays.asList(answers.get(question));
+            solutions = Arrays.asList(answers.get(trimmedQuestion));
         }
     }
 


### PR DESCRIPTION
This simply fixes the glitch of trivia solver which causes the *question* to disappear and the solver not to work.

This doesn't change the origin code logic, so other uncommon existing problems needn't fixing (*e.g.*, *problem* disapears when it's not recorded in the answer list.) isn't fixed.

**Only tested on my local computer**