### PR TITLE
Ignore invalid entity data exceptions & broken quiz question

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixin/DataTrackerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixin/DataTrackerMixin.java
@@ -1,0 +1,25 @@
+package de.hysky.skyblocker.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import de.hysky.skyblocker.utils.Utils;
+import net.minecraft.entity.data.DataTracker;
+
+@Mixin(DataTracker.class)
+public class DataTrackerMixin {
+
+	@WrapOperation(method = "writeUpdatedEntries", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/data/DataTracker;copyToFrom(Lnet/minecraft/entity/data/DataTracker$Entry;Lnet/minecraft/entity/data/DataTracker$SerializedEntry;)V"))
+	public void skyblocker$ignoreInvalidDataExceptions(DataTracker dataTracker, DataTracker.Entry<?> to, DataTracker.SerializedEntry<?> from, Operation<Void> operation) {
+		if (Utils.isOnHypixel()) {
+			try {
+				operation.call(dataTracker, to, from);
+			} catch (IllegalStateException ignored) {} //These exceptions cause annoying small lag spikes for some reason
+		} else {
+			operation.call(dataTracker, to, from);
+		}
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/mixin/DataTrackerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixin/DataTrackerMixin.java
@@ -2,24 +2,18 @@ package de.hysky.skyblocker.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import de.hysky.skyblocker.utils.Utils;
+import dev.cbyrne.betterinject.annotations.Inject;
 import net.minecraft.entity.data.DataTracker;
 
 @Mixin(DataTracker.class)
 public class DataTrackerMixin {
 
-	@WrapOperation(method = "writeUpdatedEntries", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/data/DataTracker;copyToFrom(Lnet/minecraft/entity/data/DataTracker$Entry;Lnet/minecraft/entity/data/DataTracker$SerializedEntry;)V"))
-	public void skyblocker$ignoreInvalidDataExceptions(DataTracker dataTracker, DataTracker.Entry<?> to, DataTracker.SerializedEntry<?> from, Operation<Void> operation) {
-		if (Utils.isOnHypixel()) {
-			try {
-				operation.call(dataTracker, to, from);
-			} catch (IllegalStateException ignored) {} //These exceptions cause annoying small lag spikes for some reason
-		} else {
-			operation.call(dataTracker, to, from);
-		}
+	@Inject(method = "copyToFrom", at = @At(value = "NEW", target = "Ljava/lang/IllegalStateException;", shift = At.Shift.BEFORE), cancellable = true)
+	public void skyblocker$ignoreInvalidDataExceptions(CallbackInfo ci) {
+		//These exceptions cause annoying small lag spikes for some reason
+		if (Utils.isOnHypixel()) ci.cancel();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/Trivia.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/Trivia.java
@@ -54,9 +54,10 @@ public class Trivia extends ChatPatternListener {
                 int year = (int) (diff / 446400 + 1);
                 solutions = Collections.singletonList("Year " + year);
             } else {
-                solutions = Arrays.asList(answers.get(trimmedQuestion));
+                String[] questionAnswers = answers.get(trimmedQuestion);
+                if (questionAnswers != null) solutions = Arrays.asList(questionAnswers);
             }
-        } catch (Exception e) { //Handle the broken wither lords quiz question, maybe we should try to accommodate it
+        } catch (Exception e) { //Hopefully the solver doesn't go south
             LOGGER.error("[Skyblocker] Failed to update the Trivia puzzle answers!", e);
         }
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/Trivia.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/Trivia.java
@@ -10,11 +10,15 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
+import com.mojang.logging.LogUtils;
 
 import java.util.*;
 import java.util.regex.Matcher;
 
 public class Trivia extends ChatPatternListener {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final Map<String, String[]> answers;
     private List<String> solutions = Collections.emptyList();
 
@@ -42,14 +46,18 @@ public class Trivia extends ChatPatternListener {
     }
 
     private void updateSolutions(String question) {
-        String trimmedQuestion = question.trim();
-        if (trimmedQuestion.equals("What SkyBlock year is it?")) {
-            long currentTime = System.currentTimeMillis() / 1000L;
-            long diff = currentTime - 1560276000;
-            int year = (int) (diff / 446400 + 1);
-            solutions = Collections.singletonList("Year " + year);
-        } else {
-            solutions = Arrays.asList(answers.get(trimmedQuestion));
+        try {
+            String trimmedQuestion = question.trim();
+            if (trimmedQuestion.equals("What SkyBlock year is it?")) {
+                long currentTime = System.currentTimeMillis() / 1000L;
+                long diff = currentTime - 1560276000;
+                int year = (int) (diff / 446400 + 1);
+                solutions = Collections.singletonList("Year " + year);
+            } else {
+                solutions = Arrays.asList(answers.get(trimmedQuestion));
+            }
+        } catch (Exception e) { //Handle the broken wither lords quiz question, maybe we should try to accommodate it
+            LOGGER.error("[Skyblocker] Failed to update the Trivia puzzle answers!", e);
         }
     }
 

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -10,6 +10,7 @@
     "ClientPlayerEntityMixin",
     "ClientPlayerInteractionManagerMixin",
     "ClientPlayNetworkHandlerMixin",
+    "DataTrackerMixin",
     "DrawContextMixin",
     "DyeableItemMixin",
     "FarmlandBlockMixin",


### PR DESCRIPTION
These exceptions seem to be triggered in dungeons as a result of sending invalid data in entity packets, and for some reason when the exceptions are left unchecked they cause lag spikes.

Let's take moment to congratulate Hypixel on their W multi-version support!