### PR TITLE
Personal Compactor/Deletor preview

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -145,6 +145,7 @@ public class SkyblockerConfig implements ConfigData {
     public static class General {
         public boolean acceptReparty = true;
         public boolean backpackPreviewWithoutShift = false;
+        public boolean compactorDeletorPreview = true;
         public boolean hideEmptyTooltips = true;
 
         @ConfigEntry.Category("tabHud")

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -2,12 +2,11 @@ package me.xmrvizzy.skyblocker.mixin;
 
 import me.xmrvizzy.skyblocker.SkyblockerMod;
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
-import me.xmrvizzy.skyblocker.mixin.accessor.DrawContextInvoker;
-import me.xmrvizzy.skyblocker.skyblock.item.BackpackPreview;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ChronomatronSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ExperimentSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.SuperpairsSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.UltrasequencerSolver;
+import me.xmrvizzy.skyblocker.skyblock.item.BackpackPreview;
 import me.xmrvizzy.skyblocker.skyblock.item.CompactorDeletorPreview;
 import me.xmrvizzy.skyblocker.skyblock.item.WikiLookup;
 import me.xmrvizzy.skyblocker.skyblock.itemlist.ItemRegistry;
@@ -34,6 +33,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Map;
+import java.util.regex.Matcher;
 
 @Mixin(HandledScreen.class)
 public abstract class HandledScreenMixin extends Screen {
@@ -52,27 +52,30 @@ public abstract class HandledScreenMixin extends Screen {
         }
     }
 
-    @SuppressWarnings("DataFlowIssue") // makes intellij be quiet about this.focusedSlot maybe being null. It's already null checked in mixined method.
+    @SuppressWarnings("DataFlowIssue")
+    // makes intellij be quiet about this.focusedSlot maybe being null. It's already null checked in mixined method.
     @Inject(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;II)V"), cancellable = true)
     public void skyblocker$drawMouseOverTooltip(DrawContext context, int x, int y, CallbackInfo ci) {
-        ItemStack stack = this.focusedSlot.getStack();
-        String internalName = ItemRegistry.getInternalName(stack);
+        if (!Utils.isOnSkyblock()) return;
 
         // Hide Empty Tooltips
-        if (Utils.isOnSkyblock() && SkyblockerConfig.get().general.hideEmptyTooltips && this.focusedSlot != null && focusedSlot.getStack().getName().getString().equals(" ")) {
+        if (SkyblockerConfig.get().general.hideEmptyTooltips && focusedSlot.getStack().getName().getString().equals(" ")) {
             ci.cancel();
         }
 
         // Backpack Preview
         boolean shiftDown = SkyblockerConfig.get().general.backpackPreviewWithoutShift ^ Screen.hasShiftDown();
-        if (this.client == null || this.client.player == null) return;
-        if (shiftDown && this.getTitle().getString().equals("Storage") && this.focusedSlot.inventory != this.client.player.getInventory() && BackpackPreview.renderPreview(context, this.focusedSlot.getIndex(), x, y)) {
+        if (shiftDown && getTitle().getString().equals("Storage") && focusedSlot.inventory != client.player.getInventory() && BackpackPreview.renderPreview(context, focusedSlot.getIndex(), x, y)) {
             ci.cancel();
         }
 
         // Compactor Preview
-        if ((internalName.contains("PERSONAL_COMPACTOR_") || internalName.contains("PERSONAL_DELETOR_")) && CompactorDeletorPreview.displayCompactorDeletorPreview((DrawContextInvoker) context, x, y, stack)) {
-            ci.cancel();
+        if (SkyblockerConfig.get().general.compactorDeletorPreview) {
+            ItemStack stack = focusedSlot.getStack();
+            Matcher matcher = CompactorDeletorPreview.NAME.matcher(ItemRegistry.getInternalName(stack));
+            if (matcher.matches() && CompactorDeletorPreview.drawPreview(context, stack, matcher.group("type"), matcher.group("size"), x, y)) {
+                ci.cancel();
+            }
         }
     }
 
@@ -85,7 +88,6 @@ public abstract class HandledScreenMixin extends Screen {
     private ItemStack skyblocker$experimentSolvers$replaceDisplayStack(ItemStack stack, DrawContext context, Slot slot) {
         return skyblocker$experimentSolvers$getStack(slot, stack);
     }
-
 
 
     @Unique

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -8,7 +8,7 @@ import me.xmrvizzy.skyblocker.skyblock.experiment.ChronomatronSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ExperimentSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.SuperpairsSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.UltrasequencerSolver;
-import me.xmrvizzy.skyblocker.skyblock.item.CompactorPreviewTooltipComponent;
+import me.xmrvizzy.skyblocker.skyblock.item.CompactorDeletorPreview;
 import me.xmrvizzy.skyblocker.skyblock.item.WikiLookup;
 import me.xmrvizzy.skyblocker.skyblock.itemlist.ItemRegistry;
 import me.xmrvizzy.skyblocker.utils.Utils;
@@ -16,18 +16,12 @@ import me.xmrvizzy.skyblocker.utils.render.gui.ContainerSolver;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.client.gui.tooltip.HoveredTooltipPositioner;
-import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
-import net.minecraft.text.MutableText;
-import net.minecraft.text.Style;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -39,27 +33,13 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Mixin(HandledScreen.class)
 public abstract class HandledScreenMixin extends Screen {
     @Shadow
     @Nullable
     protected Slot focusedSlot;
-
-    @Unique
-    private static final Map<String, int[]> personalCompactorTypeToSlot = new HashMap<>();
-    // Lines, and slots per lines
-    static {
-        personalCompactorTypeToSlot.put("4000", new int[]{1,1});
-        personalCompactorTypeToSlot.put("5000", new int[]{1,3});
-        personalCompactorTypeToSlot.put("6000", new int[]{1,7});
-        personalCompactorTypeToSlot.put("7000", new int[]{2,6});
-        personalCompactorTypeToSlot.put("default", new int[]{1,6});
-    }
 
     protected HandledScreenMixin(Text title) {
         super(title);
@@ -72,8 +52,12 @@ public abstract class HandledScreenMixin extends Screen {
         }
     }
 
-    @Inject(at = @At("HEAD"), method = "drawMouseoverTooltip", cancellable = true)
+    @SuppressWarnings("DataFlowIssue") // makes intellij be quiet about this.focusedSlot maybe being null. It's already null checked in mixined method.
+    @Inject(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;II)V"), cancellable = true)
     public void skyblocker$drawMouseOverTooltip(DrawContext context, int x, int y, CallbackInfo ci) {
+        ItemStack stack = this.focusedSlot.getStack();
+        String internalName = ItemRegistry.getInternalName(stack);
+
         // Hide Empty Tooltips
         if (Utils.isOnSkyblock() && SkyblockerConfig.get().general.hideEmptyTooltips && this.focusedSlot != null && focusedSlot.getStack().getName().getString().equals(" ")) {
             ci.cancel();
@@ -81,7 +65,13 @@ public abstract class HandledScreenMixin extends Screen {
 
         // Backpack Preview
         boolean shiftDown = SkyblockerConfig.get().general.backpackPreviewWithoutShift ^ Screen.hasShiftDown();
-        if (this.client != null && this.client.player != null && this.focusedSlot != null && shiftDown && this.getTitle().getString().equals("Storage") && this.focusedSlot.inventory != this.client.player.getInventory() && BackpackPreview.renderPreview(context, this.focusedSlot.getIndex(), x, y)) {
+        if (this.client == null || this.client.player == null) return;
+        if (shiftDown && this.getTitle().getString().equals("Storage") && this.focusedSlot.inventory != this.client.player.getInventory() && BackpackPreview.renderPreview(context, this.focusedSlot.getIndex(), x, y)) {
+            ci.cancel();
+        }
+
+        // Compactor Preview
+        if ((internalName.contains("PERSONAL_COMPACTOR_") || internalName.contains("PERSONAL_DELETOR_")) && CompactorDeletorPreview.displayCompactorDeletorPreview((DrawContextInvoker) context, x, y, stack)) {
             ci.cancel();
         }
     }
@@ -96,91 +86,7 @@ public abstract class HandledScreenMixin extends Screen {
         return skyblocker$experimentSolvers$getStack(slot, stack);
     }
 
-    @Inject(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;II)V"), cancellable = true)
-    private void skyblocker$addTooltipComponent(DrawContext context, int x, int y, CallbackInfo ci) {
-        if (this.focusedSlot == null || this.client == null) return;
-        ItemStack stack = this.focusedSlot.getStack();
-        String internalName = ItemRegistry.getInternalName(stack);
-        // PERSONAL COMPACTOR
-        if (internalName.contains("PERSONAL_COMPACTOR_") || internalName.contains("PERSONAL_DELETOR_")) {
-            String prefix;
-            String itemSlotPrefix;
-            if (internalName.contains("PERSONAL_COMPACTOR_")) {
-                prefix = "PERSONAL_COMPACTOR_";
-                itemSlotPrefix = "personal_compact_";
-            } else {
-                prefix = "PERSONAL_DELETOR_";
-                itemSlotPrefix = "personal_deletor_";
-            }
 
-            // Find the line to insert component
-            int targetIndex = -1;
-            int lineCount = 0;
-            List<Text> tooltips = Screen.getTooltipFromItem(this.client, stack);
-            for (int i = 0; i < tooltips.size(); i++) {
-                if (tooltips.get(i).getString().isEmpty()) {
-                    lineCount += 1;
-                }
-                if (lineCount == 2) {
-                    targetIndex = i;
-                    break;
-                }
-            }
-            if (targetIndex == -1) return;
-            List<TooltipComponent> components = new java.util.ArrayList<>(tooltips.stream().map(Text::asOrderedText).map(TooltipComponent::of).toList());
-
-            // STUFF
-            String internalID = ItemRegistry.getInternalName(stack);
-            String compactorType = internalID.replaceFirst(prefix, "");
-            int[] dimensions = personalCompactorTypeToSlot.containsKey(compactorType) ? personalCompactorTypeToSlot.get(compactorType) : personalCompactorTypeToSlot.get("default");
-
-            NbtCompound nbt = stack.getNbt();
-            if (nbt == null || !nbt.contains("ExtraAttributes", 10)) {
-                return;
-            }
-            NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
-            Set<String> attributesKeys = extraAttributes.getKeys();
-            List<String> compactorItems = attributesKeys.stream().filter(s -> s.contains(itemSlotPrefix)).toList();
-            Map<Integer, ItemStack> slotAndItem = new HashMap<>();
-
-            if (compactorItems.isEmpty()) {
-                int slotsCount = (dimensions[0] * dimensions[1]);
-                components.add(targetIndex, TooltipComponent.of(Text.literal(
-                         slotsCount + (slotsCount == 1 ? " slot": " slots"))
-                        .fillStyle(Style.EMPTY.withColor(Formatting.DARK_GRAY)).asOrderedText()));
-
-                ((DrawContextInvoker) context).invokeDrawTooltip(textRenderer, components, x, y, HoveredTooltipPositioner.INSTANCE);
-                ci.cancel();
-                return;
-            }
-
-            compactorItems.forEach(s -> slotAndItem.put(getNumberAtEnd(s, itemSlotPrefix), ItemRegistry.getItemStack(extraAttributes.getString(s))));
-
-
-            components.add(targetIndex, new CompactorPreviewTooltipComponent(slotAndItem, dimensions));
-            components.add(targetIndex, TooltipComponent.of(Text.literal(" ").append(
-                            Text.literal("Contents:").fillStyle(Style.EMPTY
-                                    .withItalic(true)))
-                    .asOrderedText()));
-            if (attributesKeys.stream().anyMatch(s -> s.contains("PERSONAL_DELETOR_ACTIVE"))) {
-                MutableText isActiveText = Text.literal("Active: ");
-                if (extraAttributes.getBoolean("PERSONAL_DELETOR_ACTIVE")) {
-                    components.add(targetIndex, TooltipComponent.of(isActiveText.append(
-                                    Text.literal("YES").fillStyle(Style.EMPTY.withBold(true).withColor(Formatting.GREEN))
-                            ).asOrderedText()
-                    ));
-                } else {
-                    components.add(targetIndex, TooltipComponent.of(isActiveText.append(
-                                    Text.literal("NO").fillStyle(Style.EMPTY.withBold(true).withColor(Formatting.RED))
-                            ).asOrderedText()
-                    ));
-                }
-            }
-            ((DrawContextInvoker) context).invokeDrawTooltip(textRenderer, components, x, y, HoveredTooltipPositioner.INSTANCE);
-            ci.cancel();
-
-        }
-    }
 
     @Unique
     private ItemStack skyblocker$experimentSolvers$getStack(Slot slot, ItemStack stack) {
@@ -210,16 +116,6 @@ public abstract class HandledScreenMixin extends Screen {
                     ultrasequencerSolver.getSlots().entrySet().stream().filter(entry -> entry.getValue().getCount() == count).findAny().map(Map.Entry::getKey).ifPresentOrElse(ultrasequencerSolver::setUltrasequencerNextSlot, () -> ultrasequencerSolver.setState(ExperimentSolver.State.END));
                 }
             }
-        }
-    }
-
-    @Unique
-    private static Integer getNumberAtEnd(String str, String attributesKey) {
-        try {
-            String numberPartOfTheString = str.replace(attributesKey, "");
-            return Integer.parseInt(numberPartOfTheString);
-        } catch (NumberFormatException e) {
-            return 0;
         }
     }
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -3,7 +3,7 @@ package me.xmrvizzy.skyblocker.mixin;
 import me.xmrvizzy.skyblocker.SkyblockerMod;
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import me.xmrvizzy.skyblocker.mixin.accessor.DrawContextInvoker;
-import me.xmrvizzy.skyblocker.skyblock.BackpackPreview;
+import me.xmrvizzy.skyblocker.skyblock.item.BackpackPreview;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ChronomatronSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ExperimentSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.SuperpairsSolver;

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -2,28 +2,33 @@ package me.xmrvizzy.skyblocker.mixin;
 
 import me.xmrvizzy.skyblocker.SkyblockerMod;
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
+import me.xmrvizzy.skyblocker.mixin.accessor.DrawContextInvoker;
 import me.xmrvizzy.skyblocker.skyblock.BackpackPreview;
-import me.xmrvizzy.skyblocker.skyblock.dungeon.DungeonChestProfit;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ChronomatronSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ExperimentSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.SuperpairsSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.UltrasequencerSolver;
+import me.xmrvizzy.skyblocker.skyblock.item.CompactorPreviewTooltipComponent;
 import me.xmrvizzy.skyblocker.skyblock.item.WikiLookup;
+import me.xmrvizzy.skyblocker.skyblock.itemlist.ItemRegistry;
 import me.xmrvizzy.skyblocker.utils.Utils;
 import me.xmrvizzy.skyblocker.utils.render.gui.ContainerSolver;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.tooltip.HoveredTooltipPositioner;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.GenericContainerScreenHandler;
-import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.Nullable;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -34,16 +39,27 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Mixin(HandledScreen.class)
 public abstract class HandledScreenMixin extends Screen {
     @Shadow
     @Nullable
     protected Slot focusedSlot;
+
+    @Unique
+    private static final Map<String, int[]> personalCompactorTypeToSlot = new HashMap<>();
+    // Lines, and slots per lines
+    static {
+        personalCompactorTypeToSlot.put("4000", new int[]{1,1});
+        personalCompactorTypeToSlot.put("5000", new int[]{1,3});
+        personalCompactorTypeToSlot.put("6000", new int[]{1,7});
+        personalCompactorTypeToSlot.put("7000", new int[]{2,6});
+        personalCompactorTypeToSlot.put("default", new int[]{1,6});
+    }
 
     protected HandledScreenMixin(Text title) {
         super(title);
@@ -80,6 +96,81 @@ public abstract class HandledScreenMixin extends Screen {
         return skyblocker$experimentSolvers$getStack(slot, stack);
     }
 
+    @Inject(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;II)V"), cancellable = true)
+    private void skyblocker$addTooltipComponent(DrawContext context, int x, int y, CallbackInfo ci) {
+        if (this.focusedSlot == null || this.client == null) return;
+        ItemStack stack = this.focusedSlot.getStack();
+        String internalName = ItemRegistry.getInternalName(stack);
+        // PERSONAL COMPACTOR
+        if (internalName.contains("PERSONAL_COMPACTOR_") || internalName.contains("PERSONAL_DELETOR_")) {
+            String prefix;
+            String itemSlotPrefix;
+            if (internalName.contains("PERSONAL_COMPACTOR_")) {
+                prefix = "PERSONAL_COMPACTOR_";
+                itemSlotPrefix = "personal_compact_";
+            } else {
+                prefix = "PERSONAL_DELETOR_";
+                itemSlotPrefix = "personal_deletor_";
+            }
+
+            // Find the line to insert component
+            int targetIndex = -1;
+            int lineCount = 0;
+            List<Text> tooltips = Screen.getTooltipFromItem(this.client, stack);
+            for (int i = 0; i < tooltips.size(); i++) {
+                if (tooltips.get(i).getString().isEmpty()) {
+                    lineCount += 1;
+                }
+                if (lineCount == 2) {
+                    targetIndex = i;
+                    break;
+                }
+            }
+            if (targetIndex == -1) return;
+            List<TooltipComponent> components = new java.util.ArrayList<>(tooltips.stream().map(Text::asOrderedText).map(TooltipComponent::of).toList());
+
+            // STUFF
+            String internalID = ItemRegistry.getInternalName(stack);
+            String compactorType = internalID.replaceFirst(prefix, "");
+            int[] dimensions = personalCompactorTypeToSlot.containsKey(compactorType) ? personalCompactorTypeToSlot.get(compactorType) : personalCompactorTypeToSlot.get("default");
+
+            NbtCompound nbt = stack.getNbt();
+            if (nbt == null || !nbt.contains("ExtraAttributes", 10)) {
+                return;
+            }
+            NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
+            Set<String> attributesKeys = extraAttributes.getKeys();
+            List<String> compactorItems = attributesKeys.stream().filter(s -> s.contains(itemSlotPrefix)).toList();
+            Map<Integer, ItemStack> slotAndItem = new HashMap<>();
+
+            compactorItems.forEach(s -> slotAndItem.put(getNumberAtEnd(s, itemSlotPrefix), ItemRegistry.getItemStack(extraAttributes.getString(s))));
+
+
+            components.add(targetIndex, new CompactorPreviewTooltipComponent(slotAndItem, dimensions));
+            components.add(targetIndex, TooltipComponent.of(Text.literal(" ").append(
+                            Text.literal("Contents:").fillStyle(Style.EMPTY
+                                    .withItalic(true)))
+                    .asOrderedText()));
+            if (attributesKeys.stream().anyMatch(s -> s.contains("PERSONAL_DELETOR_ACTIVE"))) {
+                MutableText isActiveText = Text.literal("Active: ");
+                if (extraAttributes.getBoolean("PERSONAL_DELETOR_ACTIVE")) {
+                    components.add(targetIndex, TooltipComponent.of(isActiveText.append(
+                                    Text.literal("YES").fillStyle(Style.EMPTY.withBold(true).withColor(Formatting.GREEN))
+                            ).asOrderedText()
+                    ));
+                } else {
+                    components.add(targetIndex, TooltipComponent.of(isActiveText.append(
+                                    Text.literal("NO").fillStyle(Style.EMPTY.withBold(true).withColor(Formatting.RED))
+                            ).asOrderedText()
+                    ));
+                }
+            }
+            ((DrawContextInvoker) context).invokeDrawTooltip(textRenderer, components, x, y, HoveredTooltipPositioner.INSTANCE);
+            ci.cancel();
+
+        }
+    }
+
     @Unique
     private ItemStack skyblocker$experimentSolvers$getStack(Slot slot, ItemStack stack) {
         ContainerSolver currentSolver = SkyblockerMod.getInstance().containerSolverManager.getCurrentSolver();
@@ -108,6 +199,16 @@ public abstract class HandledScreenMixin extends Screen {
                     ultrasequencerSolver.getSlots().entrySet().stream().filter(entry -> entry.getValue().getCount() == count).findAny().map(Map.Entry::getKey).ifPresentOrElse(ultrasequencerSolver::setUltrasequencerNextSlot, () -> ultrasequencerSolver.setState(ExperimentSolver.State.END));
                 }
             }
+        }
+    }
+
+    @Unique
+    private static Integer getNumberAtEnd(String str, String attributesKey) {
+        try {
+            String numberPartOfTheString = str.replace(attributesKey, "");
+            return Integer.parseInt(numberPartOfTheString);
+        } catch (NumberFormatException e) {
+            return 0;
         }
     }
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -143,6 +143,17 @@ public abstract class HandledScreenMixin extends Screen {
             List<String> compactorItems = attributesKeys.stream().filter(s -> s.contains(itemSlotPrefix)).toList();
             Map<Integer, ItemStack> slotAndItem = new HashMap<>();
 
+            if (compactorItems.isEmpty()) {
+                int slotsCount = (dimensions[0] * dimensions[1]);
+                components.add(targetIndex, TooltipComponent.of(Text.literal(
+                         slotsCount + (slotsCount == 1 ? " slot": " slots"))
+                        .fillStyle(Style.EMPTY.withColor(Formatting.DARK_GRAY)).asOrderedText()));
+
+                ((DrawContextInvoker) context).invokeDrawTooltip(textRenderer, components, x, y, HoveredTooltipPositioner.INSTANCE);
+                ci.cancel();
+                return;
+            }
+
             compactorItems.forEach(s -> slotAndItem.put(getNumberAtEnd(s, itemSlotPrefix), ItemRegistry.getItemStack(extraAttributes.getString(s))));
 
 

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/accessor/DrawContextInvoker.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/accessor/DrawContextInvoker.java
@@ -1,0 +1,18 @@
+package me.xmrvizzy.skyblocker.mixin.accessor;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.gui.tooltip.TooltipPositioner;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.List;
+
+@Mixin(DrawContext.class)
+public interface DrawContextInvoker {
+
+    @SuppressWarnings("unused")
+    @Invoker("drawTooltip")
+    void invokeDrawTooltip(TextRenderer textRenderer, List<TooltipComponent> components, int x, int y, TooltipPositioner positioner);
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/accessor/DrawContextInvoker.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/accessor/DrawContextInvoker.java
@@ -12,7 +12,6 @@ import java.util.List;
 @Mixin(DrawContext.class)
 public interface DrawContextInvoker {
 
-    @SuppressWarnings("unused")
-    @Invoker("drawTooltip")
+    @Invoker
     void invokeDrawTooltip(TextRenderer textRenderer, List<TooltipComponent> components, int x, int y, TooltipPositioner positioner);
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/BackpackPreview.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/BackpackPreview.java
@@ -1,4 +1,4 @@
-package me.xmrvizzy.skyblocker.skyblock;
+package me.xmrvizzy.skyblocker.skyblock.item;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.xmrvizzy.skyblocker.SkyblockerMod;

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CompactorDeletorPreview.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CompactorDeletorPreview.java
@@ -1,0 +1,122 @@
+package me.xmrvizzy.skyblocker.skyblock.item;
+
+import me.xmrvizzy.skyblocker.mixin.accessor.DrawContextInvoker;
+import me.xmrvizzy.skyblocker.skyblock.itemlist.ItemRegistry;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.tooltip.HoveredTooltipPositioner;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CompactorDeletorPreview {
+
+    private static final MinecraftClient mcClient = MinecraftClient.getInstance();
+    private static final Map<String, int[]> personalCompactorTypeToSlot = new HashMap<>();
+    // Lines, and slots per lines
+    static {
+        personalCompactorTypeToSlot.put("4000", new int[]{1,1});
+        personalCompactorTypeToSlot.put("5000", new int[]{1,3});
+        personalCompactorTypeToSlot.put("6000", new int[]{1,7});
+        personalCompactorTypeToSlot.put("7000", new int[]{2,6});
+        personalCompactorTypeToSlot.put("default", new int[]{1,6});
+    }
+
+    public static boolean displayCompactorDeletorPreview(DrawContextInvoker context, int x, int y, ItemStack stack) {
+        String internalName = ItemRegistry.getInternalName(stack);
+
+        String prefix;
+        String itemSlotPrefix;
+        if (internalName.contains("PERSONAL_COMPACTOR_")) {
+            prefix = "PERSONAL_COMPACTOR_";
+            itemSlotPrefix = "personal_compact_";
+        } else {
+            prefix = "PERSONAL_DELETOR_";
+            itemSlotPrefix = "personal_deletor_";
+        }
+
+        // Find the line to insert component
+        int targetIndex = -1;
+        int lineCount = 0;
+
+        List<Text> tooltips = Screen.getTooltipFromItem(mcClient, stack);
+        for (int i = 0; i < tooltips.size(); i++) {
+            if (tooltips.get(i).getString().isEmpty()) {
+                lineCount += 1;
+            }
+            if (lineCount == 2) {
+                targetIndex = i;
+                break;
+            }
+        }
+        if (targetIndex == -1) return false;
+        List<TooltipComponent> components = new java.util.ArrayList<>(tooltips.stream().map(Text::asOrderedText).map(TooltipComponent::of).toList());
+
+        // STUFF
+        String internalID = ItemRegistry.getInternalName(stack);
+        String compactorType = internalID.replaceFirst(prefix, "");
+        int[] dimensions = personalCompactorTypeToSlot.containsKey(compactorType) ? personalCompactorTypeToSlot.get(compactorType) : personalCompactorTypeToSlot.get("default");
+
+        NbtCompound nbt = stack.getNbt();
+        if (nbt == null || !nbt.contains("ExtraAttributes", 10)) {
+            return false;
+        }
+        NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
+        Set<String> attributesKeys = extraAttributes.getKeys();
+        List<String> compactorItems = attributesKeys.stream().filter(s -> s.contains(itemSlotPrefix)).toList();
+        Map<Integer, ItemStack> slotAndItem = new HashMap<>();
+
+        if (compactorItems.isEmpty()) {
+            int slotsCount = (dimensions[0] * dimensions[1]);
+            components.add(targetIndex, TooltipComponent.of(Text.literal(
+                            slotsCount + (slotsCount == 1 ? " slot": " slots"))
+                    .fillStyle(Style.EMPTY.withColor(Formatting.DARK_GRAY)).asOrderedText()));
+
+            context.invokeDrawTooltip(mcClient.textRenderer, components, x, y, HoveredTooltipPositioner.INSTANCE);
+            return true;
+        }
+
+        compactorItems.forEach(s -> slotAndItem.put(getNumberAtEnd(s, itemSlotPrefix), ItemRegistry.getItemStack(extraAttributes.getString(s))));
+
+
+        components.add(targetIndex, new CompactorPreviewTooltipComponent(slotAndItem, dimensions));
+        components.add(targetIndex, TooltipComponent.of(Text.literal(" ").append(
+                        Text.literal("Contents:").fillStyle(Style.EMPTY
+                                .withItalic(true)))
+                .asOrderedText()));
+        if (attributesKeys.stream().anyMatch(s -> s.contains("PERSONAL_DELETOR_ACTIVE"))) {
+            MutableText isActiveText = Text.literal("Active: ");
+            if (extraAttributes.getBoolean("PERSONAL_DELETOR_ACTIVE")) {
+                components.add(targetIndex, TooltipComponent.of(isActiveText.append(
+                                Text.literal("YES").fillStyle(Style.EMPTY.withBold(true).withColor(Formatting.GREEN))
+                        ).asOrderedText()
+                ));
+            } else {
+                components.add(targetIndex, TooltipComponent.of(isActiveText.append(
+                                Text.literal("NO").fillStyle(Style.EMPTY.withBold(true).withColor(Formatting.RED))
+                        ).asOrderedText()
+                ));
+            }
+        }
+        context.invokeDrawTooltip(mcClient.textRenderer, components, x, y, HoveredTooltipPositioner.INSTANCE);
+        return true;
+    }
+
+    private static Integer getNumberAtEnd(String str, String attributesKey) {
+        try {
+            String numberPartOfTheString = str.replace(attributesKey, "");
+            return Integer.parseInt(numberPartOfTheString);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CompactorPreviewTooltipComponent.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CompactorPreviewTooltipComponent.java
@@ -1,60 +1,54 @@
 package me.xmrvizzy.skyblocker.skyblock.item;
 
+import it.unimi.dsi.fastutil.ints.IntIntPair;
+import it.unimi.dsi.fastutil.ints.IntObjectPair;
 import me.xmrvizzy.skyblocker.SkyblockerMod;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 
-import java.util.Map;
-
 public class CompactorPreviewTooltipComponent implements TooltipComponent {
-
     private static final Identifier INVENTORY_TEXTURE = new Identifier(SkyblockerMod.NAMESPACE, "textures/gui/inventory_background.png");
+    private final Iterable<IntObjectPair<ItemStack>> items;
+    private final IntIntPair dimensions;
 
-    Map<Integer, ItemStack> items;
-    int[] dimensions;
-
-    public CompactorPreviewTooltipComponent(Map<Integer, ItemStack> items, int[] dimensions) {
+    public CompactorPreviewTooltipComponent(Iterable<IntObjectPair<ItemStack>> items, IntIntPair dimensions) {
         this.items = items;
         this.dimensions = dimensions;
     }
+
     @Override
     public int getHeight() {
-        return dimensions[0] * 18 + 14;
+        return dimensions.leftInt() * 18 + 14;
     }
 
     @Override
     public int getWidth(TextRenderer textRenderer) {
-        return dimensions[1] * 18 + 14;
+        return dimensions.rightInt() * 18 + 14;
     }
 
     @Override
     public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
-        context.drawTexture(INVENTORY_TEXTURE, x, y, 0, 0, 7 + dimensions[1] * 18, 7);
-        context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions[1] * 18, y, 169, 0, 7, 7);
+        context.drawTexture(INVENTORY_TEXTURE, x, y, 0, 0, 7 + dimensions.rightInt() * 18, 7);
+        context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions.rightInt() * 18, y, 169, 0, 7, 7);
 
-        for (int i = 0; i < dimensions[0]; i++) {
+        for (int i = 0; i < dimensions.leftInt(); i++) {
             context.drawTexture(INVENTORY_TEXTURE, x, y + 7 + i * 18, 0, 7, 7, 18);
-            for (int j = 0; j < dimensions[1]; j++) {
+            for (int j = 0; j < dimensions.rightInt(); j++) {
                 context.drawTexture(INVENTORY_TEXTURE, x + 7 + j * 18, y + 7 + i * 18, 7, 7, 18, 18);
             }
-            context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions[1] * 18, y + 7 + i * 18, 169, 7, 7, 18);
+            context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions.rightInt() * 18, y + 7 + i * 18, 169, 7, 7, 18);
         }
-        context.drawTexture(INVENTORY_TEXTURE, x, y + 7 + dimensions[0] * 18, 0, 25, 7 + dimensions[1] * 18, 7);
-        context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions[1] * 18, y + 7 + dimensions[0] * 18, 169, 25, 7, 7);
+        context.drawTexture(INVENTORY_TEXTURE, x, y + 7 + dimensions.leftInt() * 18, 0, 25, 7 + dimensions.rightInt() * 18, 7);
+        context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions.rightInt() * 18, y + 7 + dimensions.leftInt() * 18, 169, 25, 7, 7);
 
-        MatrixStack matrices = context.getMatrices();
-        for (Integer i : items.keySet()) {
-            int itemX = x + i % dimensions[1] * 18 + 8;
-            int itemY = y + i / dimensions[1] * 18 + 8;
-            matrices.push();
-            matrices.translate(0, 0, 200);
-            context.drawItem(items.get(i), itemX, itemY);
-            context.drawItemInSlot(textRenderer, items.get(i), itemX, itemY);
-            matrices.pop();
+        for (IntObjectPair<ItemStack> entry : items) {
+            int itemX = x + entry.leftInt() % dimensions.rightInt() * 18 + 8;
+            int itemY = y + entry.leftInt() / dimensions.rightInt() * 18 + 8;
+            context.drawItem(entry.right(), itemX, itemY);
+            context.drawItemInSlot(textRenderer, entry.right(), itemX, itemY);
         }
     }
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CompactorPreviewTooltipComponent.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/CompactorPreviewTooltipComponent.java
@@ -1,0 +1,60 @@
+package me.xmrvizzy.skyblocker.skyblock.item;
+
+import me.xmrvizzy.skyblocker.SkyblockerMod;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+
+import java.util.Map;
+
+public class CompactorPreviewTooltipComponent implements TooltipComponent {
+
+    private static final Identifier INVENTORY_TEXTURE = new Identifier(SkyblockerMod.NAMESPACE, "textures/gui/inventory_background.png");
+
+    Map<Integer, ItemStack> items;
+    int[] dimensions;
+
+    public CompactorPreviewTooltipComponent(Map<Integer, ItemStack> items, int[] dimensions) {
+        this.items = items;
+        this.dimensions = dimensions;
+    }
+    @Override
+    public int getHeight() {
+        return dimensions[0] * 18 + 14;
+    }
+
+    @Override
+    public int getWidth(TextRenderer textRenderer) {
+        return dimensions[1] * 18 + 14;
+    }
+
+    @Override
+    public void drawItems(TextRenderer textRenderer, int x, int y, DrawContext context) {
+        context.drawTexture(INVENTORY_TEXTURE, x, y, 0, 0, 7 + dimensions[1] * 18, 7);
+        context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions[1] * 18, y, 169, 0, 7, 7);
+
+        for (int i = 0; i < dimensions[0]; i++) {
+            context.drawTexture(INVENTORY_TEXTURE, x, y + 7 + i * 18, 0, 7, 7, 18);
+            for (int j = 0; j < dimensions[1]; j++) {
+                context.drawTexture(INVENTORY_TEXTURE, x + 7 + j * 18, y + 7 + i * 18, 7, 7, 18, 18);
+            }
+            context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions[1] * 18, y + 7 + i * 18, 169, 7, 7, 18);
+        }
+        context.drawTexture(INVENTORY_TEXTURE, x, y + 7 + dimensions[0] * 18, 0, 25, 7 + dimensions[1] * 18, 7);
+        context.drawTexture(INVENTORY_TEXTURE, x + 7 + dimensions[1] * 18, y + 7 + dimensions[0] * 18, 169, 25, 7, 7);
+
+        MatrixStack matrices = context.getMatrices();
+        for (Integer i : items.keySet()) {
+            int itemX = x + i % dimensions[1] * 18 + 8;
+            int itemY = y + i / dimensions[1] * 18 + 8;
+            matrices.push();
+            matrices.translate(0, 0, 200);
+            context.drawItem(items.get(i), itemX, itemY);
+            context.drawItemInSlot(textRenderer, items.get(i), itemX, itemY);
+            matrices.pop();
+        }
+    }
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/itemlist/ItemRegistry.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/itemlist/ItemRegistry.java
@@ -124,5 +124,9 @@ public class ItemRegistry {
         if (itemStack.getNbt() == null) return "";
         return itemStack.getNbt().getCompound("ExtraAttributes").getString("id");
     }
+
+    public static ItemStack getItemStack(String internalName) {
+        return itemsMap.get(internalName);
+    }
 }
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -42,6 +42,7 @@
   "text.autoconfig.skyblocker.option.general.quiverWarning.enableQuiverWarningInDungeons": "Enable Quiver Warning In Dungeons",
   "text.autoconfig.skyblocker.option.general.quiverWarning.enableQuiverWarningAfterDungeon": "Enable Quiver Warning After a Dungeon",
   "text.autoconfig.skyblocker.option.general.backpackPreviewWithoutShift": "View backpack preview without holding Shift",
+  "text.autoconfig.skyblocker.option.general.compactorDeletorPreview": "Enable Compactor/Deletor Preview",
   "text.autoconfig.skyblocker.option.general.tabHud": "Fancy tab HUD",
   "text.autoconfig.skyblocker.option.general.tabHud.tabHudEnabled": "Enable fancy tab HUD",
   "text.autoconfig.skyblocker.option.general.tabHud.tabHudScale": "Scale factor of fancy tab HUD",

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -29,7 +29,8 @@
     "accessor.PlayerListHudAccessor",
     "accessor.RecipeBookWidgetAccessor",
     "accessor.ScreenAccessor",
-    "accessor.WorldRendererAccessor"
+    "accessor.WorldRendererAccessor",
+    "accessor.DrawContextInvoker"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
As the name implies, this adds a nice little preview of the contents of a Personal Compactor/Deletor when hovering it. Pretty cool right?

## Images

<img src="https://cdn.discordapp.com/attachments/879732108745125972/1151581544624959518/image.png" width="50%" />
<img src="https://media.discordapp.net/attachments/879732108745125972/1151600041211998318/image.png" width="60%" />
<img src="https://cdn.discordapp.com/attachments/879732108745125972/1151600040419282995/image.png" width="50%" />
If there are no items, only the slot count is showed (mainly used for AH):
<img src="https://cdn.discordapp.com/attachments/879732108745125972/1151607381013319720/image.png" width="50%" />

To make this go brrrr, i made a new class, mixin and an invoker.