### PR TITLE
Remove invalid base64 log spam

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/PlayerSkinProviderMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/PlayerSkinProviderMixin.java
@@ -1,0 +1,27 @@
+package me.xmrvizzy.skyblocker.mixin;
+
+import java.util.concurrent.ExecutorService;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import me.xmrvizzy.skyblocker.utils.Utils;
+import net.minecraft.client.texture.PlayerSkinProvider;
+
+@Mixin(PlayerSkinProvider.class)
+public class PlayerSkinProviderMixin {
+
+	@Redirect(method = "loadSkin(Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/texture/PlayerSkinProvider$SkinTextureAvailableCallback;Z)V", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/ExecutorService;execute(Ljava/lang/Runnable;)V", remap = false))
+	private void skyblocker$removeInvalidBase64LogSpam(ExecutorService executor, Runnable runnable) {
+		executor.execute(() -> {
+			try {
+				runnable.run();
+			} catch (Throwable t) {
+				if (!(t instanceof IllegalArgumentException) || !Utils.isOnHypixel()) {
+					t.printStackTrace();
+				}
+			}
+		});
+	}
+}

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -17,6 +17,7 @@
     "MinecraftClientMixin",
     "PlayerListHudAccessor",
     "PlayerListHudMixin",
+    "PlayerSkinProviderMixin",
     "RecipeBookWidgetAccessor",
     "ScoreboardMixin",
     "accessor.BeaconBlockEntityRendererInvoker",


### PR DESCRIPTION
Removes log spam generated by Hypixel sending invalid base 64 packets, also makes the method safer since it's wrapped in a try catch block so any other unchecked exceptions will also be caught and properly logged which could potentially prevent some crashes if something else were to go terribly wrong.