### PR TITLE
Waypoints API & Custom Dungeon Secrets

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.config;
 
 import de.hysky.skyblocker.skyblock.item.CustomArmorTrims;
 import de.hysky.skyblocker.utils.chat.ChatFilterResult;
+import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
@@ -582,7 +583,7 @@ public class SkyblockerConfig {
 		public boolean noInitSecretWaypoints = false;
 		
 		@SerialEntry
-		public WaypointType waypointType = WaypointType.WAYPOINT;
+		public Waypoint.Type waypointType = Waypoint.Type.WAYPOINT;
 		
 		@SerialEntry
 		public boolean showSecretText = true;
@@ -622,25 +623,6 @@ public class SkyblockerConfig {
 
 		@SerialEntry
 		public boolean enableDefaultWaypoints = true;
-	}
-	
-	public enum WaypointType {
-		WAYPOINT,
-		OUTLINED_WAYPOINT,
-		HIGHLIGHT,
-		OUTLINED_HIGHLIGHT,
-		OUTLINE;
-		
-		@Override
-		public String toString() {
-			return switch (this) {
-				case WAYPOINT -> "Waypoint";
-				case OUTLINED_WAYPOINT -> "Outlined Waypoint";
-				case HIGHLIGHT -> "Highlight";
-				case OUTLINED_HIGHLIGHT -> "Outlined Highlight";
-				case OUTLINE -> "Outline";
-			};
-		}
 	}
 
 	public static class DungeonChestProfit {

--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -2,7 +2,7 @@ package de.hysky.skyblocker.config.categories;
 
 import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
-import de.hysky.skyblocker.config.SkyblockerConfig.WaypointType;
+import de.hysky.skyblocker.utils.waypoint.Waypoint.Type;
 import dev.isxander.yacl3.api.ButtonOption;
 import dev.isxander.yacl3.api.ConfigCategory;
 import dev.isxander.yacl3.api.Option;
@@ -44,7 +44,7 @@ public class DungeonsCategory {
 								.controller(ConfigUtils::createBooleanController)
 								.flag(OptionFlag.GAME_RESTART)
 								.build())
-						.option(Option.<WaypointType>createBuilder()
+						.option(Option.<Type>createBuilder()
 								.name(Text.translatable("text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.waypointType"))
 								.description(OptionDescription.of(Text.translatable("text.autoconfig.skyblocker.option.locations.dungeons.secretWaypoints.waypointType.@Tooltip")))
 								.binding(defaults.locations.dungeons.secretWaypoints.waypointType,

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
@@ -109,6 +109,9 @@ public class DungeonSecrets {
     private static final Map<Vector2ic, Room> rooms = new HashMap<>();
     private static final Map<String, JsonElement> roomsJson = new HashMap<>();
     private static final Map<String, JsonElement> waypointsJson = new HashMap<>();
+    /**
+     * The map of dungeon room names to custom waypoints relative to the room.
+     */
     private static final Multimap<String, SecretWaypoint> customWaypoints = MultimapBuilder.hashKeys().arrayListValues().build();
     @Nullable
     private static CompletableFuture<Void> roomsLoaded;
@@ -145,10 +148,16 @@ public class DungeonSecrets {
         return waypointsJson.get(room).getAsJsonArray();
     }
 
+    /**
+     * @see #customWaypoints
+     */
     public static Collection<SecretWaypoint> getCustomWaypoints(String room) {
         return customWaypoints.get(room);
     }
 
+    /**
+     * @see #customWaypoints
+     */
     @SuppressWarnings("UnusedReturnValue")
     public static boolean addCustomWaypoint(String room, SecretWaypoint waypoint) {
         return customWaypoints.put(room, waypoint);
@@ -285,25 +294,25 @@ public class DungeonSecrets {
                                 .then(argument("name", StringArgumentType.greedyString()).executes(context -> {
                                     // TODO Less hacky way with custom ClientBlockPosArgumentType
                                     BlockPos pos = context.getArgument("pos", PosArgument.class).toAbsoluteBlockPos(new ServerCommandSource(null, context.getSource().getPosition(), context.getSource().getRotation(), null, 0, null, null, null, null));
-                                    return relative ? addWaypointRelative(context, pos) : addWaypoint(context, pos);
+                                    return relative ? addCustomWaypointRelative(context, pos) : addCustomWaypoint(context, pos);
                                 }))
                         )
                 );
     }
 
-    private static int addWaypoint(CommandContext<FabricClientCommandSource> context, BlockPos pos) {
+    private static int addCustomWaypoint(CommandContext<FabricClientCommandSource> context, BlockPos pos) {
         Room room = getRoomAtPhysical(pos);
         if (isRoomMatched(room)) {
-            room.addWaypoint(context, room.actualToRelative(pos));
+            room.addCustomWaypoint(context, room.actualToRelative(pos));
         } else {
             context.getSource().sendError(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.notMatched")));
         }
         return Command.SINGLE_SUCCESS;
     }
 
-    private static int addWaypointRelative(CommandContext<FabricClientCommandSource> context, BlockPos pos) {
+    private static int addCustomWaypointRelative(CommandContext<FabricClientCommandSource> context, BlockPos pos) {
         if (isCurrentRoomMatched()) {
-            currentRoom.addWaypoint(context, pos);
+            currentRoom.addCustomWaypoint(context, pos);
         } else {
             context.getSource().sendError(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.notMatched")));
         }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonSecrets.java
@@ -1,5 +1,7 @@
 package de.hysky.skyblocker.skyblock.dungeon.secrets;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -14,7 +16,6 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
-import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import it.unimi.dsi.fastutil.objects.Object2ByteMap;
 import it.unimi.dsi.fastutil.objects.Object2ByteOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectIntPair;
@@ -107,7 +108,7 @@ public class DungeonSecrets {
     private static final Map<Vector2ic, Room> rooms = new HashMap<>();
     private static final Map<String, JsonElement> roomsJson = new HashMap<>();
     private static final Map<String, JsonElement> waypointsJson = new HashMap<>();
-    private static final Map<String, Waypoint> customWaypoints = new HashMap<>();
+    private static final Multimap<String, SecretWaypoint> customWaypoints = MultimapBuilder.hashKeys().arrayListValues().build();
     @Nullable
     private static CompletableFuture<Void> roomsLoaded;
     /**
@@ -137,6 +138,10 @@ public class DungeonSecrets {
 
     public static JsonArray getRoomWaypoints(String room) {
         return waypointsJson.get(room).getAsJsonArray();
+    }
+
+    public static Collection<SecretWaypoint> getCustomWaypoints(String room) {
+        return customWaypoints.get(room);
     }
 
     /**

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonObject;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
 import it.unimi.dsi.fastutil.ints.IntSortedSet;
@@ -165,7 +166,7 @@ public class Room {
         SecretWaypoint.Category category = SecretWaypoint.Category.CategoryArgumentType.getCategory(context, "category");
         String waypointName = StringArgumentType.getString(context, "name");
         addCustomWaypoint(secretIndex, category, waypointName, pos);
-        context.getSource().sendFeedback(Text.translatable("skyblocker.dungeons.secrets.customWaypointAdded", pos.getX(), pos.getY(), pos.getZ(), name, secretIndex, category, waypointName));
+        context.getSource().sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.dungeons.secrets.customWaypointAdded", pos.getX(), pos.getY(), pos.getZ(), name, secretIndex, category, waypointName)));
     }
 
     /**
@@ -347,7 +348,7 @@ public class Room {
             BlockPos pos = DungeonMapUtils.relativeToActual(direction, physicalCornerPos, waypoint);
             secretWaypoints.put(secretIndex, pos, new SecretWaypoint(secretIndex, waypoint, secretName, pos));
         }
-        DungeonSecrets.getCustomWaypoints(name).forEach(this::addCustomWaypoint);
+        DungeonSecrets.getCustomWaypoints(name).values().forEach(this::addCustomWaypoint);
         matched = TriState.TRUE;
 
         DungeonSecrets.LOGGER.info("[Skyblocker] Room {} matched after checking {} block(s)", name, checkedBlocks.size());

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
@@ -24,6 +24,7 @@ import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.mob.AmbientEntity;
 import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -160,7 +161,11 @@ public class Room {
      * @see #addCustomWaypoint(int, SecretWaypoint.Category, String, BlockPos)
      */
     protected void addCustomWaypoint(CommandContext<FabricClientCommandSource> context, BlockPos pos) {
-        addCustomWaypoint(IntegerArgumentType.getInteger(context, "secretIndex"), SecretWaypoint.Category.CategoryArgumentType.getCategory(context, "category"), StringArgumentType.getString(context, "name"), pos);
+        int secretIndex = IntegerArgumentType.getInteger(context, "secretIndex");
+        SecretWaypoint.Category category = SecretWaypoint.Category.CategoryArgumentType.getCategory(context, "category");
+        String waypointName = StringArgumentType.getString(context, "name");
+        addCustomWaypoint(secretIndex, category, waypointName, pos);
+        context.getSource().sendFeedback(Text.translatable("skyblocker.dungeons.secrets.customWaypointAdded", pos.getX(), pos.getY(), pos.getZ(), name, secretIndex, category, waypointName));
     }
 
     /**

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java
@@ -307,6 +307,9 @@ public class Room {
             BlockPos pos = DungeonMapUtils.relativeToActual(direction, physicalCornerPos, waypoint);
             secretWaypointsMutable.put(secretIndex, pos, new SecretWaypoint(secretIndex, waypoint, secretName, pos));
         }
+        for (SecretWaypoint customWaypoint : DungeonSecrets.getCustomWaypoints(name)) {
+            secretWaypointsMutable.put(customWaypoint.secretIndex, customWaypoint.pos, customWaypoint);
+        }
         secretWaypoints = ImmutableTable.copyOf(secretWaypointsMutable);
         matched = TriState.TRUE;
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
@@ -33,6 +33,7 @@ public class SecretWaypoint extends Waypoint {
             Codecs.TEXT.fieldOf("name").forGetter(secretWaypoint -> secretWaypoint.name),
             BlockPos.CODEC.fieldOf("pos").forGetter(secretWaypoint -> secretWaypoint.pos)
     ).apply(instance, SecretWaypoint::new));
+    public static final Codec<List<SecretWaypoint>> LIST_CODEC = CODEC.listOf();
     static final List<String> SECRET_ITEMS = List.of("Decoy", "Defuse Kit", "Dungeon Chest Key", "Healing VIII", "Inflatable Jerry", "Spirit Leap", "Training Weights", "Trap", "Treasure Talisman");
     private static final SkyblockerConfig.SecretWaypoints CONFIG = SkyblockerConfigManager.get().locations.dungeons.secretWaypoints;
     private static final Supplier<Type> TYPE_SUPPLIER = () -> CONFIG.waypointType;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.render.RenderHelper;
@@ -15,6 +16,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.StringIdentifiable;
+import net.minecraft.util.dynamic.Codecs;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +27,12 @@ import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 
 public class SecretWaypoint extends Waypoint {
+    public static final Codec<SecretWaypoint> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Codec.INT.fieldOf("secretIndex").forGetter(secretWaypoint -> secretWaypoint.secretIndex),
+            Category.CODEC.fieldOf("category").forGetter(secretWaypoint -> secretWaypoint.category),
+            Codecs.TEXT.fieldOf("name").forGetter(secretWaypoint -> secretWaypoint.name),
+            BlockPos.CODEC.fieldOf("pos").forGetter(secretWaypoint -> secretWaypoint.pos)
+    ).apply(instance, SecretWaypoint::new));
     static final List<String> SECRET_ITEMS = List.of("Decoy", "Defuse Kit", "Dungeon Chest Key", "Healing VIII", "Inflatable Jerry", "Spirit Leap", "Training Weights", "Trap", "Treasure Talisman");
     private static final SkyblockerConfig.SecretWaypoints CONFIG = SkyblockerConfigManager.get().locations.dungeons.secretWaypoints;
     private static final Supplier<Type> TYPE_SUPPLIER = () -> CONFIG.waypointType;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
@@ -17,6 +17,7 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.StringIdentifiable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -25,8 +26,8 @@ import java.util.function.ToDoubleFunction;
 
 public class SecretWaypoint extends Waypoint {
     static final List<String> SECRET_ITEMS = List.of("Decoy", "Defuse Kit", "Dungeon Chest Key", "Healing VIII", "Inflatable Jerry", "Spirit Leap", "Training Weights", "Trap", "Treasure Talisman");
-    private static final SkyblockerConfig.SecretWaypoints config = SkyblockerConfigManager.get().locations.dungeons.secretWaypoints;
-    private static final Supplier<Type> typeSupplier = () -> config.waypointType;
+    private static final SkyblockerConfig.SecretWaypoints CONFIG = SkyblockerConfigManager.get().locations.dungeons.secretWaypoints;
+    private static final Supplier<Type> TYPE_SUPPLIER = () -> CONFIG.waypointType;
     final int secretIndex;
     final Category category;
     final Text name;
@@ -41,7 +42,7 @@ public class SecretWaypoint extends Waypoint {
     }
 
     SecretWaypoint(int secretIndex, Category category, Text name, BlockPos pos) {
-        super(pos, typeSupplier, category.colorComponents);
+        super(pos, TYPE_SUPPLIER, category.colorComponents);
         this.secretIndex = secretIndex;
         this.category = category;
         this.name = name;
@@ -85,12 +86,17 @@ public class SecretWaypoint extends Waypoint {
         //TODO In the future, shrink the box for wither essence and items so its more realistic
         super.render(context);
 
-        if (config.showSecretText) {
+        if (CONFIG.showSecretText) {
             Vec3d posUp = centerPos.add(0, 1, 0);
             RenderHelper.renderText(context, name, posUp, true);
             double distance = context.camera().getPos().distanceTo(centerPos);
             RenderHelper.renderText(context, Text.literal(Math.round(distance) + "m").formatted(Formatting.YELLOW), posUp, 1, MinecraftClient.getInstance().textRenderer.fontHeight + 1, true);
         }
+    }
+
+    @NotNull
+    SecretWaypoint relativeToActual(Room room) {
+        return new SecretWaypoint(secretIndex, category, name, room.relativeToActual(pos));
     }
 
     enum Category implements StringIdentifiable {
@@ -158,7 +164,7 @@ public class SecretWaypoint extends Waypoint {
                 return new CategoryArgumentType();
             }
 
-            public static Category getCategory(CommandContext<?> context, String name) {
+            public static <S> Category getCategory(CommandContext<S> context, String name) {
                 return context.getArgument(name, Category.class);
             }
         }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
@@ -151,6 +151,11 @@ public class SecretWaypoint extends Waypoint {
         }
 
         @Override
+        public String toString() {
+            return name;
+        }
+
+        @Override
         public String asString() {
             return name;
         }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
@@ -44,7 +44,7 @@ public class SecretWaypoint extends Waypoint {
     }
 
     @Override
-    protected boolean shouldRender() {
+    public boolean shouldRender() {
         return super.shouldRender() && category.isEnabled();
     }
 
@@ -68,7 +68,7 @@ public class SecretWaypoint extends Waypoint {
      * Renders the secret waypoint, including a filled cube, a beacon beam, the name, and the distance from the player.
      */
     @Override
-    protected void render(WorldRenderContext context) {
+    public void render(WorldRenderContext context) {
         //TODO In the future, shrink the box for wither essence and items so its more realistic
         super.render(context);
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretWaypoint.java
@@ -29,7 +29,7 @@ public class SecretWaypoint extends Waypoint {
     private static final Supplier<Type> typeSupplier = () -> config.waypointType;
     final int secretIndex;
     final Category category;
-    private final Text name;
+    final Text name;
     private final Vec3d centerPos;
 
     SecretWaypoint(int secretIndex, JsonObject waypoint, String name, BlockPos pos) {
@@ -37,10 +37,14 @@ public class SecretWaypoint extends Waypoint {
     }
 
     SecretWaypoint(int secretIndex, Category category, String name, BlockPos pos) {
+        this(secretIndex, category, Text.of(name), pos);
+    }
+
+    SecretWaypoint(int secretIndex, Category category, Text name, BlockPos pos) {
         super(pos, typeSupplier, category.colorComponents);
         this.secretIndex = secretIndex;
         this.category = category;
-        this.name = Text.of(name);
+        this.name = name;
         this.centerPos = pos.toCenterPos();
     }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/BackpackPreview.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/BackpackPreview.java
@@ -1,10 +1,10 @@
 package de.hysky.skyblocker.skyblock.item;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Utils;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -60,7 +60,7 @@ public class BackpackPreview {
             // update save dir based on sb profile id
             String id = MinecraftClient.getInstance().getSession().getUuidOrNull().toString().replaceAll("-", "") + "/" + Utils.getProfileId();
             if (!id.equals(loaded)) {
-                saveDir = FabricLoader.getInstance().getConfigDir().resolve("skyblocker/backpack-preview/" + id);
+                saveDir = SkyblockerMod.CONFIG_DIR.resolve("backpack-preview/" + id);
                 //noinspection ResultOfMethodCallIgnored
                 saveDir.toFile().mkdirs();
                 // load storage again because profile id changed

--- a/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
+++ b/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
@@ -11,16 +11,20 @@ public class Waypoint {
     protected static final float DEFAULT_HIGHLIGHT_ALPHA = 0.5f;
     protected static final float DEFAULT_LINE_WIDTH = 5f;
     protected final BlockPos pos;
-    protected final Box box;
-    protected final Supplier<Type> typeSupplier;
-    protected final float[] colorComponents;
-    protected final float alpha;
-    protected final float lineWidth;
-    protected final boolean throughWalls;
-    protected boolean shouldRender;
+    private final Box box;
+    private final Supplier<Type> typeSupplier;
+    private final float[] colorComponents;
+    private final float alpha;
+    private final float lineWidth;
+    private final boolean throughWalls;
+    private boolean shouldRender;
 
     protected Waypoint(BlockPos pos, Supplier<Type> typeSupplier, float[] colorComponents) {
         this(pos, typeSupplier, colorComponents, DEFAULT_HIGHLIGHT_ALPHA);
+    }
+
+    protected Waypoint(BlockPos pos, Type type, float[] colorComponents, float alpha) {
+        this(pos, () -> type, colorComponents, alpha);
     }
 
     protected Waypoint(BlockPos pos, Supplier<Type> typeSupplier, float[] colorComponents, float alpha) {
@@ -46,7 +50,7 @@ public class Waypoint {
         this.shouldRender = shouldRender;
     }
 
-    protected boolean shouldRender() {
+    public boolean shouldRender() {
         return shouldRender;
     }
 
@@ -58,7 +62,7 @@ public class Waypoint {
         this.shouldRender = true;
     }
 
-    protected void render(WorldRenderContext context) {
+    public void render(WorldRenderContext context) {
         switch (typeSupplier.get()) {
             case WAYPOINT -> RenderHelper.renderFilledThroughWallsWithBeaconBeam(context, pos, colorComponents, alpha);
             case OUTLINED_WAYPOINT -> {

--- a/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
+++ b/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
 public class Waypoint {
     protected static final float DEFAULT_HIGHLIGHT_ALPHA = 0.5f;
     protected static final float DEFAULT_LINE_WIDTH = 5f;
-    protected final BlockPos pos;
+    public final BlockPos pos;
     private final Box box;
     private final Supplier<Type> typeSupplier;
     private final float[] colorComponents;

--- a/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
+++ b/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
@@ -1,0 +1,95 @@
+package de.hysky.skyblocker.utils.waypoint;
+
+import de.hysky.skyblocker.utils.render.RenderHelper;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+
+import java.util.function.Supplier;
+
+public class Waypoint {
+    protected static final float DEFAULT_HIGHLIGHT_ALPHA = 0.5f;
+    protected static final float DEFAULT_LINE_WIDTH = 5f;
+    protected final BlockPos pos;
+    protected final Box box;
+    protected final Supplier<Type> typeSupplier;
+    protected final float[] colorComponents;
+    protected final float alpha;
+    protected final float lineWidth;
+    protected final boolean throughWalls;
+    protected boolean shouldRender;
+
+    protected Waypoint(BlockPos pos, Supplier<Type> typeSupplier, float[] colorComponents) {
+        this(pos, typeSupplier, colorComponents, DEFAULT_HIGHLIGHT_ALPHA);
+    }
+
+    protected Waypoint(BlockPos pos, Supplier<Type> typeSupplier, float[] colorComponents, float alpha) {
+        this(pos, typeSupplier, colorComponents, alpha, DEFAULT_LINE_WIDTH);
+    }
+
+    protected Waypoint(BlockPos pos, Supplier<Type> typeSupplier, float[] colorComponents, float alpha, float lineWidth) {
+        this(pos, typeSupplier, colorComponents, alpha, lineWidth, true);
+    }
+
+    protected Waypoint(BlockPos pos, Supplier<Type> typeSupplier, float[] colorComponents, float alpha, float lineWidth, boolean throughWalls) {
+        this(pos, typeSupplier, colorComponents, alpha, lineWidth, throughWalls, true);
+    }
+
+    protected Waypoint(BlockPos pos, Supplier<Type> typeSupplier, float[] colorComponents, float alpha, float lineWidth, boolean throughWalls, boolean shouldRender) {
+        this.pos = pos;
+        this.box = new Box(pos);
+        this.typeSupplier = typeSupplier;
+        this.colorComponents = colorComponents;
+        this.alpha = alpha;
+        this.lineWidth = lineWidth;
+        this.throughWalls = throughWalls;
+        this.shouldRender = shouldRender;
+    }
+
+    protected boolean shouldRender() {
+        return shouldRender;
+    }
+
+    public void setFound() {
+        this.shouldRender = false;
+    }
+
+    public void setMissing() {
+        this.shouldRender = true;
+    }
+
+    protected void render(WorldRenderContext context) {
+        switch (typeSupplier.get()) {
+            case WAYPOINT -> RenderHelper.renderFilledThroughWallsWithBeaconBeam(context, pos, colorComponents, alpha);
+            case OUTLINED_WAYPOINT -> {
+                RenderHelper.renderFilledThroughWallsWithBeaconBeam(context, pos, colorComponents, alpha);
+                RenderHelper.renderOutline(context, box, colorComponents, lineWidth, throughWalls);
+            }
+            case HIGHLIGHT -> RenderHelper.renderFilledThroughWalls(context, pos, colorComponents, alpha);
+            case OUTLINED_HIGHLIGHT -> {
+                RenderHelper.renderFilledThroughWalls(context, pos, colorComponents, alpha);
+                RenderHelper.renderOutline(context, box, colorComponents, lineWidth, throughWalls);
+            }
+            case OUTLINE -> RenderHelper.renderOutline(context, box, colorComponents, lineWidth, throughWalls);
+        }
+    }
+
+    public enum Type {
+        WAYPOINT,
+        OUTLINED_WAYPOINT,
+        HIGHLIGHT,
+        OUTLINED_HIGHLIGHT,
+        OUTLINE;
+
+        @Override
+        public String toString() {
+            return switch (this) {
+                case WAYPOINT -> "Waypoint";
+                case OUTLINED_WAYPOINT -> "Outlined Waypoint";
+                case HIGHLIGHT -> "Highlight";
+                case OUTLINED_HIGHLIGHT -> "Outlined Highlight";
+                case OUTLINE -> "Outline";
+            };
+        }
+    }
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -273,9 +273,11 @@
   "skyblocker.dungeons.secrets.markSecretFoundUnable": "§cUnable to mark secret #%d as found.",
   "skyblocker.dungeons.secrets.markSecretMissingUnable": "§cUnable to mark secret #%d as missing.",
   "skyblocker.dungeons.secrets.posMessage": "§rRoom: %s, X: %d, Y: %d, Z: %d",
-  "skyblocker.dungeons.secrets.customWaypointAdded": "§rAdded a custom waypoint at X: %d, Y: %d, Z: %d for room %s secret #%d of category %s with name '%s'.",
   "skyblocker.dungeons.secrets.noTarget": "§cNo target block found! (Are you pointing at a block in range?)",
   "skyblocker.dungeons.secrets.notMatched": "§cThe current room is not matched! (Are you in a dungeon room?)",
+  "skyblocker.dungeons.secrets.customWaypointAdded": "§rAdded a custom waypoint at X: %d, Y: %d, Z: %d for room %s secret #%d of category %s with name '%s'.",
+  "skyblocker.dungeons.secrets.customWaypointRemoved": "§rRemoved custom waypoint at X: %d, Y: %d, Z: %d for room %s secret #%d of category %s with name '%s'.",
+  "skyblocker.dungeons.secrets.customWaypointNotFound": "§cNo custom waypoint found at X: %d, Y: %d, Z: %d for room %s.",
 
   "skyblocker.fishing.reelNow": "Reel in now!",
   "skyblocker.rift.healNow": "Heal now!",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -273,6 +273,7 @@
   "skyblocker.dungeons.secrets.markSecretFoundUnable": "§cUnable to mark secret #%d as found.",
   "skyblocker.dungeons.secrets.markSecretMissingUnable": "§cUnable to mark secret #%d as missing.",
   "skyblocker.dungeons.secrets.posMessage": "§rRoom: %s, X: %d, Y: %d, Z: %d",
+  "skyblocker.dungeons.secrets.customWaypointAdded": "§rAdded a custom waypoint at X: %d, Y: %d, Z: %d for room %s secret #%d of category %s with name '%s'.",
   "skyblocker.dungeons.secrets.noTarget": "§cNo target block found! (Are you pointing at a block in range?)",
   "skyblocker.dungeons.secrets.notMatched": "§cThe current room is not matched! (Are you in a dungeon room?)",
 


### PR DESCRIPTION
Custom dungeon secret waypoints!  

Use with `/skyblocker dungeons secrets addWaypoint|addWaypointRelatively [pos] [secretIndex] [category] [name]` and `/skyblocker dungeons secrets removeWaypoint|removeWaypointRelatively [pos]`

---

Adds `Waypoint` abstraction, currently used by Dungeon Secrets and Mythological Ritual.  
Fairy Souls, Effigy Waypoints, Enigma Souls, and Relics need to be refactored to use this abstraction.  

This provides the groundwork for a more general Waypoints system!  