### PR TITLE
Prevent exception in fairy souls

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/FairySouls.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/FairySouls.java
@@ -180,8 +180,10 @@ public class FairySouls {
     }
 
     public static void markAllFairiesOnCurrentIslandFound() {
-        initializeFoundFairiesForCurrentProfileAndLocation();
-        foundFairies.get(Utils.getProfile()).get(Utils.getLocationRaw()).addAll(fairySouls.get(Utils.getLocationRaw()));
+        if (fairySouls.get(Utils.getLocationRaw()) != null) {
+            initializeFoundFairiesForCurrentProfileAndLocation();
+            foundFairies.get(Utils.getProfile()).get(Utils.getLocationRaw()).addAll(fairySouls.get(Utils.getLocationRaw()));
+        }
     }
 
     public static void markAllFairiesOnCurrentIslandMissing() {


### PR DESCRIPTION
Prevents an exception being thrown when you use `/skyblocker fairySouls markAllInCurrentIslandFound` while on your private island.