### PR TITLE
Use standardised license identifier

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     "sources": "https://github.com/SkyblockerMod/Skyblocker",
     "issues": "https://github.com/SkyblockerMod/Skyblocker/issues"
   },
-  "license": "LGPL-3.0-only",
+  "license": "LGPL-3.0-or-later",
   "icon": "assets/skyblocker/icon.png",
   "environment": "client",
   "entrypoints": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     "sources": "https://github.com/SkyblockerMod/Skyblocker",
     "issues": "https://github.com/SkyblockerMod/Skyblocker/issues"
   },
-  "license": "GNU LGPLv3",
+  "license": "LGPL-3.0-only",
   "icon": "assets/skyblocker/icon.png",
   "environment": "client",
   "entrypoints": {


### PR DESCRIPTION
The fabric.mod.json spec recommends the use of [SPDX License Identifiers](https://spdx.org/licenses/).