### PR TITLE
1.20.4 & 1.20.2 only issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,9 +35,8 @@ body:
       label: Minecraft Version
       description: What version of Minecraft are you running? If you do not know what version you are using, look in the bottom left corner of the main menu in game.
       options:
+        - "1.20.4"
         - "1.20.2"
-        - "1.20.1"
-        - "1.20"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -16,9 +16,8 @@ body:
       label: Minecraft Version
       description: What version of Minecraft are you running? If you do not know what version you are using, look in the bottom left corner of the main menu in game.
       options:
+        - "1.20.4"
         - "1.20.2"
-        - "1.20.1"
-        - "1.20"
     validations:
       required: true
   - type: input


### PR DESCRIPTION
I'm only keeping 1.20.2 because those versions are well downloaded on Modrinth and some issues may still be relevant to 1.20.4 (e.g. mod compatibility), it is still not officially supported and should be removed in the 1.17 release.