### PR TITLE
Patch workflow

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -15,9 +15,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/github-script@v2
+      - uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
-      - uses: actions/github-script@v2
+      - uses: actions/github-script@v6
         id: fname
         with:
           result-encoding: string
@@ -46,7 +46,7 @@ jobs:
             const fs = require("fs")
             return fs.readdirSync("build/libs/").filter(e => !e.endsWith("dev.jar") && !e.endsWith("sources.jar") && e.endsWith(".jar"))[0].replace(".jar", "");
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.fname.outputs.result }}
           path: build/libs/

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -27,9 +27,9 @@ jobs:
             fs.writeFileSync("./gradle.properties", file);
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'microsoft'
           java-version: '17'
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -92,7 +92,7 @@ jobs:
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
           CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
           
-          echo "::set-output name=changelog_discord::CHANGELOG"
+          echo "::set-output name=changelog_discord::$CHANGELOG"
 
       - uses: actions/github-script@v2
         id: fname

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -17,7 +17,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/
@@ -94,7 +94,7 @@ jobs:
           
           echo "::set-output name=changelog_discord::$CHANGELOG"
 
-      - uses: actions/github-script@v2
+      - uses: actions/github-script@v6
         id: fname
         with:
           result-encoding: string

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -19,9 +19,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'microsoft'
           java-version: '17'
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -41,6 +41,13 @@ jobs:
         run: |
           CHANGELOG=$(sed '/___/Q' CHANGELOG.md)
           CHANGELOG=$(echo "$CHANGELOG" | sed 1d)
+          
+          CHANGELOGtmp="${CHANGELOG//'%'/'%25'}"
+          CHANGELOGtmp="${CHANGELOGtmp//$'\n'/'%0A'}"
+          CHANGELOGtmp="${CHANGELOGtmp//$'\r'/'%0D'}"
+          
+          echo "::set-output name=changelog::$CHANGELOGtmp"
+          
           echo "Changelog:\n$CHANGELOG"
 
           changelog="${CHANGELOG}"
@@ -81,12 +88,11 @@ jobs:
           CHANGELOG=$(echo -n "$modified_changelog")
           fi
           
-          CHANGELOG-discord="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG-discord="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG-discord="${CHANGELOG//$'\r'/'%0D'}"
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
           
-          echo "::set-output name=changelog::$changelog"
-          echo "::set-output name=changelog-discord::$CHANGELOG-discord"
+          echo "::set-output name=changelog_discord::CHANGELOG"
 
       - uses: actions/github-script@v2
         id: fname
@@ -124,12 +130,9 @@ jobs:
         with:
           args: |
             "@Update-Notification"
-            "Skyblocker ${{ steps.version_tag.outputs.value }}"
+            "## Skyblocker ${{ steps.version_tag.outputs.value }}"
             ""
-            "Changelog"
-            "```md"
-            "${{ steps.read_changelog.outputs.changelog-discord }}"
-            "```"
+            "${{ steps.read_changelog.outputs.changelog_discord }}"
             ":inbox_tray: Download latest version on Modrinth or Github:"
             "<:modrinth:900697862206287882> <${{ steps.modrinth.outputs.url }}>"
             "<:github:900697885706952725> <${{ steps.uploadrelease.outputs.url }}>"


### PR DESCRIPTION
The name "CHANGELOG-discord" was the problem. GitHub mistakenly interpreted '-discord' as a command. Fix would be underscoring or rename it.