### PR TITLE
Enhanced Museum Cache Error Handling

### DIFF
--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -78,7 +78,7 @@
   "text.autoconfig.skyblocker.option.general.itemTooltip.enableBazaarPrice": "Enable Bazaar buy/sell Price",
   "text.autoconfig.skyblocker.option.general.itemTooltip.enableObtainedDate": "Enable Obtained Date",
   "text.autoconfig.skyblocker.option.general.itemTooltip.enableMuseumInfo": "Enable Museum Info",
-  "text.autoconfig.skyblocker.option.general.itemTooltip.enableMuseumInfo.@Tooltip": "If this item is donatable to the museum, then the item's category in the musuem is displayed. It also displays a marker indicating whether you've donated that item to your musuem or not (freebies not yet supported).",
+  "text.autoconfig.skyblocker.option.general.itemTooltip.enableMuseumInfo.@Tooltip": "If this item is donatable to the museum, then the item's category in the musuem is displayed. It also displays a marker indicating whether you've donated that item to your musuem or not (freebies not yet supported).\n\nMake sure to enable your Museum API for accurate information!",
   "text.autoconfig.skyblocker.option.general.itemTooltip.enableExoticTooltip": "Enable Exotic Tooltip",
   "text.autoconfig.skyblocker.option.general.itemTooltip.enableExoticTooltip.@Tooltip": "Displays the type of exotic below the item's name if an armor piece is exotic.",
   "text.autoconfig.skyblocker.option.general.itemInfoDisplay": "Item Info Display",


### PR DESCRIPTION
Previously, it would keep requesting data every time the profile id chat message was sent if there was some kind of a failure with the previous attempt (e.g. museum api is disabled, non 200 status code was returned or an exception was thrown)