### PR TITLE
Lowercase party and search strings to ignore case

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyEntryListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyEntryListWidget.java
@@ -53,7 +53,7 @@ public class PartyEntryListWidget extends ElementListWidget<PartyEntry> {
 
     public void updateDisplay() {
         List<PartyEntry> entries = new ArrayList<>(partyEntries);
-        entries.removeIf(partyEntry -> !partyEntry.note.contains(search) && !(partyEntry instanceof PartyEntry.YourParty));
+        entries.removeIf(partyEntry -> !partyEntry.note.toLowerCase().contains(search) && !(partyEntry instanceof PartyEntry.YourParty));
         entries.sort(Comparator.comparing(PartyEntry::isLocked));
         entries.sort(Comparator.comparing(partyEntry -> !(partyEntry instanceof PartyEntry.YourParty)));
         if (entries.isEmpty() && !partyEntries.isEmpty()) {
@@ -63,7 +63,7 @@ public class PartyEntryListWidget extends ElementListWidget<PartyEntry> {
     }
 
     public void setSearch(String s) {
-        search = s;
+        search = s.toLowerCase();
         updateDisplay();
     }
 


### PR DESCRIPTION
S+ wouldn't match s+ and vice-versa, so the results would be fewer for those looking for S+ lobbies and I guess it'd break numerous other searches due to capitalization not matching 100%.