### PR TITLE
Custom Armour Trims

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
@@ -12,6 +12,7 @@ import me.xmrvizzy.skyblocker.skyblock.dungeon.DungeonMap;
 import me.xmrvizzy.skyblocker.skyblock.dungeon.LividColor;
 import me.xmrvizzy.skyblocker.skyblock.dwarven.DwarvenHud;
 import me.xmrvizzy.skyblocker.skyblock.item.CustomArmorDyeColors;
+import me.xmrvizzy.skyblocker.skyblock.item.CustomArmorTrims;
 import me.xmrvizzy.skyblocker.skyblock.item.CustomItemNames;
 import me.xmrvizzy.skyblocker.skyblock.item.PriceInfoTooltip;
 import me.xmrvizzy.skyblocker.skyblock.item.WikiLookup;
@@ -92,6 +93,7 @@ public class SkyblockerMod implements ClientModInitializer {
         TeleportOverlay.init();
         CustomItemNames.init();
         CustomArmorDyeColors.init();
+        CustomArmorTrims.init();
         containerSolverManager.init();
         scheduler.scheduleCyclic(Utils::update, 20);
         scheduler.scheduleCyclic(DiscordRPCManager::updateDataAndPresence, 100);

--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -200,6 +200,8 @@ public class SkyblockerConfig implements ConfigData {
         public Object2ObjectOpenHashMap<String, Text> customItemNames = new Object2ObjectOpenHashMap<>();
         
         public Object2IntOpenHashMap<String> customDyeColors = new Object2IntOpenHashMap<>();
+        
+        public Object2ObjectOpenHashMap<String, String> customArmorTrims = new Object2ObjectOpenHashMap<>();
     }
 
     public static class TabHudConf {

--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -1,11 +1,10 @@
 package me.xmrvizzy.skyblocker.config;
 
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
@@ -14,12 +13,14 @@ import me.shedaniel.autoconfig.serializer.ConfigSerializer;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import me.xmrvizzy.skyblocker.SkyblockerMod;
 import me.xmrvizzy.skyblocker.chat.ChatFilterResult;
+import me.xmrvizzy.skyblocker.skyblock.item.CustomArmorTrims;
 import me.xmrvizzy.skyblocker.utils.Scheduler;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -196,12 +197,15 @@ public class SkyblockerConfig implements ConfigData {
 
         @ConfigEntry.Gui.Excluded
         public List<Integer> lockedSlots = new ArrayList<>();
-        
+
+        @ConfigEntry.Gui.Excluded
         public Object2ObjectOpenHashMap<String, Text> customItemNames = new Object2ObjectOpenHashMap<>();
-        
+
+        @ConfigEntry.Gui.Excluded
         public Object2IntOpenHashMap<String> customDyeColors = new Object2IntOpenHashMap<>();
-        
-        public Object2ObjectOpenHashMap<String, String> customArmorTrims = new Object2ObjectOpenHashMap<>();
+
+        @ConfigEntry.Gui.Excluded
+        public Object2ObjectOpenHashMap<String, CustomArmorTrims.ArmorTrimId> customArmorTrims = new Object2ObjectOpenHashMap<>();
     }
 
     public static class TabHudConf {
@@ -215,11 +219,10 @@ public class SkyblockerConfig implements ConfigData {
         @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
         @ConfigEntry.Gui.Tooltip
         public NameSorting nameSorting = NameSorting.DEFAULT;
-        
     }
-    
+
     public enum NameSorting {
-    	DEFAULT,
+        DEFAULT,
         ALPHABETICAL;
 
         @Override
@@ -551,10 +554,11 @@ public class SkyblockerConfig implements ConfigData {
                 .setPrettyPrinting()
                 .registerTypeHierarchyAdapter(Text.class, new Text.Serializer())
                 .registerTypeHierarchyAdapter(Style.class, new Style.Serializer())
+                .registerTypeHierarchyAdapter(Identifier.class, new Identifier.Serializer())
                 .create();
-        
+
         ConfigSerializer.Factory<SkyblockerConfig> serializer = (cfg, cfgClass) -> new GsonConfigSerializer<>(cfg, cfgClass, gson);
-        
+
         AutoConfig.register(SkyblockerConfig.class, serializer);
         ClientCommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess) -> dispatcher.register(literal(SkyblockerMod.NAMESPACE).then(optionsLiteral("config")).then(optionsLiteral("options")))));
     }
@@ -573,7 +577,7 @@ public class SkyblockerConfig implements ConfigData {
     public static SkyblockerConfig get() {
         return AutoConfig.getConfigHolder(SkyblockerConfig.class).getConfig();
     }
-    
+
     public static void save() {
         AutoConfig.getConfigHolder(SkyblockerConfig.class).save();
     }

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ArmorTrimMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ArmorTrimMixin.java
@@ -1,13 +1,7 @@
 package me.xmrvizzy.skyblocker.mixin;
 
-import java.util.Optional;
-
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
-
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import me.xmrvizzy.skyblocker.skyblock.item.CustomArmorTrims;
@@ -15,25 +9,29 @@ import me.xmrvizzy.skyblocker.utils.Utils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.trim.ArmorTrim;
 import net.minecraft.nbt.NbtCompound;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.Optional;
 
 @Mixin(ArmorTrim.class)
 public class ArmorTrimMixin {
 
 	@ModifyReturnValue(method = "getTrim", at = @At("RETURN"))
-	private static Optional<ArmorTrim> skyblocker$customArmorTrims(Optional<ArmorTrim> original, @Local ItemStack stack) {
+	private static Optional<ArmorTrim> skyblocker$customArmorTrims(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<ArmorTrim> original, @Local ItemStack stack) {
 		NbtCompound nbt = stack.getNbt();
 
 		if (Utils.isOnSkyblock() && nbt != null && nbt.contains("ExtraAttributes")) {
-			Object2ObjectOpenHashMap<String, String> customTrims = SkyblockerConfig.get().general.customArmorTrims;
+			Object2ObjectOpenHashMap<String, CustomArmorTrims.ArmorTrimId> customTrims = SkyblockerConfig.get().general.customArmorTrims;
 			NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
 			String itemUuid = extraAttributes.contains("uuid") ? extraAttributes.getString("uuid") : null;
-			
-			if(customTrims.containsKey(itemUuid)) {
-				String trimKey = customTrims.get(itemUuid);
+
+			if (customTrims.containsKey(itemUuid)) {
+				CustomArmorTrims.ArmorTrimId trimKey = customTrims.get(itemUuid);
 				return CustomArmorTrims.TRIMS_CACHE.getOrDefault(trimKey, original);
 			}
 		}
-		
+
 		return original;
 	}
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ArmorTrimMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ArmorTrimMixin.java
@@ -1,0 +1,39 @@
+package me.xmrvizzy.skyblocker.mixin;
+
+import java.util.Optional;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
+import me.xmrvizzy.skyblocker.skyblock.item.CustomArmorTrims;
+import me.xmrvizzy.skyblocker.utils.Utils;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.trim.ArmorTrim;
+import net.minecraft.nbt.NbtCompound;
+
+@Mixin(ArmorTrim.class)
+public class ArmorTrimMixin {
+
+	@ModifyReturnValue(method = "getTrim", at = @At("RETURN"))
+	private static Optional<ArmorTrim> skyblocker$customArmorTrims(Optional<ArmorTrim> original, @Local ItemStack stack) {
+		NbtCompound nbt = stack.getNbt();
+
+		if (Utils.isOnSkyblock() && nbt != null && nbt.contains("ExtraAttributes")) {
+			Object2ObjectOpenHashMap<String, String> customTrims = SkyblockerConfig.get().general.customArmorTrims;
+			NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
+			String itemUuid = extraAttributes.contains("uuid") ? extraAttributes.getString("uuid") : null;
+			
+			if(customTrims.containsKey(itemUuid)) {
+				String trimKey = customTrims.get(itemUuid);
+				return CustomArmorTrims.TRIMS_CACHE.getOrDefault(trimKey, original);
+			}
+		}
+		
+		return original;
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorDyeColors.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorDyeColors.java
@@ -10,7 +10,7 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.item.DyeableArmorItem;
+import net.minecraft.item.DyeableItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Text;
@@ -40,7 +40,7 @@ public class CustomArmorDyeColors {
 		}
 
 		if (Utils.isOnSkyblock() && heldItem != null) {
-			if (heldItem.getItem() instanceof DyeableArmorItem) {
+			if (heldItem.getItem() instanceof DyeableItem) {
 				if (nbt != null && nbt.contains("ExtraAttributes")) {
 					NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
 					String itemUuid = extraAttributes.contains("uuid") ? extraAttributes.getString("uuid") : null;

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorDyeColors.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorDyeColors.java
@@ -22,10 +22,11 @@ public class CustomArmorDyeColors {
 
 	private static void registerCommands(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
 		dispatcher.register(ClientCommandManager.literal("skyblocker")
-				.then(ClientCommandManager.literal("dyeColor")
-						.executes(context -> customizeDyeColor(context.getSource(), null))
-						.then(ClientCommandManager.argument("hexCode", StringArgumentType.string())
-								.executes(context -> customizeDyeColor(context.getSource(), StringArgumentType.getString(context, "hexCode"))))));
+				.then(ClientCommandManager.literal("custom")
+						.then(ClientCommandManager.literal("dyeColor")
+								.executes(context -> customizeDyeColor(context.getSource(), null))
+								.then(ClientCommandManager.argument("hexCode", StringArgumentType.string())
+										.executes(context -> customizeDyeColor(context.getSource(), StringArgumentType.getString(context, "hexCode")))))));
 	}
 
 	@SuppressWarnings("SameReturnValue")

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorTrims.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorTrims.java
@@ -1,15 +1,9 @@
 package me.xmrvizzy.skyblocker.skyblock.item;
 
-import java.util.Arrays;
-import java.util.Optional;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.arguments.StringArgumentType;
-
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import me.xmrvizzy.skyblocker.utils.SkyblockEvents;
@@ -18,74 +12,82 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.command.CommandSource;
+import net.minecraft.command.argument.IdentifierArgumentType;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.trim.ArmorTrim;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtOps;
-import net.minecraft.nbt.NbtString;
-import net.minecraft.registry.DynamicRegistryManager;
-import net.minecraft.registry.RegistryOps;
+import net.minecraft.registry.*;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 public class CustomArmorTrims {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CustomArmorTrims.class);
-	public static final Object2ObjectOpenHashMap<String, Optional<ArmorTrim>> TRIMS_CACHE = new Object2ObjectOpenHashMap<>();
-	private static final String[] TRIM_MATERIALS = { "quartz", "iron", "netherite", "redstone", "copper", "gold", "emerald", "diamond", "lapis", "amethyst" };
-	private static final String[] TRIM_PATTERNS = { "sentry", "dune", "coast", "wild", "ward", "eye", "vex", "tide", "snout", "rib", "spire", "wayfinder", "shaper", "silence", "raiser", "host" };
-	
+	public static final Object2ObjectOpenHashMap<ArmorTrimId, Optional<ArmorTrim>> TRIMS_CACHE = new Object2ObjectOpenHashMap<>();
 	private static boolean trimsInitialized = false;
-	
+
 	public static void init() {
 		SkyblockEvents.JOIN.register(CustomArmorTrims::initializeTrimCache);
 		ClientCommandRegistrationCallback.EVENT.register(CustomArmorTrims::registerCommand);
 	}
-	
+
 	private static void initializeTrimCache() {
-		if (!trimsInitialized) {
-			MinecraftClient client = MinecraftClient.getInstance();
-			DynamicRegistryManager registryManager = client.player.networkHandler.getRegistryManager();
-			
-			for (String material: TRIM_MATERIALS) {
-				for (String pattern: TRIM_PATTERNS) {
-					String key = material + "+" + pattern;
-					
+		ClientPlayerEntity player = MinecraftClient.getInstance().player;
+		if (!trimsInitialized && player != null) {
+			TRIMS_CACHE.clear();
+			DynamicRegistryManager registryManager = player.networkHandler.getRegistryManager();
+			for (Identifier material : registryManager.get(RegistryKeys.TRIM_MATERIAL).getIds()) {
+				for (Identifier pattern : registryManager.get(RegistryKeys.TRIM_PATTERN).getIds()) {
 					NbtCompound compound = new NbtCompound();
-					compound.put("material", NbtString.of("minecraft:" + material));
-					compound.put("pattern", NbtString.of("minecraft:" + pattern));
-					
+					compound.putString("material", material.toString());
+					compound.putString("pattern", pattern.toString());
+
 					ArmorTrim trim = ArmorTrim.CODEC.parse(RegistryOps.of(NbtOps.INSTANCE, registryManager), compound).resultOrPartial(LOGGER::error).orElse(null);
-					
-					//Something went terribly wrong
+
+					// Something went terribly wrong
 					if (trim == null) throw new IllegalStateException("Trim shouldn't be null! [" + "\"" + material + "\",\"" + pattern + "\"]");
-					
-					TRIMS_CACHE.put(key, Optional.of(trim));
+
+					TRIMS_CACHE.put(new ArmorTrimId(material, pattern), Optional.of(trim));
 				}
 			}
-			
+
 			LOGGER.info("[Skyblocker] Successfully cached all armor trims!");
 			trimsInitialized = true;
 		}
 	}
-	
+
 	private static void registerCommand(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
 		dispatcher.register(ClientCommandManager.literal("skyblocker")
 				.then(ClientCommandManager.literal("custom")
 						.then(ClientCommandManager.literal("armorTrim")
 								.executes(context -> customizeTrim(context.getSource(), null, null))
-								.then(ClientCommandManager.argument("material", StringArgumentType.word())
-										.suggests((context, builder) -> CommandSource.suggestMatching(TRIM_MATERIALS, builder))
-										.then(ClientCommandManager.argument("pattern", StringArgumentType.word())
-												.suggests((context, builder) -> CommandSource.suggestMatching(TRIM_PATTERNS, builder))
-												.executes(context -> customizeTrim(context.getSource(), StringArgumentType.getString(context, "material").toLowerCase(), StringArgumentType.getString(context, "pattern").toLowerCase())))))));
+								.then(ClientCommandManager.argument("material", IdentifierArgumentType.identifier())
+										.suggests(getIdSuggestionProvider(RegistryKeys.TRIM_MATERIAL))
+										.executes(context -> customizeTrim(context.getSource(), context.getArgument("material", Identifier.class), null))
+										.then(ClientCommandManager.argument("pattern", IdentifierArgumentType.identifier())
+												.suggests(getIdSuggestionProvider(RegistryKeys.TRIM_PATTERN))
+												.executes(context -> customizeTrim(context.getSource(), context.getArgument("material", Identifier.class), context.getArgument("pattern", Identifier.class))))))));
 	}
-	
-	private static int customizeTrim(FabricClientCommandSource source, String material, String pattern) {
+
+	@NotNull
+	private static SuggestionProvider<FabricClientCommandSource> getIdSuggestionProvider(RegistryKey<? extends Registry<?>> registryKey) {
+		return (context, builder) -> context.getSource().listIdSuggestions(registryKey, CommandSource.SuggestedIdType.ELEMENTS, builder, context);
+	}
+
+	@SuppressWarnings("SameReturnValue")
+	private static int customizeTrim(FabricClientCommandSource source, Identifier material, Identifier pattern) {
 		ItemStack heldItem = source.getPlayer().getMainHandStack();
 		NbtCompound nbt = (heldItem != null) ? heldItem.getNbt() : null;
-		
+
 		if (Utils.isOnSkyblock() && heldItem != null) {
 			if (heldItem.getItem() instanceof ArmorItem) {
 				if (nbt != null && nbt.contains("ExtraAttributes")) {
@@ -93,8 +95,8 @@ public class CustomArmorTrims {
 					String itemUuid = extraAttributes.contains("uuid") ? extraAttributes.getString("uuid") : null;
 
 					if (itemUuid != null) {
-						Object2ObjectOpenHashMap<String, String> customArmorTrims = SkyblockerConfig.get().general.customArmorTrims;
-						
+						Object2ObjectOpenHashMap<String, ArmorTrimId> customArmorTrims = SkyblockerConfig.get().general.customArmorTrims;
+
 						if (material == null && pattern == null) {
 							if (customArmorTrims.containsKey(itemUuid)) {
 								customArmorTrims.remove(itemUuid);
@@ -104,15 +106,16 @@ public class CustomArmorTrims {
 								source.sendFeedback(Text.translatable("skyblocker.customArmorTrims.neverHad"));
 							}
 						} else {
-							
-							//Ensure that the material & trim are valid
-							if (!Arrays.stream(TRIM_MATERIALS).anyMatch(material::equals) || !Arrays.stream(TRIM_PATTERNS).anyMatch(pattern::equals)) {
+							// Ensure that the material & trim are valid
+							ArmorTrimId trimId = new ArmorTrimId(material, pattern);
+							if (TRIMS_CACHE.get(trimId) == null) {
 								source.sendError(Text.translatable("skyblocker.customArmorTrims.invalidMaterialOrPattern"));
-								
+
 								return Command.SINGLE_SUCCESS;
 							}
-							
-							customArmorTrims.put(itemUuid, material + "+" + pattern);
+
+							customArmorTrims.put(itemUuid, trimId);
+							SkyblockerConfig.save();
 							source.sendFeedback(Text.translatable("skyblocker.customArmorTrims.added"));
 						}
 					} else {
@@ -126,7 +129,19 @@ public class CustomArmorTrims {
 		} else {
 			source.sendError(Text.translatable("skyblocker.customArmorTrims.unableToSetTrim"));
 		}
-		
+
 		return Command.SINGLE_SUCCESS;
+	}
+
+	public record ArmorTrimId(Identifier material, Identifier pattern) implements Pair<Identifier, Identifier> {
+		@Override
+		public Identifier left() {
+			return material();
+		}
+
+		@Override
+		public Identifier right() {
+			return pattern();
+		}
 	}
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorTrims.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomArmorTrims.java
@@ -1,0 +1,132 @@
+package me.xmrvizzy.skyblocker.skyblock.item;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
+import me.xmrvizzy.skyblocker.utils.SkyblockEvents;
+import me.xmrvizzy.skyblocker.utils.Utils;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.command.CommandRegistryAccess;
+import net.minecraft.command.CommandSource;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.trim.ArmorTrim;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.NbtString;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.RegistryOps;
+import net.minecraft.text.Text;
+
+public class CustomArmorTrims {
+	private static final Logger LOGGER = LoggerFactory.getLogger(CustomArmorTrims.class);
+	public static final Object2ObjectOpenHashMap<String, Optional<ArmorTrim>> TRIMS_CACHE = new Object2ObjectOpenHashMap<>();
+	private static final String[] TRIM_MATERIALS = { "quartz", "iron", "netherite", "redstone", "copper", "gold", "emerald", "diamond", "lapis", "amethyst" };
+	private static final String[] TRIM_PATTERNS = { "sentry", "dune", "coast", "wild", "ward", "eye", "vex", "tide", "snout", "rib", "spire", "wayfinder", "shaper", "silence", "raiser", "host" };
+	
+	private static boolean trimsInitialized = false;
+	
+	public static void init() {
+		SkyblockEvents.JOIN.register(CustomArmorTrims::initializeTrimCache);
+		ClientCommandRegistrationCallback.EVENT.register(CustomArmorTrims::registerCommand);
+	}
+	
+	private static void initializeTrimCache() {
+		if (!trimsInitialized) {
+			MinecraftClient client = MinecraftClient.getInstance();
+			DynamicRegistryManager registryManager = client.player.networkHandler.getRegistryManager();
+			
+			for (String material: TRIM_MATERIALS) {
+				for (String pattern: TRIM_PATTERNS) {
+					String key = material + "+" + pattern;
+					
+					NbtCompound compound = new NbtCompound();
+					compound.put("material", NbtString.of("minecraft:" + material));
+					compound.put("pattern", NbtString.of("minecraft:" + pattern));
+					
+					ArmorTrim trim = ArmorTrim.CODEC.parse(RegistryOps.of(NbtOps.INSTANCE, registryManager), compound).resultOrPartial(LOGGER::error).orElse(null);
+					
+					//Something went terribly wrong
+					if (trim == null) throw new IllegalStateException("Trim shouldn't be null! [" + "\"" + material + "\",\"" + pattern + "\"]");
+					
+					TRIMS_CACHE.put(key, Optional.of(trim));
+				}
+			}
+			
+			LOGGER.info("[Skyblocker] Successfully cached all armor trims!");
+			trimsInitialized = true;
+		}
+	}
+	
+	private static void registerCommand(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
+		dispatcher.register(ClientCommandManager.literal("skyblocker")
+				.then(ClientCommandManager.literal("custom")
+						.then(ClientCommandManager.literal("armorTrim")
+								.executes(context -> customizeTrim(context.getSource(), null, null))
+								.then(ClientCommandManager.argument("material", StringArgumentType.word())
+										.suggests((context, builder) -> CommandSource.suggestMatching(TRIM_MATERIALS, builder))
+										.then(ClientCommandManager.argument("pattern", StringArgumentType.word())
+												.suggests((context, builder) -> CommandSource.suggestMatching(TRIM_PATTERNS, builder))
+												.executes(context -> customizeTrim(context.getSource(), StringArgumentType.getString(context, "material").toLowerCase(), StringArgumentType.getString(context, "pattern").toLowerCase())))))));
+	}
+	
+	private static int customizeTrim(FabricClientCommandSource source, String material, String pattern) {
+		ItemStack heldItem = source.getPlayer().getMainHandStack();
+		NbtCompound nbt = (heldItem != null) ? heldItem.getNbt() : null;
+		
+		if (Utils.isOnSkyblock() && heldItem != null) {
+			if (heldItem.getItem() instanceof ArmorItem) {
+				if (nbt != null && nbt.contains("ExtraAttributes")) {
+					NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
+					String itemUuid = extraAttributes.contains("uuid") ? extraAttributes.getString("uuid") : null;
+
+					if (itemUuid != null) {
+						Object2ObjectOpenHashMap<String, String> customArmorTrims = SkyblockerConfig.get().general.customArmorTrims;
+						
+						if (material == null && pattern == null) {
+							if (customArmorTrims.containsKey(itemUuid)) {
+								customArmorTrims.remove(itemUuid);
+								SkyblockerConfig.save();
+								source.sendFeedback(Text.translatable("skyblocker.customArmorTrims.removed"));
+							} else {
+								source.sendFeedback(Text.translatable("skyblocker.customArmorTrims.neverHad"));
+							}
+						} else {
+							
+							//Ensure that the material & trim are valid
+							if (!Arrays.stream(TRIM_MATERIALS).anyMatch(material::equals) || !Arrays.stream(TRIM_PATTERNS).anyMatch(pattern::equals)) {
+								source.sendError(Text.translatable("skyblocker.customArmorTrims.invalidMaterialOrPattern"));
+								
+								return Command.SINGLE_SUCCESS;
+							}
+							
+							customArmorTrims.put(itemUuid, material + "+" + pattern);
+							source.sendFeedback(Text.translatable("skyblocker.customArmorTrims.added"));
+						}
+					} else {
+						source.sendError(Text.translatable("skyblocker.customArmorTrims.noItemUuid"));
+					}
+				}
+			} else {
+				source.sendError(Text.translatable("skyblocker.customArmorTrims.notAnArmorPiece"));
+				return Command.SINGLE_SUCCESS;
+			}
+		} else {
+			source.sendError(Text.translatable("skyblocker.customArmorTrims.unableToSetTrim"));
+		}
+		
+		return Command.SINGLE_SUCCESS;
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomItemNames.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CustomItemNames.java
@@ -12,6 +12,8 @@ import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.command.argument.TextArgumentType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 
 public class CustomItemNames {
@@ -21,10 +23,11 @@ public class CustomItemNames {
 
 	private static void registerCommands(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
 		dispatcher.register(ClientCommandManager.literal("skyblocker")
-				.then(ClientCommandManager.literal("renameItem")
-						.executes(context -> renameItem(context.getSource(), null))
-						.then(ClientCommandManager.argument("textComponent", TextArgumentType.text())
-								.executes(context -> renameItem(context.getSource(), context.getArgument("textComponent", Text.class))))));
+				.then(ClientCommandManager.literal("custom")
+						.then(ClientCommandManager.literal("renameItem")
+								.executes(context -> renameItem(context.getSource(), null))
+								.then(ClientCommandManager.argument("textComponent", TextArgumentType.text())
+										.executes(context -> renameItem(context.getSource(), context.getArgument("textComponent", Text.class)))))));
 	}
 
 	@SuppressWarnings("SameReturnValue")
@@ -50,6 +53,11 @@ public class CustomItemNames {
 					}
 				} else {
 					//If the text is provided then set the item's custom name to it
+					
+					//Set italic to false if it hasn't been changed (or was already false)
+					Style currentStyle = text.getStyle();
+					((MutableText) text).setStyle(currentStyle.withItalic((currentStyle.isItalic() ? true : false)));
+					
 					customItemNames.put(itemUuid, text);
 					SkyblockerConfig.save();
 					source.sendFeedback(Text.translatable("skyblocker.customItemNames.added"));

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -314,5 +314,5 @@
   "skyblocker.customArmorTrims.neverHad": "§b[§6Skyblocker§b] §fThis item doesn't have a armor trim set, but why not add one? ;)",
   "skyblocker.customArmorTrims.added": "§b[§6Skyblocker§b] §fSet a custom armor trim for your currently held item!",
   "skyblocker.customArmorTrims.noItemUuid": "§b[§6Skyblocker§b] §cYou must be holding an item that has a uuid in order to set a custom armor trim!",
-  "skyblocker.customArmorTrims.unableToSetColor": "§b[§6Skyblocker§b] §cUnable to set a custom armor trim :( (Are you in skyblock?, are you holding an item?)"
+  "skyblocker.customArmorTrims.unableToSetTrim": "§b[§6Skyblocker§b] §cUnable to set a custom armor trim :( (Are you in skyblock?, are you holding an item?)"
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -306,5 +306,13 @@
   "skyblocker.customDyeColors.neverHad": "§b[§6Skyblocker§b] §fThis item doesn't have a custom dye color set, but why not add one? ;)",
   "skyblocker.customDyeColors.added": "§b[§6Skyblocker§b] §fSet a custom dye color for your currently held item!",
   "skyblocker.customDyeColors.noItemUuid": "§b[§6Skyblocker§b] §cYou must be holding an item that has a uuid in order to set a custom dye color!",
-  "skyblocker.customDyeColors.unableToSetColor": "§b[§6Skyblocker§b] §cUnable to set a custom dye color :( (Are you in skyblock?)"
+  "skyblocker.customDyeColors.unableToSetColor": "§b[§6Skyblocker§b] §cUnable to set a custom dye color :( (Are you in skyblock?, are you holding an item?)",
+  
+  "skyblocker.customArmorTrims.invalidMaterialOrPattern": "§b[§6Skyblocker§b] §cYou supplied either an invalid material, or an invalid trim pattern!",
+  "skyblocker.customArmorTrims.notAnArmorPiece": "§b[§6Skyblocker§b] §cThis item isn't an armor piece!",
+  "skyblocker.customArmorTrims.removed": "§b[§6Skyblocker§b] §fRemoved this item's custom armor trim.",
+  "skyblocker.customArmorTrims.neverHad": "§b[§6Skyblocker§b] §fThis item doesn't have a armor trim set, but why not add one? ;)",
+  "skyblocker.customArmorTrims.added": "§b[§6Skyblocker§b] §fSet a custom armor trim for your currently held item!",
+  "skyblocker.customArmorTrims.noItemUuid": "§b[§6Skyblocker§b] §cYou must be holding an item that has a uuid in order to set a custom armor trim!",
+  "skyblocker.customArmorTrims.unableToSetColor": "§b[§6Skyblocker§b] §cUnable to set a custom armor trim :( (Are you in skyblock?, are you holding an item?)"
 }

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -3,6 +3,7 @@
   "package": "me.xmrvizzy.skyblocker.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "ArmorTrimMixin",
     "ClientPlayerEntityMixin",
     "ClientPlayNetworkHandlerMixin",
     "DrawContextMixin",

--- a/src/test/java/me/xmrvizzy/skyblocker/skyblock/item/ArmorTrimIdSerializationTest.java
+++ b/src/test/java/me/xmrvizzy/skyblocker/skyblock/item/ArmorTrimIdSerializationTest.java
@@ -1,0 +1,27 @@
+package me.xmrvizzy.skyblocker.skyblock.item;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraft.util.Identifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ArmorTrimIdSerializationTest {
+    private final Gson gson = new GsonBuilder().registerTypeAdapter(Identifier.class, new Identifier.Serializer()).create();
+
+    @Test
+    void serialize() {
+        CustomArmorTrims.ArmorTrimId armorTrimId = new CustomArmorTrims.ArmorTrimId(new Identifier("material_id"), new Identifier("pattern_id"));
+        String json = gson.toJson(armorTrimId);
+        String expectedJson = "{\"material\":\"minecraft:material_id\",\"pattern\":\"minecraft:pattern_id\"}";
+        Assertions.assertEquals(expectedJson, json);
+    }
+
+    @Test
+    void deserialize() {
+        String json = "{\"material\":\"minecraft:material_id\",\"pattern\":\"minecraft:pattern_id\"}";
+        CustomArmorTrims.ArmorTrimId armorTrimId = gson.fromJson(json, CustomArmorTrims.ArmorTrimId.class);
+        CustomArmorTrims.ArmorTrimId expectedArmorTrimId = new CustomArmorTrims.ArmorTrimId(new Identifier("material_id"), new Identifier("pattern_id"));
+        Assertions.assertEquals(expectedArmorTrimId, armorTrimId);
+    }
+}


### PR DESCRIPTION
## Armour Trims
Along with the other new customization features, you'll be able to apply any armour trim of your choice to your armour sets!

Its as simple as doing `/skyblocker custom armorTrim <material> <pattern>`

Example: `/skyblocker custom armorTrim diamond snout`

Armour sets have **never** been fancier than this!

### Other
- Italic is now defaulted to false when adding a custom item name
- Customization commands are now grouped under `/skyblocker custom`