### PR TITLE
Add the missing starter commission to the Dwarven HUD.

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
@@ -35,6 +35,7 @@ public class DwarvenHud {
                     "(?<!Lucky )Raffle",
                     "Lucky Raffle",
                     "2x Mithril Powder Collector",
+                    "First Event",
                     "(?:Ruby|Amber|Sapphire|Jade|Amethyst|Topaz) Gemstone Collector",
                     "(?:Amber|Sapphire|Jade|Amethyst|Topaz) Crystal Hunter",
                     "Chest Looter").map(s -> Pattern.compile("^.*(" + s + "): (\\d+\\.?\\d*%|DONE)"))


### PR DESCRIPTION
This simple change fixes a bug where the "First Event" commission, which is one of the first commissions you receive, is missing from the HUD.
![image](https://github.com/SkyblockerMod/Skyblocker/assets/60589762/06fad173-746b-4cf1-93a9-586489c0cfb3)
