### PR TITLE
Locraw filter fix

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
@@ -323,7 +323,11 @@ public class Utils {
                 if (locRaw.has("map")) {
                     map = locRaw.get("map").getAsString();
                 }
-                return !sentLocRaw;
+                
+                boolean shouldFilter = !sentLocRaw;
+                sentLocRaw = false;
+                
+                return shouldFilter;
             }
         }
         return true;

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
@@ -49,7 +49,7 @@ public class Utils {
     private static String map = "";
     private static long clientWorldJoinTime = 0;
     private static boolean sentLocRaw = false;
-    private static long lastLocRaw = 0;
+    private static boolean canSendLocRaw = false;
 
     public static boolean isOnHypixel() {
         return isOnHypixel;
@@ -293,10 +293,10 @@ public class Utils {
     private static void updateLocRaw() {
         if (isOnSkyblock) {
             long currentTime = System.currentTimeMillis();
-            if (!sentLocRaw && currentTime > clientWorldJoinTime + 1000 && currentTime > lastLocRaw + 15000) {
+            if (!sentLocRaw && canSendLocRaw && currentTime > clientWorldJoinTime + 1000) {
                 MessageScheduler.INSTANCE.sendMessageAfterCooldown("/locraw");
                 sentLocRaw = true;
-                lastLocRaw = currentTime;
+                canSendLocRaw = false;
             }
         } else {
             resetLocRawInfo();
@@ -335,6 +335,7 @@ public class Utils {
 
     private static void resetLocRawInfo() {
         sentLocRaw = false;
+        canSendLocRaw = true;
         server = "";
         gameType = "";
         locationRaw = "";


### PR DESCRIPTION
Previously due to an oversight the mod filtered out all locraw messages even the ones not triggered by the mod

Also made it so that the mod only updates the locraw info after the player switches worlds since it doesn't need to be every 15 seconds (although because of the oversight the mod only ever sent it after the player joined the world so nothing really changed here)