### PR TITLE
change flame height

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
@@ -207,6 +207,9 @@ public class SkyblockerConfig {
 		public TeleportOverlay teleportOverlay = new TeleportOverlay();
 
 		@SerialEntry
+		public FlameOverlay flameOverlay = new FlameOverlay();
+
+		@SerialEntry
 		public List<Integer> lockedSlots = new ArrayList<>();
 		
 		@SerialEntry
@@ -386,6 +389,14 @@ public class SkyblockerConfig {
 		
 		@SerialEntry
 		public boolean enableWitherImpact = true;
+	}
+
+	public static class FlameOverlay {
+		@SerialEntry
+		public float flameHeight = 0f;
+
+		@SerialEntry
+		public float flameOpacity = 0f;
 	}
 
 	public enum Direction {

--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -503,6 +503,26 @@ public class GeneralCategory {
 								.controller(ConfigUtils::createBooleanController)
 								.build())
 						.build())
+
+				//Flame Overlay
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("text.autoconfig.skyblocker.option.general.flameOverlay"))
+						.collapsed(true)
+						.option(Option.<Float>createBuilder()
+								.name(Text.translatable("text.autoconfig.skyblocker.option.general.flameOverlay.flameHeight"))
+								.binding(defaults.general.flameOverlay.flameHeight,
+										() -> config.general.flameOverlay.flameHeight,
+										newValue -> config.general.flameOverlay.flameHeight = newValue)
+								.controller(opt -> FloatSliderControllerBuilder.create(opt).range(0.0f, 0.5f).step(0.01f))
+								.build())
+						.option(Option.<Float>createBuilder()
+								.name(Text.translatable("text.autoconfig.skyblocker.option.general.flameOverlay.flameOpacity"))
+								.binding(defaults.general.flameOverlay.flameOpacity,
+										() -> config.general.flameOverlay.flameOpacity,
+										newValue -> config.general.flameOverlay.flameOpacity = newValue)
+								.controller(opt -> FloatSliderControllerBuilder.create(opt).range(0.0f, 0.8f).step(0.1f))
+								.build())
+						.build())
 				.build();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixin/InGameOverlayRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixin/InGameOverlayRendererMixin.java
@@ -1,0 +1,22 @@
+package de.hysky.skyblocker.mixin;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import net.minecraft.client.gui.hud.InGameOverlayRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(InGameOverlayRenderer.class)
+public class InGameOverlayRendererMixin {
+
+    @ModifyArg(method = "renderFireOverlay", index = 2, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/BufferBuilder;vertex(Lorg/joml/Matrix4f;FFF)Lnet/minecraft/client/render/VertexConsumer;"))
+    private static float configureFlameHeight(float y) {
+        return y - SkyblockerConfigManager.get().general.flameOverlay.flameHeight;
+    }
+
+    @ModifyArg(method = "renderFireOverlay", index = 3, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/VertexConsumer;color(FFFF)Lnet/minecraft/client/render/VertexConsumer;"))
+    private static float configureFlameOpacity(float opacity) {
+        return opacity - SkyblockerConfigManager.get().general.flameOverlay.flameOpacity;
+    }
+
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -102,7 +102,7 @@
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableEtherTransmission": "Enable Ether Transmission Overlay",
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableSinrecallTransmission": "Enable Sinrecall Transmission Overlay",
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableWitherImpact": "Enable Wither Impact Overlay",
-  "text.autoconfig.skyblocker.option.general.flameOverlay": "Flame overlay",
+  "text.autoconfig.skyblocker.option.general.flameOverlay": "Flame Overlay",
   "text.autoconfig.skyblocker.option.general.flameOverlay.flameHeight": "Flame Height",
   "text.autoconfig.skyblocker.option.general.flameOverlay.flameOpacity": "Flame Opacity",
   "skyblocker.itemTooltip.nullMessage": "§b[§6Skyblocker§b] §cItem price information on tooltip will renew in max 60 seconds. If not, check latest.log",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -103,8 +103,8 @@
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableSinrecallTransmission": "Enable Sinrecall Transmission Overlay",
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableWitherImpact": "Enable Wither Impact Overlay",
   "text.autoconfig.skyblocker.option.general.flameOverlay": "Flame overlay",
-  "text.autoconfig.skyblocker.option.general.flameOverlay.flameHeight": "Flame height",
-  "text.autoconfig.skyblocker.option.general.flameOverlay.flameOpacity": "Flame opacity",
+  "text.autoconfig.skyblocker.option.general.flameOverlay.flameHeight": "Flame Height",
+  "text.autoconfig.skyblocker.option.general.flameOverlay.flameOpacity": "Flame Opacity",
   "skyblocker.itemTooltip.nullMessage": "§b[§6Skyblocker§b] §cItem price information on tooltip will renew in max 60 seconds. If not, check latest.log",
   "skyblocker.itemTooltip.noData": "§cNo Data",
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -102,6 +102,9 @@
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableEtherTransmission": "Enable Ether Transmission Overlay",
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableSinrecallTransmission": "Enable Sinrecall Transmission Overlay",
   "text.autoconfig.skyblocker.option.general.teleportOverlay.enableWitherImpact": "Enable Wither Impact Overlay",
+  "text.autoconfig.skyblocker.option.general.flameOverlay": "Flame overlay",
+  "text.autoconfig.skyblocker.option.general.flameOverlay.flameHeight": "Flame height",
+  "text.autoconfig.skyblocker.option.general.flameOverlay.flameOpacity": "Flame opacity",
   "skyblocker.itemTooltip.nullMessage": "§b[§6Skyblocker§b] §cItem price information on tooltip will renew in max 60 seconds. If not, check latest.log",
   "skyblocker.itemTooltip.noData": "§cNo Data",
 

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -16,6 +16,7 @@
     "GenericContainerScreenHandlerMixin",
     "HandledScreenMixin",
     "InGameHudMixin",
+    "InGameOverlayRendererMixin",
     "InventoryScreenMixin",
     "ItemMixin",
     "ItemStackMixin",


### PR DESCRIPTION
Change the burning overlay height and opacity in settings example:
with setting flame height=0.0 and opacity=0.0 (default):
![2023-10-18_00 06 45](https://github.com/SkyblockerMod/Skyblocker/assets/19829407/b0a7bdaf-8339-4395-b1f5-95f82f36b483)

with setting flame height=0.3 and opacity=0.2:
![2023-10-18_00 05 03](https://github.com/SkyblockerMod/Skyblocker/assets/19829407/07ae7cc6-28b0-41fa-8811-f9939d2170cf)
