### PR TITLE
Correct Transparent Skin Pixels

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
@@ -165,7 +165,7 @@ public class SkyblockerConfig {
 		public boolean hideStatusEffectOverlay = false;
 		
 		@SerialEntry
-		public boolean dontStripSkinAlphaValues = false;
+		public boolean dontStripSkinAlphaValues = true;
 
 		@SerialEntry
 		public TabHudConf tabHud = new TabHudConf();

--- a/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/SkyblockerConfig.java
@@ -163,6 +163,9 @@ public class SkyblockerConfig {
 
 		@SerialEntry
 		public boolean hideStatusEffectOverlay = false;
+		
+		@SerialEntry
+		public boolean dontStripSkinAlphaValues = false;
 
 		@SerialEntry
 		public TabHudConf tabHud = new TabHudConf();

--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -55,6 +55,15 @@ public class GeneralCategory {
 								newValue -> config.general.hideStatusEffectOverlay = newValue)
 						.controller(ConfigUtils::createBooleanController)
 						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("text.autoconfig.skyblocker.option.general.dontStripSkinAlphaValues"))
+						.description(OptionDescription.of(Text.translatable("text.autoconfig.skyblocker.option.general.dontStripSkinAlphaValues.@Tooltip")))
+						.binding(defaults.general.dontStripSkinAlphaValues,
+								() -> config.general.dontStripSkinAlphaValues,
+								newValue -> config.general.dontStripSkinAlphaValues = newValue)
+						.controller(ConfigUtils::createBooleanController)
+						.flag(OptionFlag.ASSET_RELOAD)
+						.build())
 
 				//Tab Hud
 				.group(OptionGroup.createBuilder()

--- a/src/main/java/de/hysky/skyblocker/mixin/PlayerSkinTextureMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixin/PlayerSkinTextureMixin.java
@@ -1,0 +1,19 @@
+package de.hysky.skyblocker.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.Utils;
+import dev.cbyrne.betterinject.annotations.Inject;
+import net.minecraft.client.texture.PlayerSkinTexture;
+
+@Mixin(PlayerSkinTexture.class)
+public class PlayerSkinTextureMixin {
+
+	@Inject(method = "stripAlpha", at = @At("HEAD"), cancellable = true)
+	private static void skyblocker$dontStripAlphaValues(CallbackInfo ci) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.dontStripSkinAlphaValues) ci.cancel();
+	}
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -295,6 +295,8 @@
 
   "text.autoconfig.skyblocker.option.general.hideEmptyTooltips": "Hide empty item tooltips in menus",
   "text.autoconfig.skyblocker.option.general.hideStatusEffectOverlay": "Hide Status Effect Overlay",
+  "text.autoconfig.skyblocker.option.general.dontStripSkinAlphaValues": "Correct Transparent Skin Pixels",
+  "text.autoconfig.skyblocker.option.general.dontStripSkinAlphaValues.@Tooltip": "When enabled, the alpha values of pixels in skin textures are no longer stripped while in Skyblock.\n\nThis results in the \"filler\" pixels on items using Player Heads to now be completely transparent, although this may have some side effects in odd cases.",
 
   "skyblocker.updaterepository.failed":  "§cUpdating local repository failed. Remove files manually and restart game.",
 

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -27,6 +27,7 @@
     "MinecraftClientMixin",
     "PlayerListHudMixin",
     "PlayerSkinProviderMixin",
+    "PlayerSkinTextureMixin",
     "ScoreboardMixin",
     "SocialInteractionsPlayerListWidgetMixin",
     "WorldRendererMixin",


### PR DESCRIPTION
Corrects transparent pixels in skins, since it cancels out the effects of the stripAlpha method a small warning was added to the description but it probably shouldn't affect other skins/heads. If the language could be improved let me know.

Resolves #425 