### PR TITLE
Glacite Mining Updates & Fixes

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 
 public class DwarvenHud {
 
-    private static final MinecraftClient client = MinecraftClient.getInstance();
+    private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
     private static List<Commission> commissionList = new ArrayList<>();
 
     public static String mithrilPowder = "0";
@@ -33,18 +33,20 @@ public class DwarvenHud {
 
     private static final List<Pattern> COMMISSIONS = Stream.of(
                     "(?:Titanium|Mithril|Hard Stone) Miner",
-                    "(?:Ice Walker|Golden Goblin|(?<!Golden )Goblin|Goblin Raid|Automaton|Sludge|Team Treasurite Member|Yog|Boss Corleone|Thyst) Slayer",
+                    "(?:Ice Walker|Golden Goblin|(?<!Golden )Goblin|Goblin Raid|Treasure Hoarder|Automaton|Sludge|Team Treasurite Member|Yog|Boss Corleone|Thyst) Slayer",
                     "(?:Lava Springs|Cliffside Veins|Rampart's Quarry|Upper Mines|Royal Mines) Mithril",
                     "(?:Lava Springs|Cliffside Veins|Rampart's Quarry|Upper Mines|Royal Mines) Titanium",
                     "Goblin Raid",
-                    "(?:Powder Ghast|Star Sentry|Treasure Hoarder) Puncher",
+                    "(?:Star Sentry|Treasure Hoarder) Puncher",
                     "(?<!Lucky )Raffle",
                     "Lucky Raffle",
                     "2x Mithril Powder Collector",
                     "First Event",
                     "(?:Ruby|Amber|Sapphire|Jade|Amethyst|Topaz) Gemstone Collector",
                     "(?:Amber|Sapphire|Jade|Amethyst|Topaz) Crystal Hunter",
-                    "Chest Looter").map(s -> Pattern.compile("(" + s + "): (\\d+\\.?\\d*%|DONE)")
+                    "(?:Umber|Tungsten|Glacite|Scrap) Collector",
+                    "Mineshaft Explorer",
+                    "(?:Chest|Corpse) Looter").map(s -> Pattern.compile("(" + s + "): (\\d+\\.?\\d*%|DONE)")
             ).collect(Collectors.toList());
     private static final Pattern MITHRIL_PATTERN = Pattern.compile("Mithril: [0-9,]+");
     private static final Pattern GEMSTONE_PATTERN = Pattern.compile("Gemstone: [0-9,]+");
@@ -61,8 +63,8 @@ public class DwarvenHud {
 
         HudRenderCallback.EVENT.register((context, tickDelta) -> {
             if (!SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.enabledCommissions && !SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.enabledPowder
-                    || client.options.playerListKey.isPressed()
-                    || client.player == null
+                    || CLIENT.options.playerListKey.isPressed()
+                    || CLIENT.player == null
                     || (!Utils.isInDwarvenMines() && !Utils.isInCrystalHollows())) {
                 return;
             }
@@ -76,7 +78,7 @@ public class DwarvenHud {
         });
     }
 
-    public static void render(HudCommsWidget hcw, HudPowderWidget hpw, DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
+    protected static void render(HudCommsWidget hcw, HudPowderWidget hpw, DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
         switch (SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.style) {
             case SIMPLE -> renderSimple(hcw, hpw, context, comHudX, comHudY, powderHudX, powderHudY, commissions);
             case FANCY -> renderFancy(hcw, hpw, context, comHudX, comHudY, powderHudX, powderHudY, commissions);
@@ -93,7 +95,7 @@ public class DwarvenHud {
      * @param powderHudY Y coordinate of the powder hud
      * @param commissions the commissions to render to the commissions hud
      */
-    public static void renderClassic(DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
+    private static void renderClassic(DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
         if (SkyblockerConfigManager.get().general.tabHud.enableHudBackground) {
             context.fill(comHudX, comHudY, comHudX + 200, comHudY + (20 * commissions.size()), 0x64000000);
             context.fill(powderHudX, powderHudY, powderHudX + 200, powderHudY + 40, 0x64000000);
@@ -108,7 +110,7 @@ public class DwarvenHud {
                     percentage = 100f;
                 }
 
-                context.drawTextWithShadow(client.textRenderer,
+                context.drawTextWithShadow(CLIENT.textRenderer,
                         Text.literal(commission.commission + ": ").formatted(Formatting.AQUA)
                                 .append(Text.literal(commission.progression).formatted(Colors.hypixelProgressColor(percentage))),
                         comHudX + 5, comHudY + y + 5, 0xFFFFFFFF);
@@ -117,16 +119,16 @@ public class DwarvenHud {
         }
         if (SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.enabledPowder) {
             //render mithril powder then gemstone
-            context.drawTextWithShadow(client.textRenderer,
+            context.drawTextWithShadow(CLIENT.textRenderer,
                     Text.literal("Mithril: " + mithrilPowder).formatted(Formatting.AQUA),
                     powderHudX + 5, powderHudY + 5, 0xFFFFFFFF);
-            context.drawTextWithShadow(client.textRenderer,
+            context.drawTextWithShadow(CLIENT.textRenderer,
                     Text.literal("Gemstone: " + gemStonePowder).formatted(Formatting.DARK_PURPLE),
                     powderHudX + 5, powderHudY + 25, 0xFFFFFFFF);
         }
     }
 
-    public static void renderSimple(HudCommsWidget hcw, HudPowderWidget hpw, DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
+    private static void renderSimple(HudCommsWidget hcw, HudPowderWidget hpw, DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
         if (SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.enabledCommissions) {
             hcw.updateData(commissions, false);
             hcw.update();
@@ -142,7 +144,7 @@ public class DwarvenHud {
         }
     }
 
-    public static void renderFancy(HudCommsWidget hcw, HudPowderWidget hpw, DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
+    private static void renderFancy(HudCommsWidget hcw, HudPowderWidget hpw, DrawContext context, int comHudX, int comHudY, int powderHudX, int powderHudY, List<Commission> commissions) {
         if (SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.enabledCommissions) {
             hcw.updateData(commissions, true);
             hcw.update();
@@ -159,7 +161,7 @@ public class DwarvenHud {
     }
 
     public static void update() {
-        if (client.player == null || client.getNetworkHandler() == null
+        if (CLIENT.player == null || CLIENT.getNetworkHandler() == null
                 || !SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.enabledCommissions && !SkyblockerConfigManager.get().locations.dwarvenMines.dwarvenHud.enabledPowder
                 || !Utils.isInCrystalHollows() && !Utils.isInDwarvenMines()) {
             return;
@@ -167,7 +169,7 @@ public class DwarvenHud {
 
         commissionList = new ArrayList<>();
 
-        for (PlayerListEntry playerListEntry : client.getNetworkHandler().getPlayerList()) {
+        for (PlayerListEntry playerListEntry : CLIENT.getNetworkHandler().getPlayerList()) {
             if (playerListEntry.getDisplayName() == null) {
                 continue;
             }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/DwarvenHud.java
@@ -24,13 +24,14 @@ import java.util.stream.Stream;
 
 public class DwarvenHud {
 
-    public static final MinecraftClient client = MinecraftClient.getInstance();
-    public static List<Commission> commissionList = new ArrayList<>();
+    private static final MinecraftClient client = MinecraftClient.getInstance();
+    private static List<Commission> commissionList = new ArrayList<>();
 
     public static String mithrilPowder = "0";
     public static String gemStonePowder = "0";
+    public static String glacitePowder = "0";
 
-    public static final List<Pattern> COMMISSIONS = Stream.of(
+    private static final List<Pattern> COMMISSIONS = Stream.of(
                     "(?:Titanium|Mithril|Hard Stone) Miner",
                     "(?:Ice Walker|Golden Goblin|(?<!Golden )Goblin|Goblin Raid|Automaton|Sludge|Team Treasurite Member|Yog|Boss Corleone|Thyst) Slayer",
                     "(?:Lava Springs|Cliffside Veins|Rampart's Quarry|Upper Mines|Royal Mines) Mithril",
@@ -45,8 +46,9 @@ public class DwarvenHud {
                     "(?:Amber|Sapphire|Jade|Amethyst|Topaz) Crystal Hunter",
                     "Chest Looter").map(s -> Pattern.compile("(" + s + "): (\\d+\\.?\\d*%|DONE)")
             ).collect(Collectors.toList());
-    public static final Pattern MITHRIL_PATTERN = Pattern.compile("Mithril Powder: [0-9,]+");
-    public static final Pattern GEMSTONE_PATTERN = Pattern.compile("Gemstone Powder: [0-9,]+");
+    private static final Pattern MITHRIL_PATTERN = Pattern.compile("Mithril: [0-9,]+");
+    private static final Pattern GEMSTONE_PATTERN = Pattern.compile("Gemstone: [0-9,]+");
+    private static final Pattern GLACITE_PATTERN = Pattern.compile("Glacite: [0-9,]+");
 
     public static void init() {
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> dispatcher.register(ClientCommandManager.literal("skyblocker")
@@ -185,6 +187,10 @@ public class DwarvenHud {
             Matcher gemstoneMatcher = GEMSTONE_PATTERN.matcher(name);
             if (gemstoneMatcher.matches()) {
                 gemStonePowder = gemstoneMatcher.group(0).split(": ")[1];
+            }
+            Matcher glaciteMatcher = GLACITE_PATTERN.matcher(name);
+            if (glaciteMatcher.matches()) {
+                glacitePowder = glaciteMatcher.group(0).split(": ")[1];
             }
         }
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/Ico.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/Ico.java
@@ -72,4 +72,5 @@ public class Ico {
     public static final ItemStack LIME_DYE = new ItemStack(Items.LIME_DYE);
     public static final ItemStack ENCHANTED_BOOK = new ItemStack(Items.ENCHANTED_BOOK);
     public static final ItemStack SPIDER_EYE = new ItemStack(Items.SPIDER_EYE);
+    public static final ItemStack BLUE_ICE = new ItemStack(Items.BLUE_ICE);
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/PlayerLocator.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/PlayerLocator.java
@@ -27,6 +27,7 @@ public class PlayerLocator {
         INSTANCED("kuudra"),
         THE_RIFT("rift"),
         DARK_AUCTION("dark_auction"),
+        GLACITE_MINESHAFT("mineshaft"),
         UNKNOWN("unknown");
 
         public final String internal;

--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/hud/HudPowderWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/hud/HudPowderWidget.java
@@ -30,6 +30,10 @@ public class HudPowderWidget extends Widget {
      */
     private static int gemstonePowder = 0;
     /**
+     * current value of Glacite Powder
+     */
+    private static int glacitePowder = 0;
+    /**
      * the difference between the previous and current value of Mithril Powder
      */
     private static int mithrilPowderDiff = 0;
@@ -37,6 +41,10 @@ public class HudPowderWidget extends Widget {
      * the difference between the previous and current value of Gemstone Powder
      */
     private static int gemstonePowderDiff = 0;
+    /**
+     * the difference between the previous and current value of Glacite Powder
+     */
+    private static int glacitePowderDiff = 0;
     /**
      * The initial value of the timer for the difference update delay countdown.
      */
@@ -77,8 +85,8 @@ public class HudPowderWidget extends Widget {
     /**
      * Converts Powder and difference values to a string and adds commas to the digits of the numbers.
      *
-     * @param powder the value of Mithril or Gemstone Powder
-     * @param diff   the difference between the previous and current value of Mithril or Gemstone Powder
+     * @param powder the value of Mithril, Gemstone Powder, or Glacite Powder
+     * @param diff   the difference between the previous and current value of Mithril, Gemstone, or Glacite Powder
      * @return formatted string
      */
     private static String formatPowderString(int powder, int diff) {
@@ -94,15 +102,18 @@ public class HudPowderWidget extends Widget {
 
         int newMithrilPowder = parsePowder(DwarvenHud.mithrilPowder);
         int newGemstonePowder = parsePowder(DwarvenHud.gemStonePowder);
+        int newGlacitePowder = parsePowder(DwarvenHud.glacitePowder);
 
-        if (newMithrilPowder != mithrilPowder || newGemstonePowder != gemstonePowder || elapsedTime > 2000) {
+        if (newMithrilPowder != mithrilPowder || newGemstonePowder != gemstonePowder || newGlacitePowder != glacitePowder || elapsedTime > 2000) {
             startTime = System.currentTimeMillis();
 
             mithrilPowderDiff = newMithrilPowder - mithrilPowder;
             gemstonePowderDiff = newGemstonePowder - gemstonePowder;
+            glacitePowderDiff = newGlacitePowder - glacitePowder;
 
             mithrilPowder = newMithrilPowder;
             gemstonePowder = newGemstonePowder;
+            glacitePowder = newGlacitePowder;
         }
     }
 
@@ -111,9 +122,11 @@ public class HudPowderWidget extends Widget {
         updatePowders();
         String mithrilPowderString = formatPowderString(mithrilPowder, mithrilPowderDiff);
         String gemstonePowderString = formatPowderString(gemstonePowder, gemstonePowderDiff);
+        String glacitePowderString = formatPowderString(glacitePowder, glacitePowderDiff);
 
-        this.addSimpleIcoText(Ico.MITHRIL, "Mithril: ", Formatting.AQUA, mithrilPowderString);
+        this.addSimpleIcoText(Ico.MITHRIL, "Mithril: ", Formatting.DARK_GREEN, mithrilPowderString);
         this.addSimpleIcoText(Ico.AMETHYST_SHARD, "Gemstone: ", Formatting.DARK_PURPLE, gemstonePowderString);
+        this.addSimpleIcoText(Ico.BLUE_ICE, "Glacite: ", Formatting.AQUA, glacitePowderString);
     }
 
 }

--- a/src/main/java/de/hysky/skyblocker/utils/Location.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Location.java
@@ -83,7 +83,7 @@ public enum Location {
      */
     KUUDRAS_HOLLOW("kuudra"),
     /**
-     * 
+     * The freezing cold Glacite Mineshafts! *brr... so cold... :(*
      */
     GLACITE_MINESHAFT("mineshaft"),
     /**

--- a/src/main/java/de/hysky/skyblocker/utils/Location.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Location.java
@@ -83,6 +83,10 @@ public enum Location {
      */
     KUUDRAS_HOLLOW("kuudra"),
     /**
+     * 
+     */
+    GLACITE_MINESHAFT("mineshaft"),
+    /**
      * Unknown Skyblock location
      */
     UNKNOWN("unknown");

--- a/src/main/java/de/hysky/skyblocker/utils/Utils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Utils.java
@@ -98,7 +98,7 @@ public class Utils {
     }
 
     public static boolean isInDwarvenMines() {
-        return location == Location.DWARVEN_MINES || FabricLoader.getInstance().isDevelopmentEnvironment();
+        return location == Location.DWARVEN_MINES || location == Location.GLACITE_MINESHAFT || FabricLoader.getInstance().isDevelopmentEnvironment();
     }
 
     public static boolean isInTheRift() {


### PR DESCRIPTION
- Fixes the powder hud not working
- Add the glacite mineshafts as locations in our two enums & make mineshafts count as being in dwarven mines for our mining features to be active.
- Adds glacite powder to the powder hud.
- Recolour the Mithril powder to dark green to align with the tab in game, and because glacite's colour is light blue/aqua.
- Adds a new dwarven commission and removes an old one that was removed a long time ago.
- Adds (most of? all of?) the new glacite mining commissions
- Refactors the access modifiers of some methods, and rename the client constant to be in line with naming conventions.

Fixes #644.