### PR TITLE
AOTV & Pearl Secret Waypoints

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
@@ -605,6 +605,12 @@ public class SkyblockerConfig {
 
 		@SerialEntry
 		public boolean enableStonkWaypoints = true;
+		
+		@SerialEntry
+		public boolean enableAotvWaypoints = true;
+		
+		@SerialEntry
+		public boolean enablePearlWaypoints = true;
 
 		@SerialEntry
 		public boolean enableDefaultWaypoints = true;

--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -123,6 +123,21 @@ public class DungeonsCategory {
 								.controller(ConfigUtils::createBooleanController)
 								.build())
 						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableAotvWaypoints"))
+								.binding(defaults.locations.dungeons.secretWaypoints.enableAotvWaypoints,
+										() -> config.locations.dungeons.secretWaypoints.enableAotvWaypoints,
+										newValue -> config.locations.dungeons.secretWaypoints.enableAotvWaypoints = newValue)
+								.controller(ConfigUtils::createBooleanController)
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enablePearlWaypoints"))
+								.description(OptionDescription.of(Text.translatable("text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enablePearlWaypoints.@Tooltip")))
+								.binding(defaults.locations.dungeons.secretWaypoints.enablePearlWaypoints,
+										() -> config.locations.dungeons.secretWaypoints.enablePearlWaypoints,
+										newValue -> config.locations.dungeons.secretWaypoints.enablePearlWaypoints = newValue)
+								.controller(ConfigUtils::createBooleanController)
+								.build())
+						.option(Option.<Boolean>createBuilder()
 								.name(Text.translatable("text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableDefaultWaypoints"))
 								.description(OptionDescription.of(Text.translatable("text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableDefaultWaypoints.@Tooltip")))
 								.binding(defaults.locations.dungeons.secretWaypoints.enableDefaultWaypoints,

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonMapUtils.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonMapUtils.java
@@ -7,7 +7,6 @@ import net.minecraft.block.MapColor;
 import net.minecraft.item.map.MapIcon;
 import net.minecraft.item.map.MapState;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.Vec3i;
 import org.jetbrains.annotations.NotNull;
@@ -173,7 +172,7 @@ public class DungeonMapUtils {
     @NotNull
     public static Vector2ic getPhysicalRoomPos(double x, double z) {
         Vector2i physicalPos = new Vector2i(x + 8.5, z + 8.5, RoundingMode.TRUNCATE);
-        return physicalPos.sub(MathHelper.floorMod(physicalPos.x(), 32), MathHelper.floorMod(physicalPos.y(), 32)).sub(8, 8);
+        return physicalPos.sub(Math.floorMod(physicalPos.x(), 32), Math.floorMod(physicalPos.y(), 32)).sub(8, 8);
     }
 
     public static Vector2ic[] getPhysicalPosFromMap(Vector2ic mapEntrancePos, int mapRoomSize, Vector2ic physicalEntrancePos, Vector2ic... mapPositions) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
@@ -249,7 +249,7 @@ public class DungeonSecrets {
 
             BlockPos relativePos = DungeonMapUtils.actualToRelative(currentRoom.getDirection(), physicalCornerPos, blockToCheck);
 
-            source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.posMessage", relativePos.getX(), relativePos.getY(), relativePos.getZ())));
+            source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.posMessage", currentRoom.getName(), relativePos.getX(), relativePos.getY(), relativePos.getZ())));
     	} else {
     	    source.sendError(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.unableToFindPos")));
     	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
@@ -377,6 +377,13 @@ public class DungeonSecrets {
         if (overlay && isCurrentRoomMatched()) {
             currentRoom.onChatMessage(text.getString());
         }
+
+        String message = text.getString();
+
+        if (message.equals("[BOSS] Bonzo: Gratz for making it this far, but I'm basically unbeatable.") || message.equals("[BOSS] Scarf: This is where the journey ends for you, Adventurers.")
+            || message.equals("[BOSS] The Professor: I was burdened with terrible news recently...") || message.equals("[BOSS] Thorn: Welcome Adventurers! I am Thorn, the Spirit! And host of the Vegan Trials!")
+            || message.equals("[BOSS] Livid: Welcome, you've arrived right on time. I am Livid, the Master of Shadows.") || message.equals("[BOSS] Sadan: So you made it all the way here... Now you wish to defy me? Sadan?!")
+            || message.equals("[BOSS] Maxor: WELL! WELL! WELL! LOOK WHO'S HERE!")) reset();
     }
 
     /**
@@ -474,7 +481,7 @@ public class DungeonSecrets {
     }
 
     /**
-     * Resets fields when leaving a dungeon.
+     * Resets fields when leaving a dungeon or entering boss.
      */
     private static void reset() {
         mapEntrancePos = null;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
@@ -40,6 +40,7 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -242,8 +243,9 @@ public class DungeonSecrets {
     }
 
     private static int getRelativePos(FabricClientCommandSource source, BlockPos pos) {
-        if (isCurrentRoomMatched()) {
-            BlockPos relativePos = DungeonMapUtils.actualToRelative(currentRoom.getDirection(), currentRoom.getPhysicalCornerPos(), pos);
+        Room room = getRoomAtPhysical(pos);
+        if (isRoomMatched(room)) {
+            BlockPos relativePos = currentRoom.actualToRelative(pos);
             source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.posMessage", currentRoom.getName(), relativePos.getX(), relativePos.getY(), relativePos.getZ())));
         } else {
             source.sendError(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.notMatched")));
@@ -442,6 +444,19 @@ public class DungeonSecrets {
      */
     @Nullable
     private static Room getRoomAtPhysical(Vec3d pos) {
+        return rooms.get(DungeonMapUtils.getPhysicalRoomPos(pos));
+    }
+
+    /**
+     * Gets the room at the given physical position.
+     *
+     * @param pos the physical position
+     * @return the room at the given physical position, or null if there is no room at the given physical position
+     * @see #rooms
+     * @see DungeonMapUtils#getPhysicalRoomPos(Vec3i)
+     */
+    @Nullable
+    private static Room getRoomAtPhysical(Vec3i pos) {
         return rooms.get(DungeonMapUtils.getPhysicalRoomPos(pos));
     }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
@@ -74,6 +74,7 @@ public class Room {
     private TriState matched = TriState.DEFAULT;
     private Table<Integer, BlockPos, SecretWaypoint> secretWaypoints;
     private Direction direction = null;
+    private String name = null;
 
     public Room(@NotNull Type type, @NotNull Vector2ic... physicalPositions) {
         this.type = type;
@@ -90,6 +91,11 @@ public class Room {
         return type;
     }
 
+    @NotNull
+    public Set<Vector2ic> getSegments() {
+        return segments;
+    }
+
     public boolean isMatched() {
         return matched == TriState.TRUE;
     }
@@ -99,9 +105,9 @@ public class Room {
         return direction;
     }
     
-    @NotNull
-    public Set<Vector2ic> getSegments() {
-        return segments;
+    @Nullable
+    public String getName() {
+        return name;
     }
 
     @Override
@@ -310,6 +316,7 @@ public class Room {
         secretWaypoints = ImmutableTable.copyOf(secretWaypointsMutable);
         matched = TriState.TRUE;
         this.direction = direction;
+        this.name = name;
 
         DungeonSecrets.LOGGER.info("[Skyblocker] Room {} matched after checking {} block(s)", name, checkedBlocks.size());
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
@@ -23,7 +23,6 @@ import net.minecraft.entity.mob.AmbientEntity;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import org.apache.commons.lang3.tuple.MutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
@@ -74,7 +73,6 @@ public class Room {
     private Table<Integer, BlockPos, SecretWaypoint> secretWaypoints;
     private String name;
     private Direction direction;
-
     private Vector2ic physicalCornerPos;
 
     public Room(@NotNull Type type, @NotNull Vector2ic... physicalPositions) {
@@ -101,20 +99,6 @@ public class Room {
      */
     public String getName() {
         return name;
-    }
-
-    /**
-     * Not null if {@link #isMatched()}.
-     */
-    public Direction getDirection() {
-        return direction;
-    }
-
-    /**
-     * Not null if {@link #isMatched()}.
-     */
-    public Vector2ic getPhysicalCornerPos() {
-        return physicalCornerPos;
     }
 
     @Override
@@ -211,8 +195,8 @@ public class Room {
         if (pos.getY() < 66 || pos.getY() > 73) {
             return true;
         }
-        int x = MathHelper.floorMod(pos.getX() - 8, 32);
-        int z = MathHelper.floorMod(pos.getZ() - 8, 32);
+        int x = Math.floorMod(pos.getX() - 8, 32);
+        int z = Math.floorMod(pos.getZ() - 8, 32);
         return (x < 13 || x > 17 || z > 2 && z < 28) && (z < 13 || z > 17 || x > 2 && x < 28);
     }
 
@@ -349,6 +333,20 @@ public class Room {
         possibleRooms = null;
         checkedBlocks = null;
         doubleCheckBlocks = 0;
+    }
+
+    /**
+     * Fails if !{@link #isMatched()}
+     */
+    protected BlockPos actualToRelative(BlockPos pos) {
+        return DungeonMapUtils.actualToRelative(direction, physicalCornerPos, pos);
+    }
+
+    /**
+     * Fails if !{@link #isMatched()}
+     */
+    protected BlockPos relativeToActual(BlockPos pos) {
+        return DungeonMapUtils.relativeToActual(direction, physicalCornerPos, pos);
     }
 
     /**

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
@@ -28,6 +28,7 @@ import net.minecraft.world.World;
 import org.apache.commons.lang3.tuple.MutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Vector2i;
 import org.joml.Vector2ic;
 
@@ -72,6 +73,7 @@ public class Room {
      */
     private TriState matched = TriState.DEFAULT;
     private Table<Integer, BlockPos, SecretWaypoint> secretWaypoints;
+    private Direction direction = null;
 
     public Room(@NotNull Type type, @NotNull Vector2ic... physicalPositions) {
         this.type = type;
@@ -90,6 +92,16 @@ public class Room {
 
     public boolean isMatched() {
         return matched == TriState.TRUE;
+    }
+    
+    @Nullable
+    public Direction getDirection() {
+        return direction;
+    }
+    
+    @NotNull
+    public Set<Vector2ic> getSegments() {
+        return segments;
     }
 
     @Override
@@ -297,6 +309,8 @@ public class Room {
         }
         secretWaypoints = ImmutableTable.copyOf(secretWaypointsMutable);
         matched = TriState.TRUE;
+        this.direction = direction;
+
         DungeonSecrets.LOGGER.info("[Skyblocker] Room {} matched after checking {} block(s)", name, checkedBlocks.size());
     }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
@@ -112,6 +112,8 @@ public class SecretWaypoint {
         LEVER(secretWaypoints -> secretWaypoints.enableLeverWaypoints, 250, 217, 2),
         FAIRYSOUL(secretWaypoints -> secretWaypoints.enableFairySoulWaypoints, 255, 85, 255),
         STONK(secretWaypoints -> secretWaypoints.enableStonkWaypoints, 146, 52, 235),
+        AOTV(secretWaypoints -> secretWaypoints.enableAotvWaypoints, 252, 98, 3),
+        PEARL(secretWaypoints -> secretWaypoints.enablePearlWaypoints, 57, 117, 125),
         DEFAULT(secretWaypoints -> secretWaypoints.enableDefaultWaypoints, 190, 255, 252);
         private final Predicate<SkyblockerConfig.SecretWaypoints> enabledPredicate;
         private final float[] colorComponents;
@@ -135,6 +137,8 @@ public class SecretWaypoint {
                 case "lever" -> Category.LEVER;
                 case "fairysoul" -> Category.FAIRYSOUL;
                 case "stonk" -> Category.STONK;
+                case "aotv" -> Category.AOTV;
+                case "pearl" -> Category.PEARL;
                 default -> Category.DEFAULT;
             };
         }

--- a/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
+++ b/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
@@ -3835,6 +3835,13 @@
       "z":51
     },
     {
+	  "secretName":"5 - AOTV",
+	  "category":"aotv",
+	  "x":16,
+	  "y":81,
+	  "z":53
+	},
+    {
       "secretName":"5 - Chest",
       "category":"chest",
       "x":31,

--- a/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
+++ b/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
@@ -4881,6 +4881,13 @@
       "z":52
     },
     {
+	  "secretName":"2 - AOTV",
+	  "category":"aotv",
+	  "x":45,
+	  "y":78,
+	  "z":47
+	},
+    {
       "secretName":"2 - Chest",
       "category":"chest",
       "x":46,
@@ -4915,6 +4922,13 @@
       "y":85,
       "z":41
     },
+    {
+	  "secretName":"5 - Pearl",
+	  "category":"pearl",
+	  "x":15,
+	  "y":84,
+	  "z":56
+	},
     {
       "secretName":"5 - Stonk",
       "category":"stonk",

--- a/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
+++ b/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
@@ -835,6 +835,13 @@
       "z":21
     },
     {
+	  "secretName":"2 - AOTV",
+	  "category":"aotv",
+	  "x":25,
+	  "y":76,
+	  "z":22
+	},
+    {
       "secretName":"2 - Stonk",
       "category":"stonk",
       "x":23,
@@ -2947,7 +2954,7 @@
       "category":"stonk",
       "x":17,
       "y":70,
-      "z":15
+      "z":14
     },
     {
       "secretName":"6 - Pressure Plate 2",
@@ -3059,6 +3066,13 @@
       "z":5
     },
     {
+	  "secretName":"2 - AOTV",
+	  "category":"aotv",
+	  "x":77,
+	  "y":82,
+	  "z":16
+	},
+    {
       "secretName":"2 - Wither Essence",
       "category":"wither",
       "x":79,
@@ -3109,6 +3123,13 @@
       "y":50,
       "z":9
     },
+    {
+	  "secretName":"3 - AOTV",
+	  "category":"aotv",
+	  "x":7,
+	  "y":80,
+	  "z":15
+	},
     {
       "secretName":"3 - Superboom",
       "category":"superboom",
@@ -3225,6 +3246,13 @@
       "y":89,
       "z":24
     },
+    {
+	  "secretName":"1/2 - AOTV",
+	  "category":"aotv",
+	  "x":84,
+	  "y":91,
+	  "z":26
+	},
     {
       "secretName":"1 - Bat",
       "category":"bat",
@@ -4071,6 +4099,13 @@
       "y":109,
       "z":30
     },
+    {
+	  "secretName":"5 - AOTV",
+	  "category":"aotv",
+	  "x":52,
+	  "y":78,
+	  "z":9
+	},
     {
       "secretName":"5 - Crypt",
       "category":"superboom",
@@ -5081,6 +5116,13 @@
       "z":61
     },
     {
+	  "secretName": "7 - AOTV",
+	  "category":"aotv",
+	  "x":39,
+	  "y":84,
+	  "z":58
+	},
+    {
       "secretName":"7 - Chest",
       "category":"chest",
       "x":41,
@@ -5332,6 +5374,13 @@
       "z":43
     },
     {
+	  "secretName":"3/4 - AOTV",
+	  "category":"aotv",
+	  "x":49,
+	  "y":83,
+	  "z":36
+	},
+    {
       "secretName":"3 - Chest",
       "category":"chest",
       "x":49,
@@ -5552,6 +5601,13 @@
       "y":45,
       "z":15
     },
+    {
+	  "secretName":"5 - Pearl",
+	  "category":"pearl",
+	  "x":8,
+	  "y":59,
+	  "z":14
+	},
     {
       "secretName":"5 - Entrance",
       "category":"entrance",
@@ -5835,6 +5891,13 @@
     }
   ],
   "Double-Stair-3":[
+	{
+	  "secretName":"1 - Pearl",
+	  "category":"pearl",
+	  "x":24,
+	  "y":72,
+	  "z":11
+	},
     {
       "secretName":"1 - Wither Essence",
       "category":"wither",

--- a/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
+++ b/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
@@ -263,6 +263,13 @@
       "z":21
     },
     {
+	  "secretName":"1 - Pearl",
+	  "category":"pearl",
+	  "x":25,
+	  "y":75,
+	  "z":27
+	},
+    {
       "secretName":"1 - Item",
       "category":"item",
       "x":27,

--- a/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
+++ b/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
@@ -1720,24 +1720,10 @@
   ],
   "Redstone-Key-3":[
     {
-      "secretName":"1 - Redstone Skull (right click)",
-      "category":"lever",
-      "x":10,
-      "y":70,
-      "z":26
-    },
-    {
       "secretName":"1 - Superboom",
       "category":"superboom",
       "x":20,
       "y":68,
-      "z":7
-    },
-    {
-      "secretName":"1 - Redstone Skull (right click)",
-      "category":"lever",
-      "x":19,
-      "y":66,
       "z":7
     },
     {
@@ -1753,6 +1739,20 @@
       "x":25,
       "y":69,
       "z":6
+    },
+    {
+      "secretName":"2 - Redstone Skull (right click)",
+      "category":"lever",
+      "x":10,
+      "y":70,
+      "z":26
+    },
+    {
+      "secretName":"2 - Redstone Skull (right click)",
+      "category":"lever",
+      "x":19,
+      "y":66,
+      "z":7
     },
     {
       "secretName":"2 - Place Skull",

--- a/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
+++ b/src/main/resources/assets/skyblocker/dungeons/secretlocations.json
@@ -2952,7 +2952,7 @@
     {
       "secretName":"6 - Stonk",
       "category":"stonk",
-      "x":17,
+      "x":18,
       "y":70,
       "z":14
     },

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -276,7 +276,8 @@
   "skyblocker.dungeons.secrets.markSecretFoundUnable": "§cUnable to mark secret #%d as found.",
   "skyblocker.dungeons.secrets.markSecretMissingUnable": "§cUnable to mark secret #%d as missing.",
   "skyblocker.dungeons.secrets.posMessage": "§rRoom: %s, X: %d, Y: %d, Z: %d",
-  "skyblocker.dungeons.secrets.unableToFindPos": "§cUnable to find room position! (Are you in a dungeon room, are you facing a block?)",
+  "skyblocker.dungeons.secrets.noTarget": "§cNo target block found! (Are you pointing at a block in range?)",
+  "skyblocker.dungeons.secrets.notMatched": "§cThe current room is not matched! (Are you in a dungeon room?)",
 
   "skyblocker.fishing.reelNow": "Reel in now!",
   "skyblocker.rift.healNow": "Heal now!",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -164,6 +164,9 @@
   "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableLeverWaypoints" : "Enable Lever Waypoints",
   "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableFairySoulWaypoints" : "Enable Fairy Soul Waypoints",
   "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableStonkWaypoints" : "Enable Stonk Waypoints",
+  "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableAotvWaypoints" : "Enable AOTV Waypoints",
+  "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enablePearlWaypoints": "Enable Pearl Waypoints",
+  "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enablePearlWaypoints.@Tooltip": "With these waypoints, you throw a pearl towards the block and at the same time AOTV up.",
   "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableDefaultWaypoints" : "Enable Default Waypoints",
   "text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.enableDefaultWaypoints.@Tooltip" : "This includes all waypoints that do not belong to a category.",
   "text.autoconfig.skyblocker.option.locations.dungeons.dungeonChestProfit": "Dungeon Chest Profit Calculator",
@@ -272,7 +275,7 @@
   "skyblocker.dungeons.secrets.markSecretMissing": "§rMarked secret #%d as missing.",
   "skyblocker.dungeons.secrets.markSecretFoundUnable": "§cUnable to mark secret #%d as found.",
   "skyblocker.dungeons.secrets.markSecretMissingUnable": "§cUnable to mark secret #%d as missing.",
-  "skyblocker.dungeons.secrets.posMessage": "§rRoom Pos: X: %d, Y: %d, Z: %d",
+  "skyblocker.dungeons.secrets.posMessage": "§rRoom: %s, X: %d, Y: %d, Z: %d",
   "skyblocker.dungeons.secrets.unableToFindPos": "§cUnable to find room position! (Are you in a dungeon room, are you facing a block?)",
 
   "skyblocker.fishing.reelNow": "Reel in now!",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -272,6 +272,8 @@
   "skyblocker.dungeons.secrets.markSecretMissing": "§rMarked secret #%d as missing.",
   "skyblocker.dungeons.secrets.markSecretFoundUnable": "§cUnable to mark secret #%d as found.",
   "skyblocker.dungeons.secrets.markSecretMissingUnable": "§cUnable to mark secret #%d as missing.",
+  "skyblocker.dungeons.secrets.posMessage": "§rRoom Pos: X: %d, Y: %d, Z: %d",
+  "skyblocker.dungeons.secrets.unableToFindPos": "§cUnable to find room position! (Are you in a dungeon room, are you facing a block?)",
 
   "skyblocker.fishing.reelNow": "Reel in now!",
   "skyblocker.rift.healNow": "Heal now!",


### PR DESCRIPTION
- Adds secret waypoints for aotv and pearl spots
- Moves 1 stonk waypoint to be more optimal on 1.20
- Adds `/skyblocker dungeons secrets getPos|getFacingPos`

There's one pearl spot I didn't get to add, and I'm tired of cycling solo f7s so I'll add it later when I find the room while playing.