### PR TITLE
remove screens when switching island

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixin/MinecraftClientMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixin/MinecraftClientMixin.java
@@ -1,17 +1,36 @@
 package de.hysky.skyblocker.mixin;
 
 import de.hysky.skyblocker.skyblock.item.HotbarSlotLock;
+import de.hysky.skyblocker.utils.JoinWorldPlaceholderScreen;
+import de.hysky.skyblocker.utils.ReconfiguringPlaceholderScreen;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.DownloadingTerrainScreen;
+import net.minecraft.client.gui.screen.ReconfiguringScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import dev.cbyrne.betterinject.annotations.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftClient.class)
 public abstract class MinecraftClientMixin {
+
+    @Shadow
+    public abstract void setScreen(@Nullable Screen screen);
+
+    @Shadow
+    protected abstract void reset(Screen screen);
+
+    @Shadow
+    @Nullable
+    public abstract ClientPlayNetworkHandler getNetworkHandler();
+
     @Shadow
     @Nullable
     public ClientPlayerEntity player;
@@ -20,6 +39,27 @@ public abstract class MinecraftClientMixin {
     public void skyblocker$handleInputEvents() {
         if (Utils.isOnSkyblock()) {
             HotbarSlotLock.handleInputEvents(player);
+        }
+    }
+
+    //Remove Downloading Terrain Screen and Reconfiguring Screen
+    @Inject(at = @At("HEAD"), method = "setScreen", cancellable = true)
+    public void setScreen(final Screen screen, final CallbackInfo ci) {
+        if (Utils.isOnSkyblock()) {
+            if (screen instanceof DownloadingTerrainScreen) {
+                ci.cancel();
+                this.setScreen(null);
+            } else if (screen instanceof ReconfiguringScreen && this.getNetworkHandler() != null) {
+                ci.cancel();
+                this.setScreen(new ReconfiguringPlaceholderScreen(this.getNetworkHandler().getConnection()));
+            }
+        }
+    }
+
+    @Redirect(method = "joinWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;reset(Lnet/minecraft/client/gui/screen/Screen;)V"))
+    private void joinWorld(final MinecraftClient minecraft, final Screen screen) {
+        if (Utils.isOnSkyblock()) {
+            this.reset(new JoinWorldPlaceholderScreen());
         }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/utils/BasePlaceholderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/utils/BasePlaceholderScreen.java
@@ -11,10 +11,10 @@ public abstract class BasePlaceholderScreen extends Screen {
     }
 
     @Override
-    public void render(final DrawContext guiGraphics, final int i, final int j, final float f) {
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
     }
 
     @Override
-    public void renderBackground(final DrawContext guiGraphics, final int i, final int j, final float f) {
+    public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
     }
 }

--- a/src/main/java/de/hysky/skyblocker/utils/BasePlaceholderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/utils/BasePlaceholderScreen.java
@@ -1,0 +1,20 @@
+package de.hysky.skyblocker.utils;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.Text;
+
+public abstract class BasePlaceholderScreen extends Screen {
+
+    public BasePlaceholderScreen(Text title) {
+        super(title);
+    }
+
+    @Override
+    public void render(final DrawContext guiGraphics, final int i, final int j, final float f) {
+    }
+
+    @Override
+    public void renderBackground(final DrawContext guiGraphics, final int i, final int j, final float f) {
+    }
+}

--- a/src/main/java/de/hysky/skyblocker/utils/JoinWorldPlaceholderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/utils/JoinWorldPlaceholderScreen.java
@@ -1,0 +1,12 @@
+package de.hysky.skyblocker.utils;
+
+import net.minecraft.text.Text;
+
+public final class JoinWorldPlaceholderScreen extends BasePlaceholderScreen {
+
+    private static final String SCREEN_TITLE = "Joining World Screen";
+
+    public JoinWorldPlaceholderScreen() {
+        super(Text.literal(SCREEN_TITLE));
+    }
+}

--- a/src/main/java/de/hysky/skyblocker/utils/ReconfiguringPlaceholderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ReconfiguringPlaceholderScreen.java
@@ -1,0 +1,24 @@
+package de.hysky.skyblocker.utils;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.text.Text;
+
+public final class ReconfiguringPlaceholderScreen extends BasePlaceholderScreen {
+    private static final String SCREEN_TITLE = "Reconfig Screen";
+
+    private final ClientConnection connection;
+
+    public ReconfiguringPlaceholderScreen(final ClientConnection connection) {
+        super(Text.literal(SCREEN_TITLE));
+        this.connection = connection;
+    }
+
+    @Override
+    public void tick() {
+        if (this.connection.isOpen()) {
+            this.connection.tick();
+        } else {
+            this.connection.handleDisconnection();
+        }
+    }
+}


### PR DESCRIPTION
Here is a small present for the community. This was on my backlog.

___

This feature removes the annoying "Loading Terrain ..." and "Reconfigure" Screens when switching island.
This feature makes the island switching experience smoother.

Comparison video

**Before:**

https://github.com/SkyblockerMod/Skyblocker/assets/19829407/f8367537-2345-487c-96a2-2a47e8649228

**After:**

https://github.com/SkyblockerMod/Skyblocker/assets/19829407/d27ac90c-d818-458d-b922-dcc89fbc5387
