### PR TITLE
Fix dragged items not rendering

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -63,22 +63,22 @@ public abstract class HandledScreenMixin extends Screen {
 
     @Redirect(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/slot/Slot;getStack()Lnet/minecraft/item/ItemStack;", ordinal = 0))
     private ItemStack skyblocker$experimentSolvers$replaceTooltipDisplayStack(Slot slot) {
-        return skyblocker$experimentSolvers$getStack(slot);
+        return skyblocker$experimentSolvers$getStack(slot, null);
     }
 
     @ModifyVariable(method = "drawSlot", at = @At(value = "LOAD", ordinal = 4), ordinal = 0)
     private ItemStack skyblocker$experimentSolvers$replaceDisplayStack(ItemStack stack, DrawContext context, Slot slot) {
-        return skyblocker$experimentSolvers$getStack(slot);
+        return skyblocker$experimentSolvers$getStack(slot, stack);
     }
 
     @Unique
-    private ItemStack skyblocker$experimentSolvers$getStack(Slot slot) {
+    private ItemStack skyblocker$experimentSolvers$getStack(Slot slot, ItemStack stack) {
         ContainerSolver currentSolver = SkyblockerMod.getInstance().containerSolverManager.getCurrentSolver();
         if ((currentSolver instanceof SuperpairsSolver || currentSolver instanceof UltrasequencerSolver) && ((ExperimentSolver) currentSolver).getState() == ExperimentSolver.State.SHOW && slot.inventory instanceof SimpleInventory) {
             ItemStack itemStack = ((ExperimentSolver) currentSolver).getSlots().get(slot.getIndex());
             return itemStack == null ? slot.getStack() : itemStack;
         }
-        return slot.getStack();
+        return (stack != null) ? stack : slot.getStack();
     }
 
     @Inject(method = "onMouseClick(Lnet/minecraft/screen/slot/Slot;IILnet/minecraft/screen/slot/SlotActionType;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;clickSlot(IIILnet/minecraft/screen/slot/SlotActionType;Lnet/minecraft/entity/player/PlayerEntity;)V"))


### PR DESCRIPTION
Fixes a critical issue where when you were dragging items in an inventory (eg a crafting table) the dragged items wouldn't render at all, this also happened in vanilla.

This issue was caused by always returning the item that was in the slot (which would be nothing) rather than retuning the actual item stack when it was available.