### PR TITLE
use mod-publish-plugin

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -19,9 +19,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -31,13 +31,13 @@ jobs:
             fs.writeFileSync("./gradle.properties", file);
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'
 
       - name: Initialize caches
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -53,7 +53,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: fname
         with:
           result-encoding: string
@@ -61,7 +61,7 @@ jobs:
             const fs = require("fs")
             return fs.readdirSync("build/libs/").filter(e => !e.endsWith("dev.jar") && !e.endsWith("sources.jar") && e.endsWith(".jar"))[0].replace(".jar", "");
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.fname.outputs.result }}
           path: build/libs/

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -17,9 +17,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/libs/
@@ -46,55 +46,29 @@ jobs:
           CHANGELOGtmp="${CHANGELOGtmp//$'\n'/'%0A'}"
           CHANGELOGtmp="${CHANGELOGtmp//$'\r'/'%0D'}"
           
-          echo "::set-output name=changelog::$CHANGELOGtmp"
+          # changelog for Github release
+          echo "changelog=$CHANGELOGtmp" >> $GITHUB_OUTPUT
           
-          echo "Changelog:\n$CHANGELOG"
+          #echo "Changelog:\n$CHANGELOG" # for debugging
 
           changelog="${CHANGELOG}"
+          highlight_section=$(echo "$changelog" | awk '/## Highlight/{flag=1;next}/^$/{flag=0}flag')
+          highlight_section="# Highlight\n$highlight_section\n\nhttps://hysky.de/"
 
-          # Because of the 2000 char limit in Discord shorten the changelog
-
-          # Calculate the number of characters to delete
-          delete_chars=$((${#changelog} + 350 - 2000 - 15))
+          # Format highlight_section with printf
+          highlight_section=$(printf "%s" "$highlight_section")
           
-          # Check if delete_chars is greater than 0
-          if [ $delete_chars -gt 0 ]; then
-
-              # Extract the "What's Changed" section from the changelog
-              changed_section=$(echo "$changelog" | awk '/## What'\''s Changed/{flag=1;next}/^$/{flag=0}flag')
-
-              # Trim the changed_section based on the delete_chars value and remove the last line
-              modified_section="${changed_section::-delete_chars}"
-              modified_section=$(echo "$modified_section" | sed '$d')
-
-              # Add "[...] and more" at the end of modified_section
-              modified_section+="\n[...] and more"
-
-              # Format modified_section with printf
-              modified_section=$(printf "%s" "$modified_section")
-
-              # Generate the modified_changelog by inserting modified_section after the "What's Changed" section
-              modified_changelog=$(awk -v modified_section="$modified_section" '
-                      /^## What'\''s Changed/ { print; print modified_section; f=1; next }
-                      f && /^$/ { f=0 }
-                      !f { print }
-                      END { if (f) print "" }
-                  ' ORS='\n' <<< "$changelog")
-
-              # Format the modified_changelog by removing "@" characters and enclosing URLs in "<>"
-              # modified_changelog=$(echo "$modified_changelog" | sed -e 's/@//g' -e 's|https\?://[^[:space:]]*|<\0>|g')
-          
-          # Store the modified_changelog in the CHANGELOG variable
-          CHANGELOG=$(echo -n "$modified_changelog")
-          fi
+          # Store the highlight_section in the CHANGELOG variable
+          CHANGELOG=$(echo -n "$highlight_section")
           
           CHANGELOG="${CHANGELOG//'%'/'%25'}"
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
           CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
           
-          echo "::set-output name=changelog_discord::$CHANGELOG"
+          # changelog for rest
+          echo "changelog_highlight=$CHANGELOG" >> $GITHUB_OUTPUT
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: fname
         with:
           result-encoding: string
@@ -110,35 +84,13 @@ jobs:
           token: ${{ secrets.GH_RELEASE }}
           files: build/libs/${{ steps.fname.outputs.result }}
 
-      - name: Publish to Modrinth
-        id: modrinth
+      - name: Publish using mod-publish-plugin
+        run: ./gradlew build publishMods
         env:
-          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN  }}
-          CHANGELOG: ${{ steps.read_changelog.outputs.changelog }}
-        run: ./gradlew modrinth
-
-      - name: Get version tag
-        id: version_tag
-        run: |
-          [[ ! "$GITHUB_REF" =~ refs/tags ]] && exit
-          echo "::set-output name=value::${GITHUB_REF#refs/tags/}"
-
-      - name: Discord notification
-        shell: bash
-        run: |
-          OUTPUT="
-          <@&1134565945482948638>
-          ## Skyblocker ${{ steps.version_tag.outputs.value }}
-          
-          ${{ steps.read_changelog.outputs.changelog_discord }}
-          
-          :inbox_tray: Download latest version on Modrinth or Github:
-          <:modrinth:900697862206287882> ${{ steps.modrinth.outputs.url }}
-          <:github:900697885706952725> ${{ steps.uploadrelease.outputs.url }}
-          
-          https://hysky.de/"
-
-          curl -H "Content-Type: application/json" -d '{"content":"'"${OUTPUT//$'\n'/\\n}"'", "flags": 4}' "${{ secrets.DISCORD_WEBHOOK }}"
+          CHANGELOG: ${{ steps.read_changelog.outputs.changelog_highlight }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
 
       - name: Trigger Modpack
         shell: bash

--- a/.github/workflows/webhook_translate.yml
+++ b/.github/workflows/webhook_translate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: '1.20'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'fabric-loom' version '1.5-SNAPSHOT'
 	id 'maven-publish'
-	id 'com.modrinth.minotaur' version '2.+'
+	id "me.modmuss50.mod-publish-plugin" version "0.5.1"
 }
 
 version = "${project.mod_version}+${project.minecraft_version}"
@@ -92,13 +92,6 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// ensure that the encoding is set to UTF-8, no matter what the system default is
-	// this fixes some edge cases with special characters not displaying correctly
-	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-	// If Javadoc is generated, this must be specified in that task too.
-
-
-	// Minecraft 1.18 upwards uses Java 17.
 	it.options.release = 17
 }
 
@@ -122,30 +115,39 @@ test {
 	useJUnitPlatform()
 }
 
-modrinth {
-	token = System.getenv('MODRINTH_TOKEN')
-	projectId = project.modrinth_id
-	versionNumber = "v${project.version}"
-	versionName = "Skyblocker ${project.mod_version} for ${project.minecraft_version}"
-	uploadFile = remapJar
-	gameVersions = [project.minecraft_version]
-	loaders = ["fabric"]
-	versionType = "release"
-	dependencies {
-		required.project "fabric-api"
-		optional.project "modmenu"
-		optional.project "rei"
-		optional.project "emi"
-	}
+publishMods {
+	file = remapJar.archiveFile
 	changelog = System.getenv('CHANGELOG')
-	syncBodyFrom = rootProject.file("MRREADME.md").text
-}
+	version = "v${project.version}"
+	displayName = "Skyblocker ${mod_version} for ${minecraft_version}"
+	modLoaders.add("fabric")
+	type = STABLE
 
-tasks.modrinth.doLast {
-	println "::set-output name=url::https://modrinth.com/mod/skyblocker-liap/version/$uploadInfo.id"
-}
+	modrinth {
+		accessToken = System.getenv("MODRINTH_TOKEN")
+		projectId = modrinth_id
+		minecraftVersions.add(minecraft_version)
+		announcementTitle = "<:modrinth:900697862206287882> Download from Modrinth"
+		requires("fabric-api")
+		optional("modmenu", "rei", "emi")
+	}
 
-tasks.modrinth.dependsOn(tasks.modrinthSyncBody)
+	curseforge {
+		accessToken = System.getenv("CURSEFORGE_TOKEN")
+		projectId = curseforge_id
+		minecraftVersions.add(minecraft_version)
+		announcementTitle = "<:curseforge:900697838453936149> Download from CurseForge"
+		projectSlug = "skyblocker"
+		requires("fabric-api")
+		optional("roughly-enough-items", "emi")
+	}
+
+	discord {
+		webhookUrl = System.getenv("DISCORD_WEBHOOK")
+		username = "Changelog"
+		content = changelog.map { "<@&1134565945482948638>\n## Skyblocker v${mod_version}\n" + it}
+	}
+}
 
 // configure the maven publication
 publishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,4 @@ mod_version = 1.17.0
 maven_group = de.hysky
 archives_base_name = skyblocker
 modrinth_id=y6DuFGwJ
+curseforge_id=936169


### PR DESCRIPTION
\- update workflow versions
\- **[minotaur](https://github.com/modrinth/minotaur)** replaced with **[mod-publish-plugin](https://github.com/modmuss50/mod-publish-plugin)**
\- the GitHub release is still be published via action-gh-release because I needed a different changelog for it.

closes #432 