### PR TITLE
Fix shortcuts not being deleted

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -238,7 +238,7 @@ public class ShortcutsConfigListWidget extends ElementListWidget<ShortcutsConfig
         }
 
         public void removeFromMap() {
-            category.shortcutsMap.remove(target.getText(), replacement.getText());
+            category.shortcutsMap.remove(target.getText());
         }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -236,5 +236,9 @@ public class ShortcutsConfigListWidget extends ElementListWidget<ShortcutsConfig
             replacement.render(context, mouseX, mouseY, tickDelta);
             context.drawCenteredTextWithShadow(client.textRenderer, "→", width / 2, y + 5, 0xFFFFFF);
         }
+
+        public void removeFromMap() {
+            category.shortcutsMap.remove(target.getText(), replacement.getText());
+        }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
@@ -72,6 +72,7 @@ public class ShortcutsConfigScreen extends Screen {
         if (client != null) {
             if (confirmedAction && shortcutsConfigListWidget.getSelectedOrNull() instanceof ShortcutsConfigListWidget.ShortcutEntry shortcutEntry) {
                 shortcutsConfigListWidget.removeEntry(shortcutEntry);
+                shortcutEntry.removeFromMap();
             }
             client.setScreen(this); // Re-inits the screen and keeps the old instance of ShortcutsConfigListWidget
             shortcutsConfigListWidget.setScrollAmount(scrollAmount);


### PR DESCRIPTION
Fixes a silly bug where you can't delete shortcuts.

Was caused by creating a new instance of the list widget in the init. When you click on delete in the confirm screen, the entry gets deleted from the list widget but not the map. So when a new instance is created when going back the config screen, it just recreates the entry.
Fixed it by making it remove it from the map right after removing the entry