### PR TITLE
Separate commands sent by skyblocker from the chat history

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/utils/MessageScheduler.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/MessageScheduler.java
@@ -32,10 +32,10 @@ public class MessageScheduler extends Scheduler {
 
     private void sendMessage(String message) {
         if (MinecraftClient.getInstance().player != null) {
-            MinecraftClient.getInstance().inGameHud.getChatHud().addToMessageHistory(message);
             if (message.startsWith("/")) {
                 MinecraftClient.getInstance().player.networkHandler.sendCommand(message.substring(1));
             } else {
+                MinecraftClient.getInstance().inGameHud.getChatHud().addToMessageHistory(message);
                 MinecraftClient.getInstance().player.networkHandler.sendChatMessage(message);
             }
         }


### PR DESCRIPTION
Commands sent by Skyblocker are no longer added to the chat history, eliminating it being spammed with stuff like /locraw, Quicknav commands and reparty commands.