### PR TITLE
Item Protection

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/SkyblockerMod.java
@@ -100,6 +100,7 @@ public class SkyblockerMod implements ClientModInitializer {
         TicTacToe.init();
         QuiverWarning.init();
         SpecialEffects.init();
+        ItemProtection.init();
         containerSolverManager.init();
         statusBarTracker.init();
         Scheduler.INSTANCE.scheduleCyclic(Utils::update, 20);

--- a/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/config/SkyblockerConfig.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import me.xmrvizzy.skyblocker.skyblock.item.CustomArmorTrims;
 import me.xmrvizzy.skyblocker.utils.chat.ChatFilterResult;
 import net.minecraft.client.resource.language.I18n;
@@ -206,6 +207,9 @@ public class SkyblockerConfig {
 
 		@SerialEntry
 		public List<Integer> lockedSlots = new ArrayList<>();
+		
+		@SerialEntry
+		public ObjectOpenHashSet<String> protectedItems = new ObjectOpenHashSet<>();
 
 		@SerialEntry
 		public Object2ObjectOpenHashMap<String, Text> customItemNames = new Object2ObjectOpenHashMap<>();

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ClientPlayerEntityMixin.java
@@ -4,7 +4,7 @@ import com.mojang.authlib.GameProfile;
 
 import dev.cbyrne.betterinject.annotations.Inject;
 import me.xmrvizzy.skyblocker.skyblock.HotbarSlotLock;
-import me.xmrvizzy.skyblocker.skyblock.ItemProtection;
+import me.xmrvizzy.skyblocker.skyblock.item.ItemProtection;
 import me.xmrvizzy.skyblocker.skyblock.rift.HealingMelonIndicator;
 import me.xmrvizzy.skyblocker.utils.Utils;
 import net.minecraft.client.network.AbstractClientPlayerEntity;

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ClientPlayerEntityMixin.java
@@ -4,6 +4,7 @@ import com.mojang.authlib.GameProfile;
 
 import dev.cbyrne.betterinject.annotations.Inject;
 import me.xmrvizzy.skyblocker.skyblock.HotbarSlotLock;
+import me.xmrvizzy.skyblocker.skyblock.ItemProtection;
 import me.xmrvizzy.skyblocker.skyblock.rift.HealingMelonIndicator;
 import me.xmrvizzy.skyblocker.utils.Utils;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
@@ -21,7 +22,10 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 
     @Inject(method = "dropSelectedItem", at = @At("HEAD"), cancellable = true)
     public void skyblocker$dropSelectedItem(CallbackInfoReturnable<Boolean> cir) {
-        if (Utils.isOnSkyblock()) HotbarSlotLock.handleDropSelectedItem(this.getInventory().selectedSlot, cir);
+        if (Utils.isOnSkyblock()) {
+            if (ItemProtection.isItemProtected(this.getInventory().getMainHandStack())) cir.setReturnValue(false);
+            HotbarSlotLock.handleDropSelectedItem(this.getInventory().selectedSlot, cir);
+        }
     }
 
     @Inject(method = "updateHealth", at = @At("RETURN"))

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -2,13 +2,13 @@ package me.xmrvizzy.skyblocker.mixin;
 
 import me.xmrvizzy.skyblocker.SkyblockerMod;
 import me.xmrvizzy.skyblocker.config.SkyblockerConfigManager;
-import me.xmrvizzy.skyblocker.skyblock.ItemProtection;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ChronomatronSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.ExperimentSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.SuperpairsSolver;
 import me.xmrvizzy.skyblocker.skyblock.experiment.UltrasequencerSolver;
 import me.xmrvizzy.skyblocker.skyblock.item.BackpackPreview;
 import me.xmrvizzy.skyblocker.skyblock.item.CompactorDeletorPreview;
+import me.xmrvizzy.skyblocker.skyblock.item.ItemProtection;
 import me.xmrvizzy.skyblocker.skyblock.item.WikiLookup;
 import me.xmrvizzy.skyblocker.skyblock.itemlist.ItemRegistry;
 import me.xmrvizzy.skyblocker.utils.Utils;

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/HandledScreenMixin.java
@@ -139,7 +139,6 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
     
     /**
      * The naming of this method in yarn is half true, its mostly to handle slot/item interactions (which are mouse or keyboard clicks)
-     * 
      * For example, using the drop key bind while hovering over an item will invoke this method to drop the players item
      */
     @Inject(method = "onMouseClick(Lnet/minecraft/screen/slot/Slot;IILnet/minecraft/screen/slot/SlotActionType;)V", at = @At("HEAD"), cancellable = true)
@@ -168,7 +167,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
                 }
                 
                 //Prevent selling to NPC shops
-                if (this.handler instanceof GenericContainerScreenHandler handler && handler.getRows() == 6) {
+                if (this.client != null && this.handler instanceof GenericContainerScreenHandler genericContainerScreenHandler && genericContainerScreenHandler.getRows() == 6) {
                     ItemStack sellItem = this.handler.slots.get(49).getStack();
                 	
                     if (sellItem.getName().getString().equals("Sell Item") || skyblocker$doesLoreContain(sellItem, this.client, "buyback")) {

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/ItemProtection.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/ItemProtection.java
@@ -1,0 +1,75 @@
+package me.xmrvizzy.skyblocker.skyblock;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import me.xmrvizzy.skyblocker.config.SkyblockerConfigManager;
+import me.xmrvizzy.skyblocker.utils.Utils;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.command.CommandRegistryAccess;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.text.Text;
+
+public class ItemProtection {
+	
+	public static void init() {
+		ClientCommandRegistrationCallback.EVENT.register(ItemProtection::registerCommand);
+	}
+
+	public static boolean isItemProtected(ItemStack stack) {
+		if (stack == null || stack.isEmpty()) return false;
+		
+		NbtCompound nbt = stack.getNbt();
+		
+		if (nbt != null && nbt.contains("ExtraAttributes")) {
+			NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
+			String itemUuid = extraAttributes.contains("uuid") ? extraAttributes.getString("uuid") : "";
+			
+			return SkyblockerConfigManager.get().general.protectedItems.contains(itemUuid);
+		}
+		
+		return false;
+	}
+	
+	private static void registerCommand(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
+		dispatcher.register(ClientCommandManager.literal("skyblocker")
+				.then(ClientCommandManager.literal("protectItem")
+						.executes(context -> protectMyItem(context.getSource()))));
+	}
+	
+	private static int protectMyItem(FabricClientCommandSource source) {
+		ItemStack heldItem = source.getPlayer().getMainHandStack();
+		NbtCompound nbt = (heldItem != null) ? heldItem.getNbt() : null;
+		
+		if (Utils.isOnSkyblock() && nbt != null && nbt.contains("ExtraAttributes")) {
+			NbtCompound extraAttributes = nbt.getCompound("ExtraAttributes");
+			String itemUuid = extraAttributes.contains("uuid") ? extraAttributes.getString("uuid") : null;
+			
+			if (itemUuid != null) {
+				ObjectOpenHashSet<String> protectedItems = SkyblockerConfigManager.get().general.protectedItems;
+				
+				if (!protectedItems.contains(itemUuid)) {
+					protectedItems.add(itemUuid);
+					SkyblockerConfigManager.save();
+					
+					source.sendFeedback(Text.translatable("skyblocker.itemProtection.added", heldItem.getName()));
+				} else {
+					protectedItems.remove(itemUuid);
+					SkyblockerConfigManager.save();
+					
+					source.sendFeedback(Text.translatable("skyblocker.itemProtection.removed", heldItem.getName()));
+				}
+			} else {
+				source.sendFeedback(Text.translatable("skyblocker.itemProtection.noItemUuid"));
+			}
+		} else {
+			source.sendFeedback(Text.translatable("skyblocker.itemProtection.unableToProtect"));
+		}
+		
+		return Command.SINGLE_SUCCESS;
+	}
+}

--- a/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/ItemProtection.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/skyblock/item/ItemProtection.java
@@ -1,4 +1,4 @@
-package me.xmrvizzy.skyblocker.skyblock;
+package me.xmrvizzy.skyblocker.skyblock.item;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -387,6 +387,11 @@
   "skyblocker.quiverWarning.50Left": "You only have 50 Arrows left in your Quiver!",
   "skyblocker.quiverWarning.10Left": "You only have 10 Arrows left in your Quiver!",
   "skyblocker.quiverWarning.empty": "You don't have any more Arrows left in your Quiver!",
+  
+  "skyblocker.itemProtection.added": "§b[§6Skyblocker§b] §fYour %s will now be protected! §o*your item now feels a little safer :')*",
+  "skyblocker.itemProtection.removed": "§b[§6Skyblocker§b] §fYour %s will §nno longer be protected§f :( - §lBeware of the dangers in doing this!",
+  "skyblocker.itemProtection.noItemUuid": "§b[§6Skyblocker§b] §cYou must be holding an item that has a uuid in order to protect it!",
+  "skyblocker.itemProtection.unableToProtect": "§b[§6Skyblocker§b] §cUnable to protect this item :( (Are you in skyblock?, are you holding an item?)",
 
   "emi.category.skyblocker.skyblock": "Skyblock"
 }


### PR DESCRIPTION
Ever felt like slot locking wasn't enough to protect your items? Ever accidentally almost tossed out that prized sword of yours? Or have you ever accidentally sold a precious item to the NPC (and maybe not gotten it back)?

Now meet `/skyblocker protectItem`!

When an item is protected it's safe from:
- Being dropped while holding it, regardless of the slot being locked
- Being dropped from picking it up in your inventory then clicking outside the screen
- Being dropped via hovering over it and pressing the drop key
- Being sold to the NPC
- Being inserted into the salvaging menu

Now you'll never have to worry about your valued items!