### PR TITLE
Adding QuickNav Customization

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -6,6 +6,7 @@ import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import me.xmrvizzy.skyblocker.chat.ChatFilterResult;
+import net.minecraft.item.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,98 @@ public class SkyblockerConfig implements ConfigData {
     @ConfigEntry.Gui.TransitiveObject
     public RichPresence richPresence = new RichPresence();
 
+    @ConfigEntry.Category("quickNav")
+    @ConfigEntry.Gui.TransitiveObject
+    public QuickNav quickNav = new QuickNav();
+
+    public static class QuickNav {
+        public boolean enableQuickNav = true;
+
+        @ConfigEntry.Category("button1")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button1 = new QuickNavItem(true, new ItemData("diamond_sword"), "Your Skills", "/skills");
+
+        @ConfigEntry.Category("button2")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button2 = new QuickNavItem(true, new ItemData("painting"), "Collection", "/collection");
+
+        @ConfigEntry.Category("button3")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button3 = new QuickNavItem(false, new ItemData("air"), "", "");
+
+        @ConfigEntry.Category("button4")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button4 = new QuickNavItem(true, new ItemData("bone"), "Pets", "/pets");
+
+        @ConfigEntry.Category("button5")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button5 = new QuickNavItem(true, new ItemData("leather_chestplate", 1, "tag:{display:{color:8991416}}"), "Wardrobe", "/wardrobe");
+
+        @ConfigEntry.Category("button6")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button6 = new QuickNavItem(true, new ItemData("ender_chest"),  "Storage", "/storage");
+
+        @ConfigEntry.Category("button7")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button7 = new QuickNavItem(true, new ItemData("player_head", 1, "tag:{SkullOwner:{Id:[I;-300151517,-631415889,-1193921967,-1821784279],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDdjYzY2ODc0MjNkMDU3MGQ1NTZhYzUzZTA2NzZjYjU2M2JiZGQ5NzE3Y2Q4MjY5YmRlYmVkNmY2ZDRlN2JmOCJ9fX0=\"}]}}}"), "", "/hub");
+
+        @ConfigEntry.Category("button8")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button8 = new QuickNavItem(true, new ItemData("player_head", 1, "tag:{SkullOwner:{Id:[I;1605800870,415127827,-1236127084,15358548],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzg5MWQ1YjI3M2ZmMGJjNTBjOTYwYjJjZDg2ZWVmMWM0MGExYjk0MDMyYWU3MWU3NTQ3NWE1NjhhODI1NzQyMSJ9fX0=\"}]}}}"), "", "/warp dungeon");
+
+        @ConfigEntry.Category("button9")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button9 = new QuickNavItem(false, new ItemData("air"), "", "");
+
+        @ConfigEntry.Category("button10")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button10 = new QuickNavItem(true, new ItemData("enchanting_table"), "Enchant", "/enchant");
+
+        @ConfigEntry.Category("button11")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button11 = new QuickNavItem(true, new ItemData("anvil"), "Anvil", "/anvil");
+
+        @ConfigEntry.Category("button12")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public QuickNavItem button12 = new QuickNavItem(true, new ItemData("crafting_table"), "Craft Item", "/craft");
+    }
+
+    public static class QuickNavItem {
+        public QuickNavItem(Boolean render, ItemData itemData, String uiTitle, String clickEvent) {
+            this.render = render;
+            this.item = itemData;
+            this.clickEvent = clickEvent;
+            this.uiTitle = uiTitle;
+        }
+
+        public Boolean render;
+
+        @ConfigEntry.Category("item")
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public ItemData item;
+
+        public String uiTitle;
+        public String clickEvent;
+    }
+
+    public static class ItemData {
+        public ItemData(String itemName, int count, String nbt) {
+            this.itemName = itemName;
+            this.count = count;
+            this.nbt = nbt;
+        }
+
+        public ItemData(String itemName) {
+            this.itemName = itemName;
+            this.count = 1;
+            this.nbt = "";
+        }
+
+        public String itemName;
+        public int count;
+        public String nbt;
+    }
+
     public static class General {
         public boolean enableUpdateNotification = true;
         public boolean backpackPreviewWithoutShift = false;
@@ -43,10 +136,6 @@ public class SkyblockerConfig implements ConfigData {
         @ConfigEntry.Category("itemList")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
         public ItemList itemList = new ItemList();
-
-        @ConfigEntry.Category("quicknav")
-        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
-        public Quicknav quicknav = new Quicknav();
 
         @ConfigEntry.Category("itemTooltip")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
@@ -121,10 +210,6 @@ public class SkyblockerConfig implements ConfigData {
 
     public static class ItemList {
         public boolean enableItemList = true;
-    }
-
-    public static class Quicknav {
-        public boolean enableQuicknav = true;
     }
 
     public enum Average {

--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -63,11 +63,11 @@ public class SkyblockerConfig implements ConfigData {
 
         @ConfigEntry.Category("button7")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
-        public QuickNavItem button7 = new QuickNavItem(true, new ItemData("player_head", 1, "tag:{SkullOwner:{Id:[I;-300151517,-631415889,-1193921967,-1821784279],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDdjYzY2ODc0MjNkMDU3MGQ1NTZhYzUzZTA2NzZjYjU2M2JiZGQ5NzE3Y2Q4MjY5YmRlYmVkNmY2ZDRlN2JmOCJ9fX0=\"}]}}}"), "", "/hub");
+        public QuickNavItem button7 = new QuickNavItem(true, new ItemData("player_head", 1, "tag:{SkullOwner:{Id:[I;-300151517,-631415889,-1193921967,-1821784279],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDdjYzY2ODc0MjNkMDU3MGQ1NTZhYzUzZTA2NzZjYjU2M2JiZGQ5NzE3Y2Q4MjY5YmRlYmVkNmY2ZDRlN2JmOCJ9fX0=\"}]}}}"), "none", "/hub");
 
         @ConfigEntry.Category("button8")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
-        public QuickNavItem button8 = new QuickNavItem(true, new ItemData("player_head", 1, "tag:{SkullOwner:{Id:[I;1605800870,415127827,-1236127084,15358548],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzg5MWQ1YjI3M2ZmMGJjNTBjOTYwYjJjZDg2ZWVmMWM0MGExYjk0MDMyYWU3MWU3NTQ3NWE1NjhhODI1NzQyMSJ9fX0=\"}]}}}"), "", "/warp dungeon");
+        public QuickNavItem button8 = new QuickNavItem(true, new ItemData("player_head", 1, "tag:{SkullOwner:{Id:[I;1605800870,415127827,-1236127084,15358548],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzg5MWQ1YjI3M2ZmMGJjNTBjOTYwYjJjZDg2ZWVmMWM0MGExYjk0MDMyYWU3MWU3NTQ3NWE1NjhhODI1NzQyMSJ9fX0=\"}]}}}"), "none", "/warp dungeon");
 
         @ConfigEntry.Category("button9")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
@@ -75,7 +75,7 @@ public class SkyblockerConfig implements ConfigData {
 
         @ConfigEntry.Category("button10")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
-        public QuickNavItem button10 = new QuickNavItem(true, new ItemData("enchanting_table"), "Enchant", "/enchant");
+        public QuickNavItem button10 = new QuickNavItem(true, new ItemData("enchanting_table"), "Enchant", "/etable");
 
         @ConfigEntry.Category("button11")
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -36,7 +36,7 @@ public abstract class HandledScreenMixin extends Screen {
     @Inject(method = "init()V", at = @At("TAIL"))
     private void init(CallbackInfo ci) {
         // quicknav
-        if (Utils.isOnSkyblock && SkyblockerConfig.get().general.quicknav.enableQuicknav) {
+        if (Utils.isOnSkyblock && SkyblockerConfig.get().quickNav.enableQuickNav) {
             String screenTitle = super.getTitle().getString().trim();
             List<QuickNavButton> buttons = QuickNav.init(screenTitle);
             for (QuickNavButton button : buttons) super.addDrawableChild(button);

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/quicknav/QuickNav.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/quicknav/QuickNav.java
@@ -1,35 +1,50 @@
 package me.xmrvizzy.skyblocker.skyblock.quicknav;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.StringNbtReader;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 public class QuickNav {
     private static final String skyblockHubIconNbt = "{id:\"minecraft:player_head\",Count:1,tag:{SkullOwner:{Id:[I;-300151517,-631415889,-1193921967,-1821784279],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDdjYzY2ODc0MjNkMDU3MGQ1NTZhYzUzZTA2NzZjYjU2M2JiZGQ5NzE3Y2Q4MjY5YmRlYmVkNmY2ZDRlN2JmOCJ9fX0=\"}]}}}}";
     private static final String dungeonHubIconNbt = "{id:\"minecraft:player_head\",Count:1,tag:{SkullOwner:{Id:[I;1605800870,415127827,-1236127084,15358548],Properties:{textures:[{Value:\"e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzg5MWQ1YjI3M2ZmMGJjNTBjOTYwYjJjZDg2ZWVmMWM0MGExYjk0MDMyYWU3MWU3NTQ3NWE1NjhhODI1NzQyMSJ9fX0=\"}]}}}}";
     public static List<QuickNavButton> init(String screenTitle) {
         List<QuickNavButton> buttons = new ArrayList<>();
+        SkyblockerConfig.QuickNav data = SkyblockerConfig.get().quickNav;
         try {
-            buttons.add(new QuickNavButton(0, screenTitle.contains("Your Skills"), "/skills", new ItemStack(Items.DIAMOND_SWORD)));
-            buttons.add(new QuickNavButton(1, screenTitle.contains("Collection"), "/collection", new ItemStack(Items.PAINTING)));
-
-            buttons.add(new QuickNavButton(3, screenTitle.contains("Pets"), "/pets", new ItemStack(Items.BONE)));
-            buttons.add(new QuickNavButton(4, screenTitle.contains("Wardrobe"), "/wardrobe", ItemStack.fromNbt(StringNbtReader.parse("{id:\"minecraft:leather_chestplate\", Count:1, tag:{display:{color:8991416}}}"))));
-            buttons.add(new QuickNavButton(5, screenTitle.contains("Storage"), "/storage", new ItemStack(Items.ENDER_CHEST)));
-
-            buttons.add(new QuickNavButton(6, false, "/warp hub", ItemStack.fromNbt(StringNbtReader.parse(skyblockHubIconNbt))));
-            buttons.add(new QuickNavButton(7, false, "/warp dungeon_hub", ItemStack.fromNbt(StringNbtReader.parse(dungeonHubIconNbt))));
-
-            buttons.add(new QuickNavButton(9, screenTitle.contains("Enchant Item"), "/etable", new ItemStack(Items.ENCHANTING_TABLE)));
-            buttons.add(new QuickNavButton(10, screenTitle.contains("Anvil"), "/anvil", new ItemStack(Items.ANVIL)));
-            buttons.add(new QuickNavButton(11, screenTitle.contains("Craft Item"), "/craft", new ItemStack(Items.CRAFTING_TABLE)));
+            if (data.button1.render) buttons.add(parseButton(data.button1, screenTitle, 0));
+            if (data.button2.render) buttons.add(parseButton(data.button2, screenTitle, 1));
+            if (data.button3.render) buttons.add(parseButton(data.button3, screenTitle, 2));
+            if (data.button4.render) buttons.add(parseButton(data.button4, screenTitle, 3));
+            if (data.button5.render) buttons.add(parseButton(data.button5, screenTitle, 4));
+            if (data.button6.render) buttons.add(parseButton(data.button6, screenTitle, 5));
+            if (data.button7.render) buttons.add(parseButton(data.button7, screenTitle, 6));
+            if (data.button8.render) buttons.add(parseButton(data.button8, screenTitle, 7));
+            if (data.button9.render) buttons.add(parseButton(data.button9, screenTitle, 8));
+            if (data.button10.render) buttons.add(parseButton(data.button10, screenTitle, 9));
+            if (data.button11.render) buttons.add(parseButton(data.button11, screenTitle, 10));
+            if (data.button12.render) buttons.add(parseButton(data.button12, screenTitle, 11));
         } catch (CommandSyntaxException e) {
             e.printStackTrace();
         }
         return buttons;
+    }
+
+    private static QuickNavButton parseButton(SkyblockerConfig.QuickNavItem buttonInfo, String screenTitle, int id) throws CommandSyntaxException {
+        SkyblockerConfig.ItemData itemData = buttonInfo.item;
+        String nbtString = "{id:\"minecraft:" + itemData.itemName.toLowerCase(Locale.ROOT) + "\",Count:1";
+        if (itemData.nbt.length() > 2) nbtString += "," + itemData.nbt;
+        nbtString += "}";
+        return new QuickNavButton(id,
+                screenTitle.contains(buttonInfo.uiTitle),
+                buttonInfo.clickEvent,
+                ItemStack.fromNbt(StringNbtReader.parse(nbtString))
+        );
     }
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
@@ -22,6 +22,7 @@ public class Utils {
     public static void sbChecker() {
         MinecraftClient client = MinecraftClient.getInstance();
         List<String> sidebar;
+
         if (client.world == null || client.isInSingleplayer() || (sidebar = getSidebar()) == null) {
             isOnSkyblock = false;
             isInDungeons = false;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -37,6 +37,21 @@
   "text.autoconfig.skyblocker.option.richPresence.enableRichPresence": "Enabled",
   "text.autoconfig.skyblocker.option.richPresence.customMessage": "Custom Message",
 
+  "text.autoconfig.skyblocker.category.quickNav" : "Quick Navigation",
+  "text.autoconfig.skyblocker.option.quickNav.enableQuickNav" : "Enable Quick Navigation",
+  "text.autoconfig.skyblocker.option.quickNav.button1" : "Button 1",
+  "text.autoconfig.skyblocker.option.quickNav.button2" : "Button 2",
+  "text.autoconfig.skyblocker.option.quickNav.button3" : "Button 3",
+  "text.autoconfig.skyblocker.option.quickNav.button4" : "Button 4",
+  "text.autoconfig.skyblocker.option.quickNav.button5" : "Button 5",
+  "text.autoconfig.skyblocker.option.quickNav.button6" : "Button 6",
+  "text.autoconfig.skyblocker.option.quickNav.button7" : "Button 7",
+  "text.autoconfig.skyblocker.option.quickNav.button8" : "Button 8",
+  "text.autoconfig.skyblocker.option.quickNav.button9" : "Button 9",
+  "text.autoconfig.skyblocker.option.quickNav.button10" : "Button 10",
+  "text.autoconfig.skyblocker.option.quickNav.button11" : "Button 11",
+  "text.autoconfig.skyblocker.option.quickNav.button12" : "Button 12",
+
   "text.autoconfig.skyblocker.option.general.itemList": "Item List",
   "text.autoconfig.skyblocker.option.general.itemList.enableItemList": "Enable Item List",
 


### PR DESCRIPTION
Adding a way to customize the quick navigation buttons in the inventory. Every button can be toggled, has a display icon with nbt data, a click event and GUI name for highlighting.

On default, everything is like before.

The only problem is cloth config translation. I never worked before with cloth and don't want to copy paste the same key 12 times for the 12 buttons. If anyone is good with cloth config and know how to change the path, just edit it or message me :+1: