### PR TITLE
Rendering Improvements, Fixes + Occlusion Culling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ repositories {
 		url = "https://maven.meteordev.org/releases"
 	}
 	maven {url "https://jitpack.io"}
+	maven { url "https://repo.codemc.io/repository/maven-public/" } // For Occlusion Culling library
 }
 
 dependencies {
@@ -63,6 +64,9 @@ dependencies {
 	include modImplementation("com.github.0x3C50:Renderer:${project.renderer_version}")
 
 	include(modImplementation ("meteordevelopment:discord-ipc:1.1"))
+	
+	// Occlusion Culling (https://github.com/LogisticsCraft/OcclusionCulling)
+	include implementation("com.logisticscraft:occlusionculling:${project.occlusionculling_version}")
 }
 
 base {

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ repositories {
 		name = "meteor-maven"
 		url = "https://maven.meteordev.org/releases"
 	}
-	maven {url "https://jitpack.io"}
 	maven { url "https://repo.codemc.io/repository/maven-public/" } // For Occlusion Culling library
+	maven {url "https://jitpack.io"}
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,9 @@ rei_version=12.0.625
 ## Renderer (https://github.com/0x3C50/Renderer)
 renderer_version = d687aced4c
 
+## Occlusion Culling (https://github.com/LogisticsCraft/OcclusionCulling)
+occlusionculling_version = 0.0.7-SNAPSHOT
+
 # Mod Properties
 mod_version = 1.10.0
 maven_group = me.xmrvizzy

--- a/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
@@ -19,6 +19,7 @@ import me.xmrvizzy.skyblocker.skyblock.rift.TheRift;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.TabHud;
 import me.xmrvizzy.skyblocker.skyblock.tabhud.util.PlayerListMgr;
 import me.xmrvizzy.skyblocker.utils.*;
+import me.xmrvizzy.skyblocker.utils.culling.OcclusionCulling;
 import me.xmrvizzy.skyblocker.utils.title.TitleContainer;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -83,6 +84,7 @@ public class SkyblockerMod implements ClientModInitializer {
         DungeonMap.init();
         TheRift.init();
         TitleContainer.init();
+        OcclusionCulling.init();
         containerSolverManager.init();
         scheduler.scheduleCyclic(Utils::update, 20);
         scheduler.scheduleCyclic(DiscordRPCManager::updateDataAndPresence, 100);

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/RenderUtils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/RenderUtils.java
@@ -82,7 +82,7 @@ public class RenderUtils {
                 e.getZ() - MathHelper.lerp(tickDelta, e.lastRenderZ, e.getZ()));
     }
 
-    public static Boolean pointExistsInArea(int x, int y, int x1, int y1, int x2, int y2) {
+    public static boolean pointExistsInArea(int x, int y, int x1, int y1, int x2, int y2) {
         return x >= x1 && x <= x2 && y >= y1 && y <= y2;
     }
 

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/culling/OcclusionCulling.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/culling/OcclusionCulling.java
@@ -1,0 +1,48 @@
+package me.xmrvizzy.skyblocker.utils.culling;
+
+import com.logisticscraft.occlusionculling.OcclusionCullingInstance;
+import com.logisticscraft.occlusionculling.cache.ArrayOcclusionCache;
+import com.logisticscraft.occlusionculling.util.Vec3d;
+
+import me.xmrvizzy.skyblocker.utils.FrustumUtils;
+import net.minecraft.client.MinecraftClient;
+
+public class OcclusionCulling {
+	private static final int TRACING_DISTANCE = 128;
+	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
+	private static OcclusionCullingInstance instance = null;
+
+	// Reused objects to reduce allocation overhead
+	private static Vec3d cameraPos = new Vec3d(0, 0, 0);
+	private static Vec3d min = new Vec3d(0, 0, 0);
+	private static Vec3d max = new Vec3d(0, 0, 0);
+
+	/**
+	 * Initializes the occlusion culling instance
+	 */
+	public static void init() {
+		instance = new OcclusionCullingInstance(TRACING_DISTANCE, new WorldProvider(), new ArrayOcclusionCache(TRACING_DISTANCE), 2);
+	}
+
+	private static void updateCameraPos() {
+		var camera = CLIENT.gameRenderer.getCamera().getPos();
+		cameraPos.set(camera.x, camera.y, camera.z);
+	}
+
+	/**
+	 * This first checks checks if the bounding box is within the camera's FOV, if
+	 * it is then it checks for whether it's occluded or not.
+	 * 
+	 * @return A boolean representing whether the bounding box is fully visible or
+	 *         not.
+	 */
+	public static boolean isVisible(double x1, double y1, double z1, double x2, double y2, double z2) {
+		if (!FrustumUtils.isVisible(x1, y1, z1, x2, y2, z2)) return false;
+
+		updateCameraPos();
+		min.set(x1, y1, z1);
+		max.set(x2, y2, z2);
+
+		return instance.isAABBVisible(min, max, cameraPos);
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/culling/WorldProvider.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/culling/WorldProvider.java
@@ -1,0 +1,29 @@
+package me.xmrvizzy.skyblocker.utils.culling;
+
+import com.logisticscraft.occlusionculling.DataProvider;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.BlockPos;
+
+public class WorldProvider implements DataProvider {
+	private final static MinecraftClient CLIENT = MinecraftClient.getInstance();
+	private ClientWorld world = null;
+
+	@Override
+	public boolean prepareChunk(int chunkX, int chunkZ) {
+		this.world = CLIENT.world;
+		return this.world != null;
+	}
+
+	@Override
+	public boolean isOpaqueFullCube(int x, int y, int z) {
+		BlockPos pos = new BlockPos(x, y, z);
+		return this.world.getBlockState(pos).isOpaqueFullCube(this.world, pos);
+	}
+
+	@Override
+	public void cleanup() {
+		this.world = null;
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/culling/package-info.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/culling/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package dedicated to occlusion culling utilities
+ */
+package me.xmrvizzy.skyblocker.utils.culling;


### PR DESCRIPTION
## Occlusion Culling
- Implemented an occlusion culling system
  - With Frustum Culling, objects that are in the camera's FOV won't be culled even if they're blocked by walls or other surfaces while with occlusion culling, if the view to an object is blocked then it is culled.
  - The implementation first checks if the bounding box is within the frustum, if its not then the function short-circuits to avoid unnecessary path tracing. If it is within the frustum then the rest of the occlusion culling logic is executed.
- Uses the [Occlusion Culling](https://github.com/LogisticsCraft/OcclusionCulling) library made by Logistics Craft

## Rendering Fixes/Changes
- All `RenderHelper` methods now use some kind culling
  - The `renderFilledIfVisible` method now uses occlusion culling
    - Fixes being able to see the mirrorverse waypoints from the edge of the Stillgore Château
  - The rest of the methods now use frustum culling since they render things through walls (thus being able to be seen as long as they're in the camera's FOV)
- The beacon beams are now rendered directly after their vertices have been written to the buffer
  - Fixes an issue where they could render incorrectly (e.g. flickering, weird rotations)
  - Also simplified the logic in the method to be more readable
- The beacon beams now render at a maximum height of 319 to match the world build height limit
  -  Prevents a weird discolouration issue with them at higher Y levels
- Made some `RenderHelper` methods private so that culling checks aren't accidentally skipped
- The `pointExistsInArea` method now uses the unboxed version of boolean