### PR TITLE
Starred Mob Glow

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -413,6 +413,8 @@ public class SkyblockerConfig implements ConfigData {
         public float mapScaling = 1f;
         public int mapX = 2;
         public int mapY = 2;
+        @ConfigEntry.Gui.Tooltip
+        public boolean starredMobGlow = false;
         public boolean solveThreeWeirdos = true;
         @ConfigEntry.Gui.Tooltip
         public boolean blazesolver = true;

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/WorldRendererMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/WorldRendererMixin.java
@@ -1,0 +1,33 @@
+package me.xmrvizzy.skyblocker.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
+
+import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
+import me.xmrvizzy.skyblocker.skyblock.dungeon.StarredMobGlow;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.entity.Entity;
+
+@Mixin(WorldRenderer.class)
+public class WorldRendererMixin {
+	
+	@ModifyExpressionValue(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"))
+	private boolean skyblocker$shouldStarredMobGlow(boolean original, @Local Entity entity, @Share("isGlowingStarredMob") LocalBooleanRef isGlowingStarredMob) {
+		boolean isAStarredMobThatShouldGlow = SkyblockerConfig.get().locations.dungeons.starredMobGlow && StarredMobGlow.shouldMobGlow(entity);
+		
+		isGlowingStarredMob.set(isAStarredMobThatShouldGlow);
+		
+		return original || isAStarredMobThatShouldGlow;
+	}
+	
+	@ModifyVariable(method = "render", at = @At("STORE"), ordinal = 0)
+	private int skyblocker$modifyGlowColor(int color, @Local Entity entity, @Share("isGlowingStarredMob") LocalBooleanRef isGlowingStarredMob) {
+		return isGlowingStarredMob.get() ? StarredMobGlow.getGlowColor(entity) : color;
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/StarredMobGlow.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/StarredMobGlow.java
@@ -1,0 +1,51 @@
+package me.xmrvizzy.skyblocker.skyblock.dungeon;
+
+import java.util.List;
+
+import me.xmrvizzy.skyblocker.utils.Utils;
+import me.xmrvizzy.skyblocker.utils.culling.OcclusionCulling;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.predicate.entity.EntityPredicates;
+import net.minecraft.util.math.Box;
+
+public class StarredMobGlow {
+
+	public static boolean shouldMobGlow(Entity entity) {
+		Box box = entity.getBoundingBox();
+		
+		if (Utils.isInDungeons() && !entity.isInvisible() && OcclusionCulling.isVisible(box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ)) {
+			//Minibosses
+			if (entity instanceof PlayerEntity) {
+				switch (entity.getName().getString()) {
+					case "Lost Adventurer": return true;
+					case "Shadow Assassin": return true;
+					case "Diamond Guy": return true;
+				}
+			}
+			
+			//Regular Mobs
+			if (!(entity instanceof ArmorStandEntity)) {
+				Box searchBox = box.expand(0, 2, 0);
+				List<ArmorStandEntity> armorStands = entity.getWorld().getEntitiesByClass(ArmorStandEntity.class, searchBox, EntityPredicates.NOT_MOUNTED);
+				
+				if (!armorStands.isEmpty() && armorStands.get(0).getName().getString().contains("✯")) return true;
+			}
+		}
+		
+		return false;
+	}
+	
+	public static int getGlowColor(Entity entity) {
+		if (entity instanceof PlayerEntity) {
+			switch (entity.getName().getString()) {
+				case "Lost Adventurer": return 0xfee15c;
+				case "Shadow Assassin": return 0x5b2cb2;
+				case "Diamond Guy": return 0x57c2f7;
+			}
+		}
+		
+		return 0xf57738;
+	}
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -204,6 +204,8 @@
   "text.autoconfig.skyblocker.option.locations.dungeons.mapScaling": "Map Scaling",
   "text.autoconfig.skyblocker.option.locations.dungeons.mapX": "Map X",
   "text.autoconfig.skyblocker.option.locations.dungeons.mapY": "Map Y",
+  "text.autoconfig.skyblocker.option.locations.dungeons.starredMobGlow": "Starred Mob Glow",
+  "text.autoconfig.skyblocker.option.locations.dungeons.starredMobGlow.@Tooltip": "Applies the glowing effect to starred mobs that are visible.",
   "text.autoconfig.skyblocker.option.locations.dungeons.solveThreeWeirdos": "Solve Three Weirdos Puzzle",
   "text.autoconfig.skyblocker.option.locations.dungeons.blazesolver": "Solve Blaze Puzzle",
   "text.autoconfig.skyblocker.option.locations.dungeons.blazesolver.@Tooltip": "Boxes the correct blaze in green, also draws a line to and boxes the next blaze to kill in white.",

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -19,6 +19,7 @@
     "PlayerListHudMixin",
     "PlayerSkinProviderMixin",
     "ScoreboardMixin",
+    "WorldRendererMixin",
     "accessor.BeaconBlockEntityRendererInvoker",
     "accessor.FrustumInvoker",
     "accessor.HandledScreenAccessor",


### PR DESCRIPTION
Adds the glowing effect to starred mobs that are visible to the player! To achieve this, the mod's existing occlusion culling system is what's used to determine whether a mob is visible or not. 

This helps to see the mobs better while complying with Hypixel's rules.
Shadow Assassins, Lost Adventurers and Angry Archaeologists have their own individual glow colours as well!

