### PR TITLE
Audit Mixins

### DIFF
--- a/src/test/java/de/hysky/skyblocker/MixinsTest.java
+++ b/src/test/java/de/hysky/skyblocker/MixinsTest.java
@@ -1,0 +1,27 @@
+package de.hysky.skyblocker;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
+
+import net.minecraft.Bootstrap;
+import net.minecraft.SharedConstants;
+
+public class MixinsTest {
+
+	@BeforeAll
+	public static void setupEnvironment() {
+		SharedConstants.createGameVersion();
+		Bootstrap.initialize();
+	}
+
+	@Test
+	public void auditMixins() {
+		//Ensure that the transformer is active so that the Mixins can be audited
+		assert MixinEnvironment.getCurrentEnvironment().getActiveTransformer() instanceof IMixinTransformer;
+
+		//If this fails check the report to get the full stack trace
+		MixinEnvironment.getCurrentEnvironment().audit();
+	}
+}

--- a/src/test/java/de/hysky/skyblocker/MixinsTest.java
+++ b/src/test/java/de/hysky/skyblocker/MixinsTest.java
@@ -20,7 +20,7 @@ public class MixinsTest {
 	@Test
 	public void auditMixins() {
 		//Ensure that the transformer is active so that the Mixins can be audited
-		Assertions.assertTrue(MixinEnvironment.getCurrentEnvironment().getActiveTransformer() instanceof IMixinTransformer);
+		Assertions.assertInstanceOf(IMixinTransformer.class, MixinEnvironment.getCurrentEnvironment().getActiveTransformer());
 
 		//If this fails check the report to get the full stack trace
 		MixinEnvironment.getCurrentEnvironment().audit();

--- a/src/test/java/de/hysky/skyblocker/MixinsTest.java
+++ b/src/test/java/de/hysky/skyblocker/MixinsTest.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.spongepowered.asm.mixin.MixinEnvironment;
@@ -19,7 +20,7 @@ public class MixinsTest {
 	@Test
 	public void auditMixins() {
 		//Ensure that the transformer is active so that the Mixins can be audited
-		assert MixinEnvironment.getCurrentEnvironment().getActiveTransformer() instanceof IMixinTransformer;
+		Assertions.assertTrue(MixinEnvironment.getCurrentEnvironment().getActiveTransformer() instanceof IMixinTransformer);
 
 		//If this fails check the report to get the full stack trace
 		MixinEnvironment.getCurrentEnvironment().audit();


### PR DESCRIPTION
Adds a test that audits all of the mod's Mixins, if an injection fails then an exception is thrown and the build will fail. The test report contains the necessary stack trace to debug the misbehaving Mixins (the stack trace is exactly the same as it would be if you tried to start the game and it crashed).

This should streamline development since you don't need to go through the process of running the game in order to test the mixins, you can either build the mod or just run the tests only to see if the Mixins are ok.