### PR TITLE
1.20.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ dependencies {
 	modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
 
 	// EMI
-	modCompileOnly "dev.emi:emi-fabric:${project.emi_version}+${project.minecraft_version}:api"
-	modLocalRuntime "dev.emi:emi-fabric:${project.emi_version}+${project.minecraft_version}"
+	modCompileOnly "dev.emi:emi-fabric:${project.emi_version}:api"
+	modLocalRuntime "dev.emi:emi-fabric:${project.emi_version}"
 
 	// Renderer (https://github.com/0x3C50/Renderer)
 	include modImplementation("com.github.0x3C50:Renderer:${project.renderer_version}") {

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,10 @@ dependencies {
 	// include implementation("moe.nea:neurepoparser:${project.repoparser_version}")
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/skyblocker.accesswidener")
+}
+
 base {
 	archivesName = project.archives_base_name
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.parallel=true
 
 # Fabric Properties (https://fabricmc.net/versions.html)
 ## 1.20
-minecraft_version=1.20.2-rc1
-yarn_mappings=1.20.2-rc1+build.2
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.1
 loader_version=0.14.22
 
 #Fabric api
 ## 1.20
-fabric_api_version=0.88.5+1.20.2
+fabric_api_version=0.89.1+1.20.2
 
 ## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)
-clothconfig_version=12.0.107
+clothconfig_version=12.0.108
 ## Mod Menu (https://www.curseforge.com/minecraft/mc-mods/modmenu/files)
 mod_menu_version=8.0.0-beta.2
 ## REI (https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,18 @@ org.gradle.parallel=true
 
 # Fabric Properties (https://fabricmc.net/versions.html)
 ## 1.20
-minecraft_version=1.20.2-pre1
-yarn_mappings=1.20.2-pre1+build.3
+minecraft_version=1.20.2-rc1
+yarn_mappings=1.20.2-rc1+build.2
 loader_version=0.14.22
 
 #Fabric api
 ## 1.20
-fabric_api_version=0.88.2+1.20.2
+fabric_api_version=0.88.5+1.20.2
 
 ## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)
 clothconfig_version=12.0.107
 ## Mod Menu (https://www.curseforge.com/minecraft/mc-mods/modmenu/files)
-mod_menu_version=7.0.1
+mod_menu_version=8.0.0-beta.2
 ## REI (https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files)
 rei_version=12.0.625
 ## EMI (https://modrinth.com/mod/emi/versions)

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,11 +11,11 @@ loader_version=0.14.22
 ## 1.20
 fabric_api_version=0.89.1+1.20.2
 
-## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)
+## Cloth Api (https://modrinth.com/mod/cloth-config/versions)
 clothconfig_version=12.0.108
-## Mod Menu (https://www.curseforge.com/minecraft/mc-mods/modmenu/files)
+## Mod Menu (https://modrinth.com/mod/modmenu/versions)
 mod_menu_version=8.0.0-beta.2
-## REI (https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files)
+## REI (https://modrinth.com/mod/rei/versions?l=fabric)
 rei_version=12.0.625
 ## EMI (https://modrinth.com/mod/emi/versions)
 emi_version = 1.0.19+1.20.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,23 +3,22 @@ org.gradle.parallel=true
 
 # Fabric Properties (https://fabricmc.net/versions.html)
 ## 1.20
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.21
+minecraft_version=1.20.2-pre1
+yarn_mappings=1.20.2-pre1+build.3
+loader_version=0.14.22
 
 #Fabric api
 ## 1.20
-fabric_api_version=0.86.0+1.20.1
+fabric_api_version=0.88.2+1.20.2
 
-# Dependencies
-## Cloth Api (https://modrinth.com/mod/cloth-config/versions)
-clothconfig_version=11.1.106
-## Mod Menu (https://modrinth.com/mod/modmenu/versions)
+## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)
+clothconfig_version=12.0.107
+## Mod Menu (https://www.curseforge.com/minecraft/mc-mods/modmenu/files)
 mod_menu_version=7.0.1
 ## REI (https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files)
 rei_version=12.0.625
 ## EMI (https://modrinth.com/mod/emi/versions)
-emi_version = 1.0.19
+emi_version = 1.0.19+1.20.1
 ## Renderer (https://github.com/0x3C50/Renderer)
 renderer_version = master-SNAPSHOT
 

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ClientPlayNetworkHandlerMixin.java
@@ -12,26 +12,22 @@ import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
 import org.slf4j.Logger;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(ClientPlayNetworkHandler.class)
 public abstract class ClientPlayNetworkHandlerMixin {
-    @Shadow
-    @Final
-    private MinecraftClient client;
 
     @Inject(method = "onPlaySound", at = @At("RETURN"))
     private void skyblocker$onPlaySound(PlaySoundS2CPacket packet) {
         FishingHelper.onSound(packet);
     }
 
-    @ModifyVariable(method = "onItemPickupAnimation", at = @At(value = "STORE", ordinal = 0))
+    @SuppressWarnings("resource")
+	@ModifyVariable(method = "onItemPickupAnimation", at = @At(value = "STORE", ordinal = 0))
     private ItemEntity skyblocker$onItemPickup(ItemEntity itemEntity, @Local LivingEntity collector) {
-        DungeonSecrets.onItemPickup(itemEntity, collector, collector == client.player);
+        DungeonSecrets.onItemPickup(itemEntity, collector, collector == MinecraftClient.getInstance().player);
         return itemEntity;
     }
 

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/PlayerSkinProviderMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/PlayerSkinProviderMixin.java
@@ -1,20 +1,29 @@
 package me.xmrvizzy.skyblocker.mixin;
 
-import me.xmrvizzy.skyblocker.utils.Utils;
-import net.minecraft.client.texture.PlayerSkinProvider;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
-@Mixin(PlayerSkinProvider.class)
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+
+import me.xmrvizzy.skyblocker.utils.Utils;
+import net.minecraft.client.texture.PlayerSkinProvider.Textures;
+
+@Mixin(targets = "net.minecraft.client.texture.PlayerSkinProvider$1")
 public class PlayerSkinProviderMixin {
-    /*@ModifyVariable(method = "loadSkin(Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/texture/PlayerSkinProvider$SkinTextureAvailableCallback;Z)V", at = @At("STORE"))
-    private Runnable skyblocker$removeInvalidBase64LogSpam(Runnable runnable) {
-        return Utils.isOnHypixel() ? () -> {
-            try {
-                runnable.run();
-            } catch (IllegalArgumentException ignored) {
-            }
-        } : runnable;
-    }*/
+
+	@ModifyReturnValue(method = "method_52867", at = @At("RETURN"))
+	private static Textures skyblocker$fixTexturesThatHadAnInvalidSignature(Textures texture, @Local MinecraftSessionService sessionService, @Local GameProfile profile) {
+		if (Utils.isOnHypixel() && texture == Textures.MISSING) {
+			try {
+				return Textures.fromMap(sessionService.getTextures(profile, false), false);
+			} catch (Throwable t) {
+				return Textures.MISSING;
+			}
+		}
+
+		return texture;
+	}
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/PlayerSkinProviderMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/PlayerSkinProviderMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(PlayerSkinProvider.class)
 public class PlayerSkinProviderMixin {
-    @ModifyVariable(method = "loadSkin(Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/texture/PlayerSkinProvider$SkinTextureAvailableCallback;Z)V", at = @At("STORE"))
+    /*@ModifyVariable(method = "loadSkin(Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/texture/PlayerSkinProvider$SkinTextureAvailableCallback;Z)V", at = @At("STORE"))
     private Runnable skyblocker$removeInvalidBase64LogSpam(Runnable runnable) {
         return Utils.isOnHypixel() ? () -> {
             try {
@@ -16,5 +16,5 @@ public class PlayerSkinProviderMixin {
             } catch (IllegalArgumentException ignored) {
             }
         } : runnable;
-    }
+    }*/
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilMinecraftSessionServiceMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilMinecraftSessionServiceMixin.java
@@ -1,0 +1,20 @@
+package me.xmrvizzy.skyblocker.mixin;
+
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService;
+
+import me.xmrvizzy.skyblocker.utils.Utils;
+
+@Mixin(value = YggdrasilMinecraftSessionService.class, remap = false)
+public class YggdrasilMinecraftSessionServiceMixin {
+
+	@WrapOperation(method = "getSecurePropertyValue", remap = false, at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;)V", remap = false))
+	private void skyblocker$dontLogMissingSignaturesOrTamperedProperties(Logger logger, String message, Object property, Operation<Void> operation) {
+		if (!Utils.isOnHypixel()) operation.call(logger, message, property);
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilServicesKeyInfoMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/YggdrasilServicesKeyInfoMixin.java
@@ -51,4 +51,9 @@ public class YggdrasilServicesKeyInfoMixin {
             throw e;
         }
     }
+    
+    @WrapOperation(method = "validateProperty", remap = false, at = @At(value = "INVOKE", target = "org/slf4j/Logger.error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false))
+    private void skyblocker$dontLogFailedSignatureValidation(Logger logger, String message, Object property, Object exception, Operation<Void> operation) {
+        if (!Utils.isOnHypixel()) operation.call(logger, message, property, exception);
+    }
 }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/DungeonMapConfigScreen.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/DungeonMapConfigScreen.java
@@ -21,7 +21,7 @@ public class DungeonMapConfigScreen extends Screen {
 	@Override
 	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
 		super.render(context, mouseX, mouseY, delta);
-		renderBackground(context);
+		renderBackground(context, mouseX, mouseY, delta);
 		DungeonMap.renderHUDMap(context, hudX, hudY);
 		context.drawCenteredTextWithShadow(textRenderer, "Right Click To Reset Position", width >> 1, height >> 1, Color.GRAY.getRGB());
 	}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/OldLever.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/OldLever.java
@@ -2,7 +2,7 @@ package me.xmrvizzy.skyblocker.skyblock.dungeon;
 
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import net.minecraft.block.Block;
-import net.minecraft.block.enums.WallMountLocation;
+import net.minecraft.block.enums.BlockFace;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
 
@@ -13,13 +13,13 @@ public class OldLever {
     protected static final VoxelShape EAST_SHAPE = Block.createCuboidShape(0.0D, 3.0D, 5.0D, 6.0D, 13.0D, 11.0D);
     protected static final VoxelShape WEST_SHAPE = Block.createCuboidShape(10.0D, 3.0D, 5.0D, 16.0D, 13.0D, 11.0D);
 
-    public static VoxelShape getShape(WallMountLocation wallMountLocation, Direction direction) {
+    public static VoxelShape getShape(BlockFace face, Direction direction) {
         if (!SkyblockerConfig.get().general.hitbox.oldLeverHitbox)
             return null;
 
-        if (wallMountLocation == WallMountLocation.FLOOR) {
+        if (face == BlockFace.FLOOR) {
             return FLOOR_SHAPE;
-        } else if (wallMountLocation == WallMountLocation.WALL) {
+        } else if (face == BlockFace.WALL) {
             switch (direction) {
                 case EAST -> {
                     return EAST_SHAPE;

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/secrets/DungeonMapUtils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dungeon/secrets/DungeonMapUtils.java
@@ -44,8 +44,8 @@ public class DungeonMapUtils {
     @Nullable
     private static Vector2i getMapPlayerPos(MapState map) {
         for (MapIcon icon : map.getIcons()) {
-            if (icon.getType() == MapIcon.Type.FRAME) {
-                return new Vector2i((icon.getX() >> 1) + 64, (icon.getZ() >> 1) + 64);
+            if (icon.type() == MapIcon.Type.FRAME) {
+                return new Vector2i((icon.x() >> 1) + 64, (icon.z() >> 1) + 64);
             }
         }
         return null;

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/dwarven/DwarvenHudConfigScreen.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/dwarven/DwarvenHudConfigScreen.java
@@ -27,7 +27,7 @@ public class DwarvenHudConfigScreen extends Screen {
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         super.render(context, mouseX, mouseY, delta);
-        renderBackground(context);
+        renderBackground(context, mouseX, mouseY, delta);
         DwarvenHud.render(HudCommsWidget.INSTANCE_CFG, context, hudX, hudY, List.of(new DwarvenHud.Commission("Test Commission 1", "1%"), new DwarvenHud.Commission("Test Commission 2", "2%")));
         context.drawCenteredTextWithShadow(textRenderer, "Right Click To Reset Position", width / 2, height / 2, Color.GRAY.getRGB());
     }

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/BackpackPreview.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/BackpackPreview.java
@@ -53,7 +53,7 @@ public class BackpackPreview {
             // save all dirty storages
             saveStorage();
             // update save dir based on uuid and sb profile
-            String uuid = MinecraftClient.getInstance().getSession().getUuid().replaceAll("-", "");
+            String uuid = MinecraftClient.getInstance().getSession().getUuidOrNull().toString().replaceAll("-", "");
             String profile = Utils.getProfile();
             if (profile != null && !profile.isEmpty()) {
                 save_dir = FabricLoader.getInstance().getConfigDir().resolve("skyblocker/backpack-preview/" + uuid + "/" + profile);

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/itemlist/SearchResultsWidget.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/itemlist/SearchResultsWidget.java
@@ -5,6 +5,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.screen.ButtonTextures;
 import net.minecraft.client.gui.widget.ToggleButtonWidget;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
@@ -20,7 +21,8 @@ import java.util.regex.Pattern;
 import org.jetbrains.annotations.Nullable;
 
 public class SearchResultsWidget implements Drawable {
-    private static final Identifier TEXTURE = new Identifier("textures/gui/recipe_book.png");
+    private static final ButtonTextures PAGE_FORWARD_TEXTURES = new ButtonTextures(new Identifier("recipe_book/page_forward"), new Identifier("recipe_book/page_forward_highlighted"));
+    private static final ButtonTextures PAGE_BACKWARD_TEXTURES = new ButtonTextures(new Identifier("recipe_book/page_backward"), new Identifier("recipe_book/page_backward_highlighted"));
     private static final int COLS = 5;
     private static final int MAX_TEXT_WIDTH = 124;
     private static final String ELLIPSIS = "...";
@@ -54,9 +56,9 @@ public class SearchResultsWidget implements Drawable {
                 resultButtons.add(new ResultButtonWidget(x, y));
             }
         this.nextPageButton = new ToggleButtonWidget(parentX + 93, parentY + 137, 12, 17, false);
-        this.nextPageButton.setTextureUV(1, 208, 13, 18, TEXTURE);
+        this.nextPageButton.setTextures(PAGE_FORWARD_TEXTURES);
         this.prevPageButton = new ToggleButtonWidget(parentX + 38, parentY + 137, 12, 17, true);
-        this.prevPageButton.setTextureUV(1, 208, 13, 18, TEXTURE);
+        this.prevPageButton.setTextures(PAGE_BACKWARD_TEXTURES);
     }
 
     public void closeRecipeView() {

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/rift/EffigyWaypoints.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/rift/EffigyWaypoints.java
@@ -7,6 +7,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ScoreboardDisplaySlot;
 import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.scoreboard.ScoreboardPlayerScore;
 import net.minecraft.scoreboard.Team;
@@ -40,7 +41,7 @@ public class EffigyWaypoints {
             ClientPlayerEntity player = MinecraftClient.getInstance().player;
             if (player == null) return;
             Scoreboard scoreboard = player.getScoreboard();
-            ScoreboardObjective objective = scoreboard.getObjectiveForSlot(1);
+            ScoreboardObjective objective = scoreboard.getObjectiveForSlot(ScoreboardDisplaySlot.FROM_ID.apply(1));
             for (ScoreboardPlayerScore score : scoreboard.getAllPlayerScores(objective)) {
                 Team team = scoreboard.getPlayerTeam(score.getPlayerName());
                 if (team != null) {

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/component/PlayerComponent.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/tabhud/widget/component/PlayerComponent.java
@@ -24,7 +24,7 @@ public class PlayerComponent extends Component {
         Team team = ple.getScoreboardTeam();
         String username = ple.getProfile().getName();
         name = (team != null && !plainNames) ? Text.empty().append(team.getPrefix()).append(Text.literal(username).formatted(team.getColor())).append(team.getSuffix()) : Text.of(username);
-        tex = ple.getSkinTexture();
+        tex = ple.getSkinTextures().texture();
 
         this.width = SKIN_ICO_DIM + PAD_S + txtRend.getWidth(name);
         this.height = txtRend.fontHeight;

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Boxes.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Boxes.java
@@ -17,7 +17,7 @@ public class Boxes {
 
     /** Returns the vector of the side lengths of this box. **/
     public static Vec3d getLengthVec(Box box) {
-        return new Vec3d(box.getXLength(), box.getYLength(), box.getZLength());
+        return new Vec3d(box.getLengthX(), box.getLengthY(), box.getLengthZ());
     }
 
     /** Offsets this box so that minX, minY and minZ are all zero. **/

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/SlayerUtils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/SlayerUtils.java
@@ -5,6 +5,7 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ScoreboardDisplaySlot;
 import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.scoreboard.ScoreboardPlayerScore;
 import net.minecraft.scoreboard.Team;
@@ -48,7 +49,7 @@ public class SlayerUtils {
             ClientPlayerEntity client = MinecraftClient.getInstance().player;
             if (client == null) return false;
             Scoreboard scoreboard = MinecraftClient.getInstance().player.getScoreboard();
-            ScoreboardObjective objective = scoreboard.getObjectiveForSlot(1);
+            ScoreboardObjective objective = scoreboard.getObjectiveForSlot(ScoreboardDisplaySlot.FROM_ID.apply(1));
             for (ScoreboardPlayerScore score : scoreboard.getAllPlayerScores(objective)) {
                 Team team = scoreboard.getPlayerTeam(score.getPlayerName());
                 if (team != null) {

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
@@ -167,10 +167,10 @@ public class Utils {
     }
 
     private static boolean isConnectedToHypixel(MinecraftClient client) {
-    	String serverAddress = (client.getCurrentServerEntry() != null) ? client.getCurrentServerEntry().address.toLowerCase() : "";
-    	String serverBrand = (client.player != null && client.player.networkHandler != null && client.player.networkHandler.getBrand() != null) ? client.player.networkHandler.getBrand() : "";
-    	
-    	return serverAddress.equalsIgnoreCase(ALTERNATE_HYPIXEL_ADDRESS) || serverAddress.contains("hypixel.net") || serverAddress.contains("hypixel.io") || serverBrand.contains("Hypixel BungeeCord");
+        String serverAddress = (client.getCurrentServerEntry() != null) ? client.getCurrentServerEntry().address.toLowerCase() : "";
+        String serverBrand = (client.player != null && client.player.networkHandler != null && client.player.networkHandler.getBrand() != null) ? client.player.networkHandler.getBrand() : "";
+
+        return serverAddress.equalsIgnoreCase(ALTERNATE_HYPIXEL_ADDRESS) || serverAddress.contains("hypixel.net") || serverAddress.contains("hypixel.io") || serverBrand.contains("Hypixel BungeeCord");
     }
 
     private static void leaveSkyblock() {
@@ -324,10 +324,10 @@ public class Utils {
                 if (locRaw.has("map")) {
                     map = locRaw.get("map").getAsString();
                 }
-                
+
                 boolean shouldFilter = !sentLocRaw;
                 sentLocRaw = false;
-                
+
                 return shouldFilter;
             }
         }

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/Utils.java
@@ -15,6 +15,7 @@ import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ScoreboardDisplaySlot;
 import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.scoreboard.ScoreboardPlayerScore;
 import net.minecraft.scoreboard.Team;
@@ -166,10 +167,10 @@ public class Utils {
     }
 
     private static boolean isConnectedToHypixel(MinecraftClient client) {
-        String serverAddress = (client.getCurrentServerEntry() != null) ? client.getCurrentServerEntry().address.toLowerCase() : "";
-        String serverBrand = (client.player != null && client.player.getServerBrand() != null) ? client.player.getServerBrand() : "";
-
-        return serverAddress.equalsIgnoreCase(ALTERNATE_HYPIXEL_ADDRESS) || serverAddress.contains("hypixel.net") || serverAddress.contains("hypixel.io") || serverBrand.contains("Hypixel BungeeCord");
+    	String serverAddress = (client.getCurrentServerEntry() != null) ? client.getCurrentServerEntry().address.toLowerCase() : "";
+    	String serverBrand = (client.player != null && client.player.networkHandler != null && client.player.networkHandler.getBrand() != null) ? client.player.networkHandler.getBrand() : "";
+    	
+    	return serverAddress.equalsIgnoreCase(ALTERNATE_HYPIXEL_ADDRESS) || serverAddress.contains("hypixel.net") || serverAddress.contains("hypixel.io") || serverBrand.contains("Hypixel BungeeCord");
     }
 
     private static void leaveSkyblock() {
@@ -244,7 +245,7 @@ public class Utils {
             ClientPlayerEntity client = MinecraftClient.getInstance().player;
             if (client == null) return Collections.emptyList();
             Scoreboard scoreboard = MinecraftClient.getInstance().player.getScoreboard();
-            ScoreboardObjective objective = scoreboard.getObjectiveForSlot(1);
+            ScoreboardObjective objective = scoreboard.getObjectiveForSlot(ScoreboardDisplaySlot.FROM_ID.apply(1));
             List<String> lines = new ArrayList<>();
             for (ScoreboardPlayerScore score : scoreboard.getAllPlayerScores(objective)) {
                 Team team = scoreboard.getPlayerTeam(score.getPlayerName());

--- a/src/main/java/me/xmrvizzy/skyblocker/utils/render/title/TitleContainerConfigScreen.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/utils/render/title/TitleContainerConfigScreen.java
@@ -28,7 +28,7 @@ public class TitleContainerConfigScreen extends Screen {
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         super.render(context, mouseX, mouseY, delta);
-        renderBackground(context);
+        renderBackground(context, mouseX, mouseY, delta);
         TitleContainer.render(context, Set.of(example1, example2, example3), (int) hudX, (int) hudY, delta);
         SkyblockerConfig.Direction direction = SkyblockerConfig.get().general.titleContainer.direction;
         SkyblockerConfig.Alignment alignment = SkyblockerConfig.get().general.titleContainer.alignment;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,8 +35,8 @@
     "skyblocker.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.21",
-    "fabric-api": ">=0.86.0",
+    "fabricloader": ">=0.14.22",
+    "fabric-api": ">=0.88.2+1.20.2",
     "cloth-config2": "*",
     "minecraft": "~1.20"
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,11 +34,12 @@
   "mixins": [
     "skyblocker.mixins.json"
   ],
+  "accesswidener": "skyblocker.accesswidener",
   "depends": {
     "fabricloader": ">=0.14.22",
-    "fabric-api": ">=0.88.5+1.20.2",
+    "fabric-api": ">=0.89.1+1.20.2",
     "cloth-config2": "*",
-    "minecraft": "~1.20"
+    "minecraft": "~1.20.2"
   },
   "conflicts": {
     "immediatelyfast": "<=1.1.26+1.20.1"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.14.22",
-    "fabric-api": ">=0.88.2+1.20.2",
+    "fabric-api": ">=0.88.5+1.20.2",
     "cloth-config2": "*",
     "minecraft": "~1.20"
   },

--- a/src/main/resources/skyblocker.accesswidener
+++ b/src/main/resources/skyblocker.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v2 named
+
+accessible class net/minecraft/client/texture/PlayerSkinProvider$Textures

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -24,6 +24,7 @@
     "ScoreboardMixin",
     "SocialInteractionsPlayerListWidgetMixin",
     "WorldRendererMixin",
+    "YggdrasilMinecraftSessionServiceMixin",
     "YggdrasilServicesKeyInfoMixin",
     "accessor.BeaconBlockEntityRendererInvoker",
     "accessor.FrustumInvoker",


### PR DESCRIPTION
- Ports the mod to 1.20.2 and introduces some new patches relating to it
- All of the stuff that changed has been tested and is fully working

## Patches
As of 1.20.2 Mojang made changes to how loading player skin textures work (all texture payloads **MUST** have a signature) so I've added some patches to restore 1.20.1 functionality when on Hypixel:

- Suppress log spam from 2 new sources relating to player skin textures having bad signatures 
- Fixes skin textures appearing as missing when Hypixel sends an invalid signature
  - Note: The Mixin catches all throwables which matches vanilla behaviour (Also, trying to implement it with an `@Redirect` or `@WrapOperation` caused Mixin itself to throw an NPE lmfao)