### PR TITLE
Fix Active Effects widget

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/EffectWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/EffectWidget.java
@@ -59,7 +59,7 @@ public class EffectWidget extends Widget {
                     .append(Text.literal(number).formatted(Formatting.YELLOW));
 
             IcoFatTextComponent iftc = new IcoFatTextComponent(Ico.POTION, active,
-                    Text.literal(lines[3]).formatted(Formatting.AQUA));
+                    Text.literal(lines[2]).formatted(Formatting.AQUA));
             this.addComponent(iftc);
         }
     }


### PR DESCRIPTION
Hypixel moved the "use /effects" thing onto the line where it tells you how many effects you have active -_- (As to why it was not there before I do not know)