### PR TITLE
Reduce Network Bandwidth

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
@@ -41,6 +41,7 @@ import java.nio.file.Path;
  * this class.
  */
 public class SkyblockerMod implements ClientModInitializer {
+	public static final String VERSION = FabricLoader.getInstance().getModContainer("skyblocker").get().getMetadata().getVersion().getFriendlyString();
     public static final String NAMESPACE = "skyblocker";
     public static final Path CONFIG_DIR = FabricLoader.getInstance().getConfigDir().resolve(NAMESPACE);
     public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
@@ -41,7 +41,7 @@ import java.nio.file.Path;
  * this class.
  */
 public class SkyblockerMod implements ClientModInitializer {
-	public static final String VERSION = FabricLoader.getInstance().getModContainer("skyblocker").get().getMetadata().getVersion().getFriendlyString();
+    public static final String VERSION = FabricLoader.getInstance().getModContainer("skyblocker").get().getMetadata().getVersion().getFriendlyString();
     public static final String NAMESPACE = "skyblocker";
     public static final Path CONFIG_DIR = FabricLoader.getInstance().getConfigDir().resolve(NAMESPACE);
     public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/PriceInfoTooltip.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/PriceInfoTooltip.java
@@ -402,14 +402,14 @@ public class PriceInfoTooltip {
             String url = apiAddresses.get(type);
             
             if (type.equals("npc") || type.equals("museum") || type.equals("motes")) {
-            	HttpHeaders headers = Http.sendHeadRequest(url);
-            	long combinedHash = Http.getEtag(headers).hashCode() + Http.getLastModified(headers).hashCode();
+                HttpHeaders headers = Http.sendHeadRequest(url);
+                long combinedHash = Http.getEtag(headers).hashCode() + Http.getLastModified(headers).hashCode();
             	
-            	switch (type) {
-            	    case "npc": if (npcHash == combinedHash) return npcPricesJson; else npcHash = combinedHash;
-            	    case "museum": if (museumHash == combinedHash) return isMuseumJson; else museumHash = combinedHash;
-            	    case "motes": if (motesHash == combinedHash) return motesPricesJson; else motesHash = combinedHash;
-            	}
+                switch (type) {
+                    case "npc": if (npcHash == combinedHash) return npcPricesJson; else npcHash = combinedHash;
+                    case "museum": if (museumHash == combinedHash) return isMuseumJson; else museumHash = combinedHash;
+                    case "motes": if (motesHash == combinedHash) return motesPricesJson; else motesHash = combinedHash;
+                }
             }
             
             String apiResponse = Http.sendGetRequest(url);

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Http.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Http.java
@@ -1,0 +1,91 @@
+package me.xmrvizzy.skyblocker.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+
+import me.xmrvizzy.skyblocker.SkyblockerMod;
+import net.minecraft.SharedConstants;
+
+/**
+ * @implNote All http requests are sent using HTTP 2
+ */
+public class Http {
+	private static final String USER_AGENT = "Skyblocker/" + SkyblockerMod.VERSION + " (" + SharedConstants.getGameVersion().getName() + ")";
+	private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+			.connectTimeout(Duration.ofSeconds(10))
+			.build();
+	
+	public static String sendGetRequest(String url) throws IOException, InterruptedException {
+		HttpRequest request = HttpRequest.newBuilder()
+				.GET()
+				.header("Accept", "application/json")
+				.header("Accept-Encoding", "gzip, deflate")
+				.header("User-Agent", USER_AGENT)
+				.version(Version.HTTP_2)
+				.uri(URI.create(url))
+				.build();
+		
+		HttpResponse<InputStream> response = HTTP_CLIENT.send(request, BodyHandlers.ofInputStream());
+		InputStream decodedInputStream = getDecodedInputStream(response);
+		String body = new String(decodedInputStream.readAllBytes());
+		
+		return body;
+	}
+	
+	public static HttpHeaders sendHeadRequest(String url) throws IOException, InterruptedException {
+		HttpRequest request = HttpRequest.newBuilder()
+				.method("HEAD", BodyPublishers.noBody())
+				.header("Accept", "application/json")
+				.header("Accept-Encoding", "gzip, deflate")
+				.header("User-Agent", USER_AGENT)
+				.version(Version.HTTP_2)
+				.uri(URI.create(url))
+				.build();
+		
+		HttpResponse<Void> response = HTTP_CLIENT.send(request, BodyHandlers.discarding());		
+		return response.headers();
+	}
+	
+	private static InputStream getDecodedInputStream(HttpResponse<InputStream> response) {
+		String encoding = getContentEncoding(response);
+		
+		try {
+			switch (encoding) {
+				case "":
+					return response.body();
+				case "gzip":
+					return new GZIPInputStream(response.body());
+				case "deflate":
+					return new InflaterInputStream(response.body());
+				default:
+					throw new UnsupportedOperationException("The server sent content in an unexpected encoding: " + encoding);
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+	
+	private static String getContentEncoding(HttpResponse<InputStream> response) {
+		return response.headers().firstValue("Content-Encoding").orElse("");
+	}
+	
+	public static String getEtag(HttpHeaders headers) {
+		return headers.firstValue("Etag").orElse("");
+	}
+	
+	public static String getLastModified(HttpHeaders headers) {
+		return headers.firstValue("Last-Modified").orElse("");
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Http.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Http.java
@@ -47,8 +47,6 @@ public class Http {
 	public static HttpHeaders sendHeadRequest(String url) throws IOException, InterruptedException {
 		HttpRequest request = HttpRequest.newBuilder()
 				.method("HEAD", BodyPublishers.noBody())
-				.header("Accept", "application/json")
-				.header("Accept-Encoding", "gzip, deflate")
 				.header("User-Agent", USER_AGENT)
 				.version(Version.HTTP_2)
 				.uri(URI.create(url))


### PR DESCRIPTION
Reduces network bandwidth generated from the mod loading data from various apis

- When requesting data from semi static endpoints, the mod first sends a `HEAD` request and combines the string hashcodes of the `Last-Modified` and `ETag` header to determine if the content has changed or not.
- Now uses Java's HTTP Client Api
- Requests (and gets) gzip compression from all apis
- Requests are now made over HTTP/2
- The mod now has a user agent
  - It follows this format `Skyblocker/MOD_VERION (MC_VERSION)` ex: `Skyblocker/1.13.0 (1.20.1)`