### PR TITLE
Prevent teammates glow during Livid

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixin/WorldRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixin/WorldRendererMixin.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.mixin;
 
+import de.hysky.skyblocker.skyblock.dungeon.LividColor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -12,17 +13,22 @@ import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import de.hysky.skyblocker.skyblock.entity.MobGlow;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.injection.Slice;
 
 @Mixin(WorldRenderer.class)
 public class WorldRendererMixin {
 	@ModifyExpressionValue(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"))
 	private boolean skyblocker$shouldMobGlow(boolean original, @Local Entity entity, @Share("hasCustomGlow") LocalBooleanRef hasCustomGlow) {
+		boolean allowGlow = LividColor.allowGlow();
 		boolean shouldGlow = MobGlow.shouldMobGlow(entity);
 		hasCustomGlow.set(shouldGlow);
-		return original || shouldGlow;
+		return allowGlow && original || shouldGlow;
 	}
 
-	@ModifyVariable(method = "render", at = @At("STORE"), ordinal = 0)
+	@ModifyVariable(method = "render",
+			slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"), to = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/OutlineVertexConsumerProvider;setColor(IIII)V")),
+			at = @At("STORE"), ordinal = 0
+	)
 	private int skyblocker$modifyGlowColor(int color, @Local Entity entity, @Share("hasCustomGlow") LocalBooleanRef hasCustomGlow) {
 		return hasCustomGlow.get() ? MobGlow.getGlowColor(entity) : color;
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonBoss.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonBoss.java
@@ -1,0 +1,47 @@
+package de.hysky.skyblocker.skyblock.dungeon;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum DungeonBoss {
+    NONE(-1, ""),
+    BONZO(1, "[BOSS] Bonzo: Gratz for making it this far, but I'm basically unbeatable."),
+    SCARF(2, "[BOSS] Scarf: This is where the journey ends for you, Adventurers."),
+    PROFESSOR(3, "[BOSS] The Professor: I was burdened with terrible news recently..."),
+    THORN(4, "[BOSS] Thorn: Welcome Adventurers! I am Thorn, the Spirit! And host of the Vegan Trials!"),
+    LIVID(5, "[BOSS] Livid: Welcome, you've arrived right on time. I am Livid, the Master of Shadows."),
+    SADAN(6, "[BOSS] Sadan: So you made it all the way here... Now you wish to defy me? Sadan?!"),
+    MAXOR(7, "[BOSS] Maxor: WELL! WELL! WELL! LOOK WHO'S HERE!");
+
+    private static final Map<String, DungeonBoss> BOSSES = Arrays.stream(values()).collect(Collectors.toUnmodifiableMap(DungeonBoss::message, Function.identity()));
+
+    public final int floor;
+    public final String message;
+
+    DungeonBoss(int floor, String message) {
+        this.floor = floor;
+        this.message = message;
+    }
+
+    public int floor() {
+        return floor;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public boolean isInBoss() {
+        return this != NONE;
+    }
+
+    public boolean isFloor(int floor) {
+        return this.floor == floor;
+    }
+
+    public static DungeonBoss fromMessage(String message) {
+        return BOSSES.getOrDefault(message, NONE);
+    }
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonBoss.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonBoss.java
@@ -17,8 +17,8 @@ public enum DungeonBoss {
 
     private static final Map<String, DungeonBoss> BOSSES = Arrays.stream(values()).collect(Collectors.toUnmodifiableMap(DungeonBoss::message, Function.identity()));
 
-    public final int floor;
-    public final String message;
+    private final int floor;
+    private final String message;
 
     DungeonBoss(int floor, String message) {
         this.floor = floor;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.skyblock.dungeon;
 
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
@@ -11,7 +12,6 @@ import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.registry.Registries;
 import net.minecraft.text.MutableText;
-import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
 
@@ -89,6 +89,10 @@ public class LividColor {
             client.inGameHud.setTitle(message);
         }
         tenTicks = 0;
+    }
+
+    public static boolean allowGlow() {
+        return !SkyblockerConfigManager.get().locations.dungeons.lividColor.enableLividColorGlow || !DungeonManager.getBoss().isFloor(5);
     }
 
     public static boolean shouldGlow(String name) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonManager.java
@@ -15,6 +15,7 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.debug.Debug;
+import de.hysky.skyblocker.skyblock.dungeon.DungeonBoss;
 import de.hysky.skyblocker.skyblock.dungeon.DungeonMap;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Tickable;
@@ -148,7 +149,8 @@ public class DungeonManager {
     @Nullable
     private static Vector2ic physicalEntrancePos;
     private static Room currentRoom;
-    private static boolean inBoss;
+    @NotNull
+    private static DungeonBoss boss = DungeonBoss.NONE;
 
     public static boolean isRoomsLoaded() {
         return roomsLoaded != null && roomsLoaded.isDone();
@@ -201,12 +203,20 @@ public class DungeonManager {
         return customWaypoints.remove(room, pos);
     }
 
+    /**
+     * not null if {@link #isCurrentRoomMatched()}
+     */
     public static Room getCurrentRoom() {
         return currentRoom;
     }
 
+    @NotNull
+    public static DungeonBoss getBoss() {
+        return boss;
+    }
+
     public static boolean isInBoss() {
-        return inBoss;
+        return boss.isInBoss();
     }
 
     /**
@@ -643,12 +653,10 @@ public class DungeonManager {
             }
         }
 
-        if (message.equals("[BOSS] Bonzo: Gratz for making it this far, but I'm basically unbeatable.") || message.equals("[BOSS] Scarf: This is where the journey ends for you, Adventurers.")
-                || message.equals("[BOSS] The Professor: I was burdened with terrible news recently...") || message.equals("[BOSS] Thorn: Welcome Adventurers! I am Thorn, the Spirit! And host of the Vegan Trials!")
-                || message.equals("[BOSS] Livid: Welcome, you've arrived right on time. I am Livid, the Master of Shadows.") || message.equals("[BOSS] Sadan: So you made it all the way here... Now you wish to defy me? Sadan?!")
-                || message.equals("[BOSS] Maxor: WELL! WELL! WELL! LOOK WHO'S HERE!")) {
+        var newBoss = DungeonBoss.fromMessage(message);
+        if (!isInBoss() && newBoss.isInBoss()) {
             reset();
-            inBoss = true;
+            boss = newBoss;
         }
     }
 
@@ -762,6 +770,6 @@ public class DungeonManager {
         physicalEntrancePos = null;
         rooms.clear();
         currentRoom = null;
-        inBoss = false;
+        boss = DungeonBoss.NONE;
     }
 }


### PR DESCRIPTION
Prevents anything other than Livid or other explicitly glowing mobs to glow.  
Adds `DungeonBoss` to check for boss. See `DungeonManager.isInBoss()` and `DungeonManager.getBoss()`.  

Hopefully doesn't conflict with Aaron's #647.  

<img width="1440" alt="Screenshot 2024-04-15 at 00 02 35" src="https://github.com/SkyblockerMod/Skyblocker/assets/92656833/9c088972-72a4-48f1-84ab-5a43f465e4b4">
