### PR TITLE
Fix broken Hypixel detection

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
@@ -129,9 +129,10 @@ public class Utils {
             return;
         }
         String string = sidebar.toString();
+        String serverAddress = (client.getCurrentServerEntry() != null) ? client.getCurrentServerEntry().address : "";
 
         if (sidebar.isEmpty()) return;
-        if (sidebar.get(sidebar.size() - 1).equals("www.hypixel.net")) {
+        if (serverAddress.contains("hypixel.net") || serverAddress.contains("hypixel.io")) {
             if (!isOnHypixel) {
                 isOnHypixel = true;
             }


### PR DESCRIPTION
Hypixel seems to have some kind of a limit on the entires in the scoreboard, so sometimes the `www.hypixel.net` got cut out and thus broke the mods detection of whether its on hypixel (and by extension broke its ability to check if we're in skyblock or not).

So now its based on the server ip!