### PR TITLE
Fix fishing timer appearing outside Skyblock.

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/FishingHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/FishingHelper.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.skyblock;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.RenderHelper;
 import de.hysky.skyblocker.utils.render.title.Title;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
@@ -23,6 +24,9 @@ public class FishingHelper {
     public static void init() {
         UseItemCallback.EVENT.register((player, world, hand) -> {
             ItemStack stack = player.getStackInHand(hand);
+            if (!Utils.isOnSkyblock()) {
+                return TypedActionResult.pass(stack);
+            }
             if (stack.getItem() instanceof FishingRodItem) {
                 if (player.fishHook == null) {
                     start(player);


### PR DESCRIPTION
Hello, this is a very simple fix, but the fishing helper does not work outside Skyblock. It will flash at the wrong time and it is otherwise inconsistent with the rest of the mod's behaviour outside Skyblock, which is why this commit removes it altogether.