### PR TITLE
Add sound notification to fishing helper

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/FishingHelper.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/FishingHelper.java
@@ -8,8 +8,10 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.FishingRodItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
+import net.minecraft.sound.SoundEvent;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
@@ -51,6 +53,7 @@ public class FishingHelper {
                 if (Math.abs(normalYawVector.x * soundToFishHook.z - normalYawVector.z * soundToFishHook.x) < 0.2D && Math.abs(normalYawVector.dotProduct(soundToFishHook)) < 4D && player.getPos().squaredDistanceTo(packet.getX(), packet.getY(), packet.getZ()) > 1D) {
                     client.inGameHud.setTitleTicks(0, 10, 5);
                     client.inGameHud.setTitle(Text.translatable("skyblocker.fishing.reelNow").formatted(Formatting.GREEN));
+                    player.playSound(SoundEvent.of(new Identifier("minecraft", "entity.experience_orb.pickup")), 100f, 0.1f);
                     reset();
                 }
             } else {


### PR DESCRIPTION
Adds a small ding notification to the fishing helper, this is the last thing it's missing.

If you want to see what sound it plays run this in single player: `/playsound minecraft:entity.experience_orb.pickup music @p ~ ~ ~ 100 0.1`