### PR TITLE
Hide fake players in social interactions screen

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/SocialInteractionsPlayerListWidgetMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/SocialInteractionsPlayerListWidgetMixin.java
@@ -1,0 +1,24 @@
+package me.xmrvizzy.skyblocker.mixin;
+
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import me.xmrvizzy.skyblocker.utils.Utils;
+import net.minecraft.client.gui.screen.multiplayer.SocialInteractionsPlayerListEntry;
+import net.minecraft.client.gui.screen.multiplayer.SocialInteractionsPlayerListWidget;
+
+@Mixin(SocialInteractionsPlayerListWidget.class)
+public class SocialInteractionsPlayerListWidgetMixin {
+
+	@WrapOperation(method = "setPlayers", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
+	private Object skyblocker$hideInvalidPlayers(Map<Object, Object> map, Object uuid, Object entry, Operation<Object> operation) {
+		if (Utils.isOnSkyblock() && !((SocialInteractionsPlayerListEntry) entry).getName().matches("[A-Za-z0-9_]+")) return null;
+		
+		return operation.call(map, uuid, entry);
+	}
+}

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -22,6 +22,7 @@
     "PlayerListHudMixin",
     "PlayerSkinProviderMixin",
     "ScoreboardMixin",
+    "SocialInteractionsPlayerListWidgetMixin",
     "WorldRendererMixin",
     "YggdrasilServicesKeyInfoMixin",
     "accessor.BeaconBlockEntityRendererInvoker",


### PR DESCRIPTION
Hides all entries in the social interactions screen belonging to known fake players. Doesn't catch everything but it does catch all the dummy entries from the tab list (ones starting with an exclamation mark)

This'll be helpful since in 1.20.2 Mojang is adding the ability to report bad usernames and skins, and this menu being filled with a bunch of garbage entries hinders the ability to use it effectively.