### PR TITLE
Fix delete shortcut

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -70,6 +70,12 @@ public class ShortcutsConfigListWidget extends ElementListWidget<ShortcutsConfig
         getCategory().ifPresent(category -> children().add(children().indexOf(getSelectedOrNull()) + 1, new ShortcutEntry(category)));
     }
 
+    protected void updatePositions() {
+        for (AbstractShortcutEntry child : children()) {
+            child.updatePositions();
+        }
+    }
+
     @Override
     protected boolean removeEntry(AbstractShortcutEntry entry) {
         return super.removeEntry(entry);
@@ -90,10 +96,11 @@ public class ShortcutsConfigListWidget extends ElementListWidget<ShortcutsConfig
         return children().stream().filter(ShortcutEntry.class::isInstance).map(ShortcutEntry.class::cast).filter(ShortcutEntry::isNotEmpty);
     }
 
-    protected static abstract class AbstractShortcutEntry extends ElementListWidget.Entry<AbstractShortcutEntry> {
+    public static abstract class AbstractShortcutEntry extends ElementListWidget.Entry<AbstractShortcutEntry> {
+        protected void updatePositions() {}
     }
 
-    private class ShortcutCategoryEntry extends AbstractShortcutEntry {
+    protected class ShortcutCategoryEntry extends AbstractShortcutEntry {
         private final Map<String, String> shortcutsMap;
         private final Text targetName;
         private final Text replacementName;
@@ -235,6 +242,13 @@ public class ShortcutsConfigListWidget extends ElementListWidget<ShortcutsConfig
             target.render(context, mouseX, mouseY, tickDelta);
             replacement.render(context, mouseX, mouseY, tickDelta);
             context.drawCenteredTextWithShadow(client.textRenderer, "→", width / 2, y + 5, 0xFFFFFF);
+        }
+
+        @Override
+        protected void updatePositions() {
+            super.updatePositions();
+            target.setX(width / 2 - 160);
+            replacement.setX(width / 2 + 10);
         }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
@@ -16,11 +16,12 @@ public class ShortcutsConfigScreen extends Screen {
     private ButtonWidget buttonDelete;
     private ButtonWidget buttonNew;
     private ButtonWidget buttonDone;
+    private boolean initialized;
     private double scrollAmount;
     private final Screen parent;
 
     public ShortcutsConfigScreen() {
-    	this(null);
+        this(null);
     }
 
     public ShortcutsConfigScreen(Screen parent) {
@@ -36,7 +37,13 @@ public class ShortcutsConfigScreen extends Screen {
     @Override
     protected void init() {
         super.init();
-        shortcutsConfigListWidget = new ShortcutsConfigListWidget(client, this, width, height - 96, 32, 25);
+        if (initialized) {
+            shortcutsConfigListWidget.setDimensions(width, height - 96);
+            shortcutsConfigListWidget.updatePositions();
+        } else {
+            shortcutsConfigListWidget = new ShortcutsConfigListWidget(client, this, width, height - 96, 32, 25);
+            initialized = true;
+        }
         addDrawableChild(shortcutsConfigListWidget);
         GridWidget gridWidget = new GridWidget();
         gridWidget.getMainPositioner().marginX(5).marginY(2);
@@ -44,7 +51,7 @@ public class ShortcutsConfigScreen extends Screen {
         buttonDelete = ButtonWidget.builder(Text.translatable("selectServer.delete"), button -> {
             if (client != null && shortcutsConfigListWidget.getSelectedOrNull() instanceof ShortcutsConfigListWidget.ShortcutEntry shortcutEntry) {
                 scrollAmount = shortcutsConfigListWidget.getScrollAmount();
-                client.setScreen(new ConfirmScreen(this::deleteEntry, Text.translatable("skyblocker.shortcuts.deleteQuestion"), Text.translatable("skyblocker.shortcuts.deleteWarning", shortcutEntry), Text.translatable("selectServer.deleteButton"), ScreenTexts.CANCEL));
+                client.setScreen(new ConfirmScreen(this::deleteEntry, Text.translatable("skyblocker.shortcuts.deleteQuestion"), Text.stringifiedTranslatable("skyblocker.shortcuts.deleteWarning", shortcutEntry), Text.translatable("selectServer.deleteButton"), ScreenTexts.CANCEL));
             }
         }).build();
         adder.add(buttonDelete);
@@ -86,16 +93,18 @@ public class ShortcutsConfigScreen extends Screen {
 
     @Override
     public void close() {
-        if (client != null && shortcutsConfigListWidget.hasChanges()) {
-            client.setScreen(new ConfirmScreen(confirmedAction -> {
-                if (confirmedAction) {
-                    this.client.setScreen(parent);
-                } else {
-                    client.setScreen(this);
-                }
-            }, Text.translatable("text.skyblocker.quit_config"), Text.translatable("text.skyblocker.quit_config_sure"), Text.translatable("text.skyblocker.quit_discard"), ScreenTexts.CANCEL));
-        } else {
-            this.client.setScreen(parent);
+        if (client != null) {
+            if (shortcutsConfigListWidget.hasChanges()) {
+                client.setScreen(new ConfirmScreen(confirmedAction -> {
+                    if (confirmedAction) {
+                        this.client.setScreen(parent);
+                    } else {
+                        client.setScreen(this);
+                    }
+                }, Text.translatable("text.skyblocker.quit_config"), Text.translatable("text.skyblocker.quit_config_sure"), Text.translatable("text.skyblocker.quit_discard"), ScreenTexts.CANCEL));
+            } else {
+                this.client.setScreen(parent);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes delete shortcut by keeping ShortcutsConfigListWidget instance across initializations and updating text field positions.  

Reverts 46ef432.  

Supercedes #659.  

Refactor Shortcuts.  