### PR TITLE
Optimize Base64 Replacer

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilServicesKeyInfoMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilServicesKeyInfoMixin.java
@@ -47,7 +47,7 @@ public class YggdrasilServicesKeyInfoMixin {
                         LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode the base64 string No.{} again", ERRONEUS_SIGNATURE_HASHES.indexOf(signatureHashCode));
                     }
                 }
-        	}
+            }
             throw e;
         }
     }

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilServicesKeyInfoMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilServicesKeyInfoMixin.java
@@ -3,6 +3,9 @@ package me.xmrvizzy.skyblocker.mixin;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.authlib.yggdrasil.YggdrasilServicesKeyInfo;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import me.xmrvizzy.skyblocker.utils.Utils;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
@@ -11,9 +14,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
 import java.util.Map;
 
 @Mixin(value = YggdrasilServicesKeyInfo.class, remap = false)
@@ -22,27 +23,31 @@ public class YggdrasilServicesKeyInfoMixin {
     @Final
     private static Logger LOGGER;
     @Unique
-    private static final Map<String, String> REPLACEMENT_HASHMAP = Map.of();
+    private static final Map<String, String> REPLACEMENT_MAP = Map.of();
     @Unique
-    private static final List<Integer> ERROR_HASH_ARRAYLIST = new ArrayList<>();
+    private static final IntList ERRONEUS_SIGNATURE_HASHES = new IntArrayList();
 
     @WrapOperation(method = "validateProperty", at = @At(value = "INVOKE", target = "Ljava/util/Base64$Decoder;decode(Ljava/lang/String;)[B", remap = false), remap = false)
     private byte[] skyblocker$replaceKnownWrongBase64(Base64.Decoder decoder, String signature, Operation<byte[]> decode) {
         try {
-            return decode.call(decoder, signature.replaceAll("[^A-Za-z0-9+/=]", ""));
+            return decode.call(decoder, signature);
         } catch (IllegalArgumentException e) {
-            if (Utils.isOnSkyblock()) {
-                if (REPLACEMENT_HASHMAP.containsKey(signature)) {
-                    return decode.call(decoder, REPLACEMENT_HASHMAP.get(signature));
+            try {
+                return decode.call(decoder, signature.replaceAll("[^A-Za-z0-9+/=]", ""));
+            } catch (IllegalArgumentException e2) {
+                if (Utils.isOnSkyblock()) {
+                    if (REPLACEMENT_MAP.containsKey(signature)) {
+                        return decode.call(decoder, REPLACEMENT_MAP.get(signature));
+                    }
+                    int signatureHashCode = signature.hashCode();
+                    if (!ERRONEUS_SIGNATURE_HASHES.contains(signatureHashCode)) {
+                    	ERRONEUS_SIGNATURE_HASHES.add(signatureHashCode);
+                        LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode base64 string No.{}: {}", ERRONEUS_SIGNATURE_HASHES.size() - 1, signature);
+                    } else {
+                        LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode the base64 string No.{} again", ERRONEUS_SIGNATURE_HASHES.indexOf(signatureHashCode));
+                    }
                 }
-                int signatureHashCode = signature.hashCode();
-                if (!ERROR_HASH_ARRAYLIST.contains(signatureHashCode)) {
-                    ERROR_HASH_ARRAYLIST.add(signatureHashCode);
-                    LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode base64 string No.{}: {}", ERROR_HASH_ARRAYLIST.size() - 1, signature);
-                } else {
-                    LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode the base64 string No.{} again", ERROR_HASH_ARRAYLIST.indexOf(signatureHashCode));
-                }
-            }
+        	}
             throw e;
         }
     }


### PR DESCRIPTION
Simply changes it so that it attempts to decode it regularly first, then if there is an error it'll take the path of replacing invalid base64 characters. This helps avoid unnecessary regex operations (and allocations) on strings when they aren't needed (since most skins won't contain invalid signatures)