### PR TITLE
Croesus Solver crash fix

### DIFF
--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
@@ -113,7 +113,7 @@ public class ContainerSolverManager {
         for (ColorHighlight highlight : highlights) {
             Slot slot = slots.get(highlight.slot());
             int color = highlight.color();
-            context.fillGradient(slot.x, slot.y, slot.x + 16, slot.y + 16, color, color);
+            context.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, color);
         }
         RenderSystem.colorMask(true, true, true, true);
     }

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
@@ -84,6 +84,7 @@ public class ContainerSolverManager {
                         groups[i] = matcher.group(i + 1);
                     }
                     currentSolver.start(screen);
+                    markDirty();
                     return;
                 }
             }


### PR DESCRIPTION
Possible fix for when you are such a gamer that you have too many runs in Croesus, you click on a run and it crashes.
[the report](https://discord.com/channels/879732108745125969/1222535599513276436)

Included in this PR is a quick change to the drawing of the highlighted slots, saves 4 arithmetic operations per slot or somethin like that.