### PR TITLE
Added Rift Tab Hud + 1 Rift related fix

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/discord/DiscordRPCManager.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/discord/DiscordRPCManager.java
@@ -108,13 +108,13 @@ public class DiscordRPCManager {
             switch (SkyblockerConfig.get().richPresence.info) {
                 case BITS -> info = "Bits: " + DECIMAL_FORMAT.format(Utils.getBits());
                 case PURSE -> info = "Purse: " + DECIMAL_FORMAT.format(Utils.getPurse());
-                case LOCATION -> info = "⏣ " + Utils.getLocation();
+                case LOCATION -> info = Utils.getLocation();
             }
         } else if (SkyblockerConfig.get().richPresence.cycleMode) {
             switch (cycleCount) {
                 case 0 -> info = "Bits: " + DECIMAL_FORMAT.format(Utils.getBits());
                 case 1 -> info = "Purse: " + DECIMAL_FORMAT.format(Utils.getPurse());
-                case 2 -> info = "⏣ " + Utils.getLocation();
+                case 2 -> info = Utils.getLocation();
             }
         }
         return info;

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/screens/Screen.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/screens/Screen.java
@@ -6,6 +6,7 @@ import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.TabHud;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.genericInfo.GardenInfoScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.genericInfo.GenericInfoScreen;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.genericInfo.GenericRiftInfoScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.CrimsonIsleScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.DungeonHubScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.DungeonScreen;
@@ -17,6 +18,7 @@ import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.HomeServerScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.HubServerScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.MineServerScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.ParkServerScreen;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main.RiftScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.playerList.DungeonPlayerScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.playerList.GuestPlayerScreen;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.playerList.HomePlayerScreen;
@@ -51,6 +53,7 @@ public class Screen {
     private static Screen correctGenericScrn(int w, int h, Text footer) {
         return switch (PlayerLocator.getPlayerLocation()) {
             case GARDEN -> new GardenInfoScreen(w, h, footer); // ok
+            case THE_RIFT -> new GenericRiftInfoScreen(w, h, footer);
             case UNKNOWN -> new EmptyScreen(w, h, footer); // ok
             default -> new GenericInfoScreen(w, h, footer); // ok
         };
@@ -78,6 +81,7 @@ public class Screen {
             case DUNGEON -> new DungeonScreen(w, h, footer); // ok
             case CRIMSON_ISLE -> new CrimsonIsleScreen(w, h, footer);
             case GARDEN -> new GardenScreen(w, h, footer); // ok
+            case THE_RIFT -> new RiftScreen(w, h, footer);
             case UNKNOWN -> new EmptyScreen(w, h, footer); // ok
             default -> new GenericServerScreen(w, h, footer); // ok
         };

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/screens/genericInfo/GenericRiftInfoScreen.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/screens/genericInfo/GenericRiftInfoScreen.java
@@ -1,0 +1,38 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.screens.genericInfo;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.Screen;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift.RiftProfileWidget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift.RiftStatsWidget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift.ShenWidget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.CookieWidget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift.AdvertisementWidget;
+import net.minecraft.text.Text;
+
+public class GenericRiftInfoScreen extends Screen {
+
+	public GenericRiftInfoScreen(int w, int h, Text footer) {
+		super(w, h);
+		
+		String f = footer.getString();
+		
+		RiftProfileWidget profile = new RiftProfileWidget();
+		RiftStatsWidget stats = new RiftStatsWidget();
+		ShenWidget shen = new ShenWidget();
+		
+		CookieWidget cookie = new CookieWidget(f);
+		AdvertisementWidget advertisement = new AdvertisementWidget();
+		
+		this.stackWidgetsH(stats, advertisement);
+		this.stackWidgetsH(profile, shen, cookie);
+
+		this.offCenterL(stats);
+		this.offCenterL(advertisement);
+		
+		this.offCenterR(profile);
+		this.offCenterR(shen);
+		this.offCenterR(cookie);
+		
+		this.addWidgets(profile, stats, shen, cookie, advertisement);
+	}
+
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/screens/main/RiftScreen.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/screens/main/RiftScreen.java
@@ -1,0 +1,28 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.screens.main;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.screens.Screen;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift.RiftProgressWidget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift.GoodToKnowWidget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift.RiftServerInfoWidget;
+
+
+import net.minecraft.text.Text;
+
+public class RiftScreen extends Screen {
+
+	public RiftScreen(int w, int h, Text footer) {
+		super(w, h);
+		
+		RiftProgressWidget rftProg = new RiftProgressWidget();
+		GoodToKnowWidget gtk = new GoodToKnowWidget();
+		RiftServerInfoWidget si = new RiftServerInfoWidget();
+		
+		this.stackWidgetsH(si, gtk);
+		this.stackWidgetsH(rftProg);
+		this.offCenterL(si);
+		this.offCenterL(gtk);
+		this.offCenterR(rftProg);
+		this.addWidgets(si, gtk, rftProg);
+	}
+
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/util/Ico.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/util/Ico.java
@@ -52,4 +52,9 @@ public class Ico {
     public static final ItemStack SAPLING = new ItemStack(Items.OAK_SAPLING);
     public static final ItemStack MILESTONE = new ItemStack(Items.LODESTONE);
     public static final ItemStack PICKAXE = new ItemStack(Items.IRON_PICKAXE);
+    public static final ItemStack NETHER_STAR = new ItemStack(Items.NETHER_STAR);
+    public static final ItemStack HEART_OF_THE_SEA = new ItemStack(Items.HEART_OF_THE_SEA);
+    public static final ItemStack EXPERIENCE_BOTTLE = new ItemStack(Items.EXPERIENCE_BOTTLE);
+    public static final ItemStack PINK_DYE = new ItemStack(Items.PINK_DYE);
+    public static final ItemStack ENCHANTED_BOOK = new ItemStack(Items.ENCHANTED_BOOK);
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/util/PlayerListMgr.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/util/PlayerListMgr.java
@@ -98,8 +98,8 @@ public class PlayerListMgr {
 	 * @return the text or null, if the display name is null
 	 * 
 	 * @implNote currently designed specifically for crimson isles faction quests
-	 *           widget, might not work correctly without modification for other
-	 *           stuff. you've been warned!
+	 *           widget and the rift widgets, might not work correctly without
+	 *           modification for other stuff. you've been warned!
 	 */
 	public static Text textAt(int idx) {
 
@@ -128,11 +128,16 @@ public class PlayerListMgr {
 			// Trim leading & trailing space - this can only be done at the start and end
 			// otherwise it'll produce malformed results
 			if (i == 0)
-				textToAppend = StringUtils.removeStart(textToAppend, " ");
+				textToAppend = textToAppend.stripLeading();
 			if (i == size - 1)
-				textToAppend = StringUtils.removeEnd(textToAppend, " ");
+				textToAppend = textToAppend.stripTrailing();
 
 			newText.append(Text.literal(textToAppend).setStyle(current.getStyle()));
+		}
+
+		// Avoid returning an empty component - Rift advertisements needed this
+		if (newText.getString().length() == 0) {
+			return null;
 		}
 
 		return newText;

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/util/PlayerLocator.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/util/PlayerLocator.java
@@ -25,6 +25,7 @@ public class PlayerLocator {
         JERRY,
         GARDEN,
         INSTANCED,
+        THE_RIFT,
         UNKNOWN
     }
 
@@ -82,6 +83,8 @@ public class PlayerLocator {
                 return Location.GARDEN;
             case "Instanced":
                 return Location.INSTANCED;
+            case "The Rift":
+            	return Location.THE_RIFT;
             default:
                 return Location.UNKNOWN;
         }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/AdvertisementWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/AdvertisementWidget.java
@@ -8,18 +8,19 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 public class AdvertisementWidget extends Widget {
-	
-	private static final MutableText TITLE = Text.literal("Advertisement").formatted(Formatting.DARK_AQUA, Formatting.BOLD);
+
+	private static final MutableText TITLE = Text.literal("Advertisement").formatted(Formatting.DARK_AQUA,
+			Formatting.BOLD);
 
 	public AdvertisementWidget() {
 		super(TITLE, Formatting.DARK_AQUA.getColorValue());
-		
-				
-		for(int i = 73; i < 80; i++) {
+
+		for (int i = 73; i < 80; i++) {
 			Text text = PlayerListMgr.textAt(i);
-			if(text != null) this.addComponent(new PlainTextComponent(text));
+			if (text != null)
+				this.addComponent(new PlainTextComponent(text));
 		}
-		
+
 		this.pack();
 	}
 

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/AdvertisementWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/AdvertisementWidget.java
@@ -1,0 +1,26 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.PlayerListMgr;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.Widget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.component.PlainTextComponent;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class AdvertisementWidget extends Widget {
+	
+	private static final MutableText TITLE = Text.literal("Advertisement").formatted(Formatting.DARK_AQUA, Formatting.BOLD);
+
+	public AdvertisementWidget() {
+		super(TITLE, Formatting.DARK_AQUA.getColorValue());
+		
+				
+		for(int i = 73; i < 80; i++) {
+			Text text = PlayerListMgr.textAt(i);
+			if(text != null) this.addComponent(new PlainTextComponent(text));
+		}
+		
+		this.pack();
+	}
+
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/GoodToKnowWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/GoodToKnowWidget.java
@@ -9,38 +9,47 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 public class GoodToKnowWidget extends Widget {
-	
+
 	private static final MutableText TITLE = Text.literal("Good To Know").formatted(Formatting.BLUE, Formatting.BOLD);
-	
+
 	public GoodToKnowWidget() {
 		super(TITLE, Formatting.BLUE.getColorValue());
-		
-		//After you progress further the tab adds more info so we need to be careful of that
-		//In beginning it only shows montezuma, then timecharms and enigma souls are added
-		Text pos49 = PlayerListMgr.textAt(49); //Can be times visited rift
-		Text pos51 = PlayerListMgr.textAt(51); //Can be lifetime motes or visited rift
-		Text pos53 = PlayerListMgr.textAt(53); //Can be lifetime motes
-		
+
+		// After you progress further the tab adds more info so we need to be careful of
+		// that
+		// In beginning it only shows montezuma, then timecharms and enigma souls are
+		// added
+		Text pos49 = PlayerListMgr.textAt(49); // Can be times visited rift
+		Text pos51 = PlayerListMgr.textAt(51); // Can be lifetime motes or visited rift
+		Text pos53 = PlayerListMgr.textAt(53); // Can be lifetime motes
+
 		int visitedRiftPos = 0;
 		int lifetimeMotesPos = 0;
-		
-		//Check each position to see what is or isn't there so we don't try adding invalid components
-		if(pos49.getString().contains("times")) visitedRiftPos = 49;
-		if(pos51.getString().contains("Motes")) lifetimeMotesPos = 51;
-		if(pos51.getString().contains("times")) visitedRiftPos = 51;
-		if(pos53.getString().contains("Motes")) lifetimeMotesPos = 53;
-		
+
+		// Check each position to see what is or isn't there so we don't try adding
+		// invalid components
+		if (pos49.getString().contains("times"))
+			visitedRiftPos = 49;
+		if (pos51.getString().contains("Motes"))
+			lifetimeMotesPos = 51;
+		if (pos51.getString().contains("times"))
+			visitedRiftPos = 51;
+		if (pos53.getString().contains("Motes"))
+			lifetimeMotesPos = 53;
+
 		Text timesVisitedRift = (visitedRiftPos == 51) ? pos51 : (visitedRiftPos == 49) ? pos49 : null;
 		Text lifetimeMotesEarned = (lifetimeMotesPos == 53) ? pos53 : (lifetimeMotesPos == 51) ? pos51 : null;
-		
-		if(visitedRiftPos != 0) {
-			this.addComponent(new IcoTextComponent(Ico.EXPERIENCE_BOTTLE, Text.literal("Visited Rift: ").append(timesVisitedRift)));
+
+		if (visitedRiftPos != 0) {
+			this.addComponent(new IcoTextComponent(Ico.EXPERIENCE_BOTTLE,
+					Text.literal("Visited Rift: ").append(timesVisitedRift)));
 		}
-		
-		if(lifetimeMotesPos != 0) {
-			this.addComponent(new IcoTextComponent(Ico.PINK_DYE, Text.literal("Lifetime Earned: ").append(lifetimeMotesEarned)));
+
+		if (lifetimeMotesPos != 0) {
+			this.addComponent(
+					new IcoTextComponent(Ico.PINK_DYE, Text.literal("Lifetime Earned: ").append(lifetimeMotesEarned)));
 		}
-		
+
 		this.pack();
 	}
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/GoodToKnowWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/GoodToKnowWidget.java
@@ -1,0 +1,46 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.component.IcoTextComponent;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.Ico;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.PlayerListMgr;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.Widget;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class GoodToKnowWidget extends Widget {
+	
+	private static final MutableText TITLE = Text.literal("Good To Know").formatted(Formatting.BLUE, Formatting.BOLD);
+	
+	public GoodToKnowWidget() {
+		super(TITLE, Formatting.BLUE.getColorValue());
+		
+		//After you progress further the tab adds more info so we need to be careful of that
+		//In beginning it only shows montezuma, then timecharms and enigma souls are added
+		Text pos49 = PlayerListMgr.textAt(49); //Can be times visited rift
+		Text pos51 = PlayerListMgr.textAt(51); //Can be lifetime motes or visited rift
+		Text pos53 = PlayerListMgr.textAt(53); //Can be lifetime motes
+		
+		int visitedRiftPos = 0;
+		int lifetimeMotesPos = 0;
+		
+		//Check each position to see what is or isn't there so we don't try adding invalid components
+		if(pos49.getString().contains("times")) visitedRiftPos = 49;
+		if(pos51.getString().contains("Motes")) lifetimeMotesPos = 51;
+		if(pos51.getString().contains("times")) visitedRiftPos = 51;
+		if(pos53.getString().contains("Motes")) lifetimeMotesPos = 53;
+		
+		Text timesVisitedRift = (visitedRiftPos == 51) ? pos51 : (visitedRiftPos == 49) ? pos49 : null;
+		Text lifetimeMotesEarned = (lifetimeMotesPos == 53) ? pos53 : (lifetimeMotesPos == 51) ? pos51 : null;
+		
+		if(visitedRiftPos != 0) {
+			this.addComponent(new IcoTextComponent(Ico.EXPERIENCE_BOTTLE, Text.literal("Visited Rift: ").append(timesVisitedRift)));
+		}
+		
+		if(lifetimeMotesPos != 0) {
+			this.addComponent(new IcoTextComponent(Ico.PINK_DYE, Text.literal("Lifetime Earned: ").append(lifetimeMotesEarned)));
+		}
+		
+		this.pack();
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftProfileWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftProfileWidget.java
@@ -1,0 +1,19 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.Ico;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.Widget;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class RiftProfileWidget extends Widget {
+	
+	private static final MutableText TITLE = Text.literal("Profile").formatted(Formatting.DARK_AQUA, Formatting.BOLD);
+	
+	public RiftProfileWidget() {
+		super(TITLE, Formatting.DARK_AQUA.getColorValue());
+		
+		this.addSimpleIcoText(Ico.SIGN, "Profile:", Formatting.GREEN, 61);
+		this.pack();
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftProgressWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftProgressWidget.java
@@ -1,0 +1,88 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.Ico;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.PlayerListMgr;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.Widget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.component.ProgressComponent;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.math.MathHelper;
+
+public class RiftProgressWidget extends Widget {
+	
+	private static final MutableText TITLE = Text.literal("Rift Progress").formatted(Formatting.BLUE, Formatting.BOLD);
+	
+	private static final Pattern TIMECHARMS_PATTERN = Pattern.compile("Timecharms: (?<current>[0-9]+)\\/(?<total>[0-9]+)");
+	private static final Pattern ENIGMA_SOULS_PATTERN = Pattern.compile("Enigma Souls: (?<current>[0-9]+)\\/(?<total>[0-9]+)");
+	private static final Pattern MONTEZUMA_PATTERN = Pattern.compile("Montezuma: (?<current>[0-9]+)\\/(?<total>[0-9]+)");
+
+	public RiftProgressWidget() {
+		super(TITLE, Formatting.BLUE.getColorValue());
+		
+		//After you progress further the tab adds more info so we need to be careful of that
+		//In beginning it only shows montezuma, then timecharms and enigma souls are added
+		String pos45 = PlayerListMgr.strAt(45); //Can be Montezuma or Timecharms
+		String pos46 = PlayerListMgr.strAt(46); //Can be Enigma Souls or Empty
+		String pos47 = PlayerListMgr.strAt(47); //Can be Montezuma or "Good to know" heading
+		
+		boolean hasTimecharms = false;
+		boolean hasEnigmaSouls = false;
+		int montezumaPos = 0;
+		
+		//Check each position to see what is or isn't there so we don't try adding invalid components
+		if(pos45.contains("Timecharms")) hasTimecharms = true;
+		if(pos46.contains("Enigma Souls")) hasEnigmaSouls = true;
+		
+		//Small ternary to account for positions, defaults to -1 if it for some reason does not exist (which shouldn't be the case!)
+		montezumaPos = (pos47.contains("Montezuma")) ? 47 : (pos45.contains("Montezuma")) ? 45 : -1;
+		
+		if(hasTimecharms) {
+			Matcher m = PlayerListMgr.regexAt(45, TIMECHARMS_PATTERN);
+			
+			int current = Integer.parseInt(m.group("current"));
+			int total = Integer.parseInt(m.group("total"));
+			float pcnt = ((float) current / (float) total) * 100f;
+			Text progressText = Text.literal(current + "/" + total);
+			
+			ProgressComponent pc = new ProgressComponent(Ico.NETHER_STAR, Text.literal("Timecharms"), progressText, pcnt, pcntToCol(pcnt));
+			
+			this.addComponent(pc);
+		}
+		
+		if(hasEnigmaSouls) {
+			Matcher m = PlayerListMgr.regexAt(46, ENIGMA_SOULS_PATTERN);
+			
+			int current = Integer.parseInt(m.group("current"));
+			int total = Integer.parseInt(m.group("total"));
+			float pcnt = ((float) current / (float) total) * 100f;
+			Text progressText = Text.literal(current + "/" + total);
+			
+			ProgressComponent pc = new ProgressComponent(Ico.HEART_OF_THE_SEA, Text.literal("Enigma Souls"), progressText, pcnt, pcntToCol(pcnt));
+			
+			this.addComponent(pc);
+		}
+		
+		if(montezumaPos != -1) {
+			Matcher m = PlayerListMgr.regexAt(montezumaPos, MONTEZUMA_PATTERN);
+			
+			int current = Integer.parseInt(m.group("current"));
+			int total = Integer.parseInt(m.group("total"));
+			float pcnt = ((float) current / (float) total) * 100f;
+			Text progressText = Text.literal(current + "/" + total);
+			
+			ProgressComponent pc = new ProgressComponent(Ico.BONE, Text.literal("Montezuma"), progressText, pcnt, pcntToCol(pcnt));
+			
+			this.addComponent(pc);
+		}
+				
+		this.pack();
+	}
+	
+	private static int pcntToCol(float pcnt) {
+		return MathHelper.hsvToRgb(pcnt / 300f, 0.9f, 0.9f);
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftProgressWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftProgressWidget.java
@@ -13,75 +13,84 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.math.MathHelper;
 
 public class RiftProgressWidget extends Widget {
-	
+
 	private static final MutableText TITLE = Text.literal("Rift Progress").formatted(Formatting.BLUE, Formatting.BOLD);
-	
+
 	private static final Pattern TIMECHARMS_PATTERN = Pattern.compile("Timecharms: (?<current>[0-9]+)\\/(?<total>[0-9]+)");
 	private static final Pattern ENIGMA_SOULS_PATTERN = Pattern.compile("Enigma Souls: (?<current>[0-9]+)\\/(?<total>[0-9]+)");
 	private static final Pattern MONTEZUMA_PATTERN = Pattern.compile("Montezuma: (?<current>[0-9]+)\\/(?<total>[0-9]+)");
 
 	public RiftProgressWidget() {
 		super(TITLE, Formatting.BLUE.getColorValue());
-		
-		//After you progress further the tab adds more info so we need to be careful of that
-		//In beginning it only shows montezuma, then timecharms and enigma souls are added
-		String pos45 = PlayerListMgr.strAt(45); //Can be Montezuma or Timecharms
-		String pos46 = PlayerListMgr.strAt(46); //Can be Enigma Souls or Empty
-		String pos47 = PlayerListMgr.strAt(47); //Can be Montezuma or "Good to know" heading
-		
+
+		// After you progress further the tab adds more info so we need to be careful of
+		// that
+		// In beginning it only shows montezuma, then timecharms and enigma souls are
+		// added
+		String pos45 = PlayerListMgr.strAt(45); // Can be Montezuma or Timecharms
+		String pos46 = PlayerListMgr.strAt(46); // Can be Enigma Souls or Empty
+		String pos47 = PlayerListMgr.strAt(47); // Can be Montezuma or "Good to know" heading
+
 		boolean hasTimecharms = false;
 		boolean hasEnigmaSouls = false;
 		int montezumaPos = 0;
-		
-		//Check each position to see what is or isn't there so we don't try adding invalid components
-		if(pos45.contains("Timecharms")) hasTimecharms = true;
-		if(pos46.contains("Enigma Souls")) hasEnigmaSouls = true;
-		
-		//Small ternary to account for positions, defaults to -1 if it for some reason does not exist (which shouldn't be the case!)
+
+		// Check each position to see what is or isn't there so we don't try adding
+		// invalid components
+		if (pos45.contains("Timecharms"))
+			hasTimecharms = true;
+		if (pos46.contains("Enigma Souls"))
+			hasEnigmaSouls = true;
+
+		// Small ternary to account for positions, defaults to -1 if it for some reason
+		// does not exist (which shouldn't be the case!)
 		montezumaPos = (pos47.contains("Montezuma")) ? 47 : (pos45.contains("Montezuma")) ? 45 : -1;
-		
-		if(hasTimecharms) {
+
+		if (hasTimecharms) {
 			Matcher m = PlayerListMgr.regexAt(45, TIMECHARMS_PATTERN);
-			
+
 			int current = Integer.parseInt(m.group("current"));
 			int total = Integer.parseInt(m.group("total"));
 			float pcnt = ((float) current / (float) total) * 100f;
 			Text progressText = Text.literal(current + "/" + total);
-			
-			ProgressComponent pc = new ProgressComponent(Ico.NETHER_STAR, Text.literal("Timecharms"), progressText, pcnt, pcntToCol(pcnt));
-			
+
+			ProgressComponent pc = new ProgressComponent(Ico.NETHER_STAR, Text.literal("Timecharms"), progressText,
+					pcnt, pcntToCol(pcnt));
+
 			this.addComponent(pc);
 		}
-		
-		if(hasEnigmaSouls) {
+
+		if (hasEnigmaSouls) {
 			Matcher m = PlayerListMgr.regexAt(46, ENIGMA_SOULS_PATTERN);
-			
+
 			int current = Integer.parseInt(m.group("current"));
 			int total = Integer.parseInt(m.group("total"));
 			float pcnt = ((float) current / (float) total) * 100f;
 			Text progressText = Text.literal(current + "/" + total);
-			
-			ProgressComponent pc = new ProgressComponent(Ico.HEART_OF_THE_SEA, Text.literal("Enigma Souls"), progressText, pcnt, pcntToCol(pcnt));
-			
+
+			ProgressComponent pc = new ProgressComponent(Ico.HEART_OF_THE_SEA, Text.literal("Enigma Souls"),
+					progressText, pcnt, pcntToCol(pcnt));
+
 			this.addComponent(pc);
 		}
-		
-		if(montezumaPos != -1) {
+
+		if (montezumaPos != -1) {
 			Matcher m = PlayerListMgr.regexAt(montezumaPos, MONTEZUMA_PATTERN);
-			
+
 			int current = Integer.parseInt(m.group("current"));
 			int total = Integer.parseInt(m.group("total"));
 			float pcnt = ((float) current / (float) total) * 100f;
 			Text progressText = Text.literal(current + "/" + total);
-			
-			ProgressComponent pc = new ProgressComponent(Ico.BONE, Text.literal("Montezuma"), progressText, pcnt, pcntToCol(pcnt));
-			
+
+			ProgressComponent pc = new ProgressComponent(Ico.BONE, Text.literal("Montezuma"), progressText, pcnt,
+					pcntToCol(pcnt));
+
 			this.addComponent(pc);
 		}
-				
+
 		this.pack();
 	}
-	
+
 	private static int pcntToCol(float pcnt) {
 		return MathHelper.hsvToRgb(pcnt / 300f, 0.9f, 0.9f);
 	}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftServerInfoWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftServerInfoWidget.java
@@ -1,0 +1,26 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.Ico;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.Widget;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+/**
+ * Special version of the server info widget for the rift!
+ *
+ */
+public class RiftServerInfoWidget extends Widget {
+	
+	private static final MutableText TITLE = Text.literal("Server Info").formatted(Formatting.LIGHT_PURPLE, Formatting.BOLD);
+
+	public RiftServerInfoWidget() {
+		super(TITLE, Formatting.LIGHT_PURPLE.getColorValue());
+		
+		this.addSimpleIcoText(Ico.MAP, "Area:", Formatting.LIGHT_PURPLE, 41);
+		this.addSimpleIcoText(Ico.NTAG, "Server ID:", Formatting.GRAY, 42);
+		
+		this.pack();
+	}
+
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftStatsWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/RiftStatsWidget.java
@@ -1,0 +1,41 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.Ico;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.Widget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.component.IcoTextComponent;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.component.TableComponent;
+
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class RiftStatsWidget extends Widget {
+
+	private static final MutableText TITLE = Text.literal("Stats").formatted(Formatting.DARK_AQUA, Formatting.BOLD);
+
+	public RiftStatsWidget() {
+		super(TITLE, Formatting.DARK_AQUA.getColorValue());
+		
+		Text riftDamage = Widget.simpleEntryText(64, "RDG", Formatting.DARK_PURPLE);
+		IcoTextComponent rdg = new IcoTextComponent(Ico.DIASWORD, riftDamage);
+		
+		Text speed = Widget.simpleEntryText(65, "SPD", Formatting.WHITE);
+		IcoTextComponent spd = new IcoTextComponent(Ico.SUGAR, speed);
+		
+		Text intelligence = Widget.simpleEntryText(66, "INT", Formatting.AQUA);
+		IcoTextComponent intel = new IcoTextComponent(Ico.ENCHANTED_BOOK, intelligence);
+		
+		Text manaRegen = Widget.simpleEntryText(67, "MRG", Formatting.AQUA);
+		IcoTextComponent mrg = new IcoTextComponent(Ico.DIAMOND, manaRegen);
+		
+		TableComponent tc = new TableComponent(2, 2, Formatting.AQUA.getColorValue());
+		tc.addToCell(0, 0, rdg);
+		tc.addToCell(0, 1, spd);
+		tc.addToCell(1, 0, intel);
+		tc.addToCell(1, 1, mrg);
+		
+		this.addComponent(tc);
+		this.pack();
+	}
+
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/ShenWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/rift/ShenWidget.java
@@ -1,0 +1,20 @@
+package me.xmrvizzy.skyblocker.skyblock.tabhud.widget.rift;
+
+import me.xmrvizzy.skyblocker.skyblock.tabhud.util.PlayerListMgr;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.Widget;
+import me.xmrvizzy.skyblocker.skyblock.tabhud.widget.component.PlainTextComponent;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class ShenWidget extends Widget {
+	
+	private static final MutableText TITLE = Text.literal("Shen's Countdown").formatted(Formatting.DARK_AQUA, Formatting.BOLD);
+
+	public ShenWidget() {
+		super(TITLE, Formatting.DARK_AQUA.getColorValue());
+		
+		this.addComponent(new PlainTextComponent(Text.literal(PlayerListMgr.strAt(70))));
+		this.pack();
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
@@ -145,9 +145,10 @@ public class Utils {
             if (sidebarLines != null) {
                 for (String sidebarLine : sidebarLines) {
                     if (sidebarLine.contains("⏣")) location = sidebarLine;
+                    if (sidebarLine.contains("ф")) location = sidebarLine; //Rift
                 }
                 if (location == null) location = "Unknown";
-                location = location.replace('⏣', ' ').strip();
+                location = location.strip();
             }
         } catch (IndexOutOfBoundsException e) {
             e.printStackTrace();


### PR DESCRIPTION
- Added a Tab Hud for the Rift
- Fixed an issue where rift locations weren't recognized since the rift uses a different character to denote locations in the sidebar (this broke the RPC location)

In the Tab Hud for the rift, there's code which accounts for two different versions of the tab I've encountered myself. It first only had information about Montezuma progress but then information about enigma souls and time charms were added, I'm not sure if this is because I progressed further or if this change was made for everyone regardless of progress so my code accounts for the two different versions.