### PR TITLE
Codec-based Test

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/CustomArmorTrims.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/CustomArmorTrims.java
@@ -142,8 +142,8 @@ public class CustomArmorTrims {
 	public record ArmorTrimId(@SerialEntry Identifier material, @SerialEntry Identifier pattern) implements Pair<Identifier, Identifier> {
 		public static final Codec<ArmorTrimId> CODEC = RecordCodecBuilder.create(instance -> instance.group(
 				Identifier.CODEC.fieldOf("material").forGetter(ArmorTrimId::material),
-				Identifier.CODEC.fieldOf("pattern").forGetter(ArmorTrimId::pattern)
-				).apply(instance, ArmorTrimId::new));
+				Identifier.CODEC.fieldOf("pattern").forGetter(ArmorTrimId::pattern))
+				.apply(instance, ArmorTrimId::new));
 		
 		@Override
 		public Identifier left() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/CustomArmorTrims.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/CustomArmorTrims.java
@@ -3,6 +3,9 @@ package de.hysky.skyblocker.skyblock.item;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.ItemUtils;
@@ -137,6 +140,11 @@ public class CustomArmorTrims {
 	}
 
 	public record ArmorTrimId(@SerialEntry Identifier material, @SerialEntry Identifier pattern) implements Pair<Identifier, Identifier> {
+		public static final Codec<ArmorTrimId> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+				Identifier.CODEC.fieldOf("material").forGetter(ArmorTrimId::material),
+				Identifier.CODEC.fieldOf("pattern").forGetter(ArmorTrimId::pattern)
+				).apply(instance, ArmorTrimId::new));
+		
 		@Override
 		public Identifier left() {
 			return material();

--- a/src/test/java/de/hysky/skyblocker/skyblock/item/ArmorTrimIdSerializationTest.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/item/ArmorTrimIdSerializationTest.java
@@ -1,27 +1,32 @@
 package de.hysky.skyblocker.skyblock.item;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.mojang.serialization.JsonOps;
+
+import de.hysky.skyblocker.skyblock.item.CustomArmorTrims.ArmorTrimId;
 import net.minecraft.util.Identifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ArmorTrimIdSerializationTest {
-    private final Gson gson = new GsonBuilder().registerTypeAdapter(Identifier.class, new Identifier.Serializer()).create();
+    private final Gson gson = new Gson();
 
     @Test
     void serialize() {
-        CustomArmorTrims.ArmorTrimId armorTrimId = new CustomArmorTrims.ArmorTrimId(new Identifier("material_id"), new Identifier("pattern_id"));
-        String json = gson.toJson(armorTrimId);
+        ArmorTrimId armorTrimId = new ArmorTrimId(new Identifier("material_id"), new Identifier("pattern_id"));
+        JsonElement json = ArmorTrimId.CODEC.encodeStart(JsonOps.INSTANCE, armorTrimId).result().orElseThrow();
         String expectedJson = "{\"material\":\"minecraft:material_id\",\"pattern\":\"minecraft:pattern_id\"}";
-        Assertions.assertEquals(expectedJson, json);
+
+        Assertions.assertEquals(expectedJson, json.toString());
     }
 
     @Test
     void deserialize() {
         String json = "{\"material\":\"minecraft:material_id\",\"pattern\":\"minecraft:pattern_id\"}";
-        CustomArmorTrims.ArmorTrimId armorTrimId = gson.fromJson(json, CustomArmorTrims.ArmorTrimId.class);
-        CustomArmorTrims.ArmorTrimId expectedArmorTrimId = new CustomArmorTrims.ArmorTrimId(new Identifier("material_id"), new Identifier("pattern_id"));
+        ArmorTrimId armorTrimId = ArmorTrimId.CODEC.parse(JsonOps.INSTANCE, gson.fromJson(json, JsonElement.class)).result().orElseThrow();
+        ArmorTrimId expectedArmorTrimId = new ArmorTrimId(new Identifier("material_id"), new Identifier("pattern_id"));
+
         Assertions.assertEquals(expectedArmorTrimId, armorTrimId);
     }
 }


### PR DESCRIPTION
This should simplify the test as it removes the element of a custom type adapter, it's also inline with some recent changes (in 1.20.3 some classes' serializers such as for the `Style` class were removed in favour of codecs)