### PR TITLE
Fixes error when the directory doesn't exist

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/ImageRepoLoader.java
+++ b/src/main/java/de/hysky/skyblocker/config/ImageRepoLoader.java
@@ -56,7 +56,7 @@ public class ImageRepoLoader {
 
 						//Delete all directories to clear potentially now unused/old files
 						//TODO change this to only delete periodically?
-						deleteDirectories();
+						if (Files.exists(REPO_DIRECTORY)) deleteDirectories();
 
 						try (ZipInputStream zis = new ZipInputStream(in)) {
 							ZipEntry entry;


### PR DESCRIPTION
I added this after I had first loaded it and didn't bother deleting the entire directory as part of testing so it went unseen.
Either way the repo loader will no longer throw an exception everytime if you didn't have the folder created.