### PR TITLE
Translations update from hysky translate [skip ci]

### DIFF
--- a/src/main/resources/assets/skyblocker/lang/es_es.json
+++ b/src/main/resources/assets/skyblocker/lang/es_es.json
@@ -95,7 +95,6 @@
     "text.autoconfig.skyblocker.option.messages.hideAOTE": "Ocultar Mensajes de la AOTE",
     "text.autoconfig.skyblocker.option.messages.hideMana": "Ocultar los Mensajes del Consumo de Maná de la Barra de Acción",
     "text.autoconfig.skyblocker.option.messages.hideMana.@Tooltip": "Da una mejor experiencia con FancyBar",
-    "skyblocker.update.hover_text": "Abrir Modrinth",
     "skyblocker.updaterepository.failed": "§b[§6Skyblocker§b] §cLa actualización del repositorio local fallo. Elimina los archivos manualmente y reinicia el juego.",
     "text.autoconfig.skyblocker.option.quickNav.button11": "Botón 11",
     "text.autoconfig.skyblocker.option.quickNav.button9.item.itemName": "Nombre del objeto",

--- a/src/main/resources/assets/skyblocker/lang/tr_tr.json
+++ b/src/main/resources/assets/skyblocker/lang/tr_tr.json
@@ -38,7 +38,6 @@
     "text.autoconfig.skyblocker.option.messages.hideAutopet": "Autopet mesajlarını filtrele",
     "text.autoconfig.skyblocker.option.messages.hideMana": "Aksiyon barındaki mana tüketimlerini gizle",
     "text.autoconfig.skyblocker.option.messages.hideMana.@Tooltip": "FancyBar ile daha iyi bir deneyim sunar",
-    "skyblocker.api.got_key": "§b[§6Skyblocker§b] §2API anahtarınız otomatik olarak kaydedildi!",
     "text.autoconfig.skyblocker.option.general.hideEmptyTooltips": "Menülerdeki boş eşya açıklamalarını gizle",
     "text.autoconfig.skyblocker.option.locations.dwarvenMines.dwarvenHud.y": "Y",
     "text.autoconfig.skyblocker.option.locations.dwarvenMines.dwarvenHud.x": "X",


### PR DESCRIPTION
Translations update from [hysky translate](https://translate.hysky.de) for [Skyblocker/Skyblocker](https://translate.hysky.de/projects/Skyblocker/skyblocker/).



Current translation status:

![Weblate translation status](https://translate.hysky.de/widgets/Skyblocker/-/skyblocker/horizontal-auto.svg)