### PR TITLE
Add Hypixel's colouring to Dwarven Mines HUD.

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.skyblock.dwarven;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.tabhud.util.Colors;
 import de.hysky.skyblocker.skyblock.tabhud.widget.hud.HudCommsWidget;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import it.unimi.dsi.fastutil.ints.IntIntPair;
@@ -91,12 +92,19 @@ public class DwarvenHud {
 
         int y = 0;
         for (Commission commission : commissions) {
+            float percentage;
+            if (!commission.progression().contains("DONE")) {
+                percentage = Float.parseFloat(commission.progression().substring(0, commission.progression().length() - 1));
+            } else {
+                percentage = 100f;
+            }
+
             context
                     .drawTextWithShadow(client.textRenderer,
                             Text.literal(commission.commission + ": ")
                                     .styled(style -> style.withColor(Formatting.AQUA))
                                     .append(Text.literal(commission.progression)
-                                            .styled(style -> style.withColor(Formatting.GREEN))),
+                                            .styled(style -> style.withColor(Colors.hypixelProgressColor(percentage)))),
                             hudX + 5, hudY + y + 5, 0xFFFFFFFF);
             y += 20;
         }

--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/Colors.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/Colors.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.tabhud.util;
 
+import net.minecraft.util.Formatting;
 import net.minecraft.util.math.MathHelper;
 
 public class Colors {
@@ -10,5 +11,17 @@ public class Colors {
      */
     public static int pcntToCol(float pcnt) {
         return MathHelper.hsvToRgb(pcnt / 300f, 0.9f, 0.9f);
+    }
+
+    public static Formatting hypixelProgressColor(float pcnt) {
+        if (pcnt < 25) {
+            return Formatting.RED;
+        } else if (pcnt < 50) {
+            return Formatting.GOLD;
+        } else if (pcnt < 75) {
+            return Formatting.YELLOW;
+        } else {
+            return Formatting.GREEN;
+        }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/hud/HudCommsWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/hud/HudCommsWidget.java
@@ -60,7 +60,8 @@ public class HudCommsWidget extends Widget {
             } else {
                 comp = new PlainTextComponent(
                         Text.literal(comm.commission() + ": ")
-                                .append(Text.literal(comm.progression()).formatted(Formatting.GREEN)));
+                                .append(Text.literal(comm.progression())
+                                        .formatted(Colors.hypixelProgressColor(p))));
             }
             this.addComponent(comp);
         }


### PR DESCRIPTION
Hello, this branch adds the tab list default colouring provided by Hypixel to the Dwarven Mines HUD. Previously, the mod made this text always green and I personally found it odd since I was used to the colour codes. I don't know if this should be in config or not, but since it was really small detail I figured it's okay not to for now. This only affects the 'Simple' and 'Classic' styles, the 'Fancy' style already has some custom colouring.

![Screenshot from 2024-01-13 01-40-36](https://github.com/SkyblockerMod/Skyblocker/assets/60589762/f9405e4b-e287-4385-8de0-05d0c8f2e7f1)
![Screenshot from 2024-01-13 01-45-28](https://github.com/SkyblockerMod/Skyblocker/assets/60589762/426bd9a3-c379-42ff-bc92-4c60b53b41e4)
