### PR TITLE
Fix hotbar lock rendering mixin

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/InGameHudMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/InGameHudMixin.java
@@ -1,5 +1,6 @@
 package me.xmrvizzy.skyblocker.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import me.xmrvizzy.skyblocker.SkyblockerMod;
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import me.xmrvizzy.skyblocker.skyblock.FancyStatusBars;
@@ -11,11 +12,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -26,9 +24,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Environment(EnvType.CLIENT)
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
-	//@Shadow
-	//@Final
-	//private static Identifier ICONS = new Identifier("textures/gui/icons.png");
     @Unique
     private static final Identifier SLOT_LOCK = new Identifier(SkyblockerMod.NAMESPACE, "textures/gui/slot_lock.png");
     @Unique
@@ -36,10 +31,6 @@ public abstract class InGameHudMixin {
     private final StatusBarTracker statusBarTracker = SkyblockerMod.getInstance().statusBarTracker;
     @Unique
     private final FancyStatusBars statusBars = new FancyStatusBars();
-    @Unique
-    private DrawContext hotbarContext;
-    @Unique
-    private int hotbarSlotIndex;
 
     @Shadow
     private int scaledHeight;
@@ -63,21 +54,10 @@ public abstract class InGameHudMixin {
         }
     }
 
-    @Inject(method = "renderHotbar", at = @At("HEAD"))
-    public void skyblocker$renderHotbar(float f, DrawContext context, CallbackInfo ci) {
-        if (Utils.isOnSkyblock()) {
-            hotbarContext = context;
-            hotbarSlotIndex = 0;
-        }
-    }
-
-    @Inject(method = "renderHotbarItem", at = @At("HEAD"))
-    public void skyblocker$renderHotbarItem(DrawContext context, int i, int j, float f, PlayerEntity player, ItemStack stack, int seed, CallbackInfo ci) {
-        if (Utils.isOnSkyblock()) {
-            if (HotbarSlotLock.isLocked(hotbarSlotIndex)) {
-                hotbarContext.drawTexture(SLOT_LOCK, i, j, 0, 0, 16, 16);
-            }
-            hotbarSlotIndex++;
+    @Inject(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderHotbarItem(Lnet/minecraft/client/gui/DrawContext;IIFLnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/ItemStack;I)V", ordinal = 0))
+    public void skyblocker$renderHotbarItemLock(float tickDelta, DrawContext context, CallbackInfo ci, @Local(ordinal = 4, name = "m") int index, @Local(ordinal = 5, name = "n") int x, @Local(ordinal = 6, name = "o") int y) {
+        if (Utils.isOnSkyblock() && HotbarSlotLock.isLocked(index)) {
+            context.drawTexture(SLOT_LOCK, x, y, 0, 0, 16, 16);
         }
     }
 


### PR DESCRIPTION
Refactor `InGameHudMixin` to be cleaner and safer.  
Fix #210  
Tested by spamming `h` on Skyblock. (That should be enough right?)  