### PR TITLE
Increase shortcuts character limit & Reset griffin burrows on world change

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -194,6 +194,8 @@ public class ShortcutsConfigListWidget extends ElementListWidget<ShortcutsConfig
             this.category = category;
             target = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, width / 2 - 160, 5, 150, 20, category.targetName);
             replacement = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, width / 2 + 10, 5, 150, 20, category.replacementName);
+            target.setMaxLength(48);
+            replacement.setMaxLength(48);
             target.setText(targetString);
             replacement.setText(category.shortcutsMap.getOrDefault(targetString, ""));
             children = List.of(target, replacement);


### PR DESCRIPTION
Some commands like `/joindungeon MASTER_CATACOMBS_FLOOR_SEVEN` are 41 characters long so I increased the character limit to 48 to accommodate longer commands.

Since I forgot to swap branches this now also resets griffin burrows on world changes to prevent the lines from persisting between lobby swaps.