### PR TITLE
Fix update repository

### DIFF
--- a/src/main/java/de/hysky/skyblocker/utils/FileUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/FileUtils.java
@@ -28,9 +28,9 @@ public class FileUtils {
 			}
 		}
 
-        if (!Files.isWritable(dir) && !dir.toFile().setWritable(true)) {
-            LOGGER.error("[Skyblocker] Failed to make file writable. Path: {}", dir.toAbsolutePath());
-        }
+		if (!Files.isWritable(dir) && !dir.toFile().setWritable(true)) {
+			LOGGER.error("[Skyblocker] Failed to make file writable. Path: {}", dir.toAbsolutePath());
+		}
 
 		Files.delete(dir);
 	}

--- a/src/main/java/de/hysky/skyblocker/utils/FileUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/FileUtils.java
@@ -1,37 +1,43 @@
 package de.hysky.skyblocker.utils;
 
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import org.slf4j.Logger;
-
-import com.mojang.logging.LogUtils;
+import java.util.stream.Stream;
 
 public class FileUtils {
 	private static final Logger LOGGER = LogUtils.getLogger();
 
 	public static void recursiveDelete(Path dir) throws IOException {
-		if (Files.isDirectory(dir) && !Files.isSymbolicLink(dir)) {
-			Files.list(dir).forEach(child -> {
-				try {
-					recursiveDelete(child);
-				} catch (Exception e) {
-					LOGGER.error("[Skyblocker] Encountered an exception while deleting a file! Path: {}", child.toAbsolutePath(), e);
-				}
-			});
+		if (!Files.exists(dir)) {
+			return;
 		}
 
-		if (!Files.isWritable(dir)) {
-			dir.toFile().setWritable(true);
+		if (Files.isDirectory(dir) && !Files.isSymbolicLink(dir)) {
+			try (Stream<Path> stream = Files.list(dir)) {
+				stream.forEach(child -> {
+					try {
+						recursiveDelete(child);
+					} catch (Exception e) {
+						LOGGER.error("[Skyblocker] Encountered an exception while deleting a file. Path: {}", child.toAbsolutePath(), e);
+					}
+				});
+			}
 		}
+
+        if (!Files.isWritable(dir) && !dir.toFile().setWritable(true)) {
+            LOGGER.error("[Skyblocker] Failed to make file writable. Path: {}", dir.toAbsolutePath());
+        }
 
 		Files.delete(dir);
 	}
 
 	/**
 	 * Replaces any characters that do not match the regex: [^a-z0-9_.-]
-	 * 
+	 *
 	 * @implNote Designed to convert a file path to an {@link net.minecraft.util.Identifier}
 	 */
 	public static String normalizePath(Path path) {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -506,7 +506,7 @@
   "skyblocker.updateRepository.deleted": "§bDeleted the local repository successfully, downloading new files... This will take a minute!",
   "skyblocker.updateRepository.success": "§aUpdated the local repository successfully.",
   "skyblocker.updateRepository.failed": "§cUpdating the local repository failed. See logs for details.",
-  "skyblocker.updateRepository.error":  "§cEncountered an error while deleting and updating the local repository. Try again in a moment or remove files manually and restart game. See logs for details.",
+  "skyblocker.updateRepository.error":  "§cEncountered an error while deleting and updating the local repository. Try again in a moment or remove the files manually and restart the game. See logs for details.",
 
   "skyblocker.dungeons.secrets.physicalEntranceNotFound": "§cDungeon Entrance Room coordinates not found. Please go back to the green Entrance Room.",
   "skyblocker.dungeons.secrets.markSecretFound": "§rMarked secret #%d as found.",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -501,12 +501,12 @@
   "skyblocker.bars.config.explanationTitle": "What is this?",
   "skyblocker.bars.config.explanation": "Welcome to the status bars config screen!\n\nDrag and drop the bars to snap them to an anchor (white squares) or existing bars.\nYou can right click them to edit a bunch of properties.\nBy hovering your mouse between 2 bars (your cursor should change), you can resize them.\n\nEverything is saved when you leave",
 
-  "skyblocker.updateRepository.start": "§bUpdating local repository...",
-  "skyblocker.updateRepository.loading": "§cLocal repository is currently being updated by another process, please try again in a moment.",
-  "skyblocker.updateRepository.deleted": "§bDeleted local repository successfully, downloading new files... This will take a minute!",
-  "skyblocker.updateRepository.success": "§aUpdated local repository successfully.",
-  "skyblocker.updateRepository.failed": "§cUpdating local repository failed. See logs for details.",
-  "skyblocker.updateRepository.error":  "§cEncountered an error while deleting and updating local repository. Try again in a moment or remove files manually and restart game. See logs for details.",
+  "skyblocker.updateRepository.start": "§bUpdating the local repository...",
+  "skyblocker.updateRepository.loading": "§cThe local repository is currently being updated by another process, please try again in a moment.",
+  "skyblocker.updateRepository.deleted": "§bDeleted the local repository successfully, downloading new files... This will take a minute!",
+  "skyblocker.updateRepository.success": "§aUpdated the local repository successfully.",
+  "skyblocker.updateRepository.failed": "§cUpdating the local repository failed. See logs for details.",
+  "skyblocker.updateRepository.error":  "§cEncountered an error while deleting and updating the local repository. Try again in a moment or remove files manually and restart game. See logs for details.",
 
   "skyblocker.dungeons.secrets.physicalEntranceNotFound": "§cDungeon Entrance Room coordinates not found. Please go back to the green Entrance Room.",
   "skyblocker.dungeons.secrets.markSecretFound": "§rMarked secret #%d as found.",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -501,7 +501,12 @@
   "skyblocker.bars.config.explanationTitle": "What is this?",
   "skyblocker.bars.config.explanation": "Welcome to the status bars config screen!\n\nDrag and drop the bars to snap them to an anchor (white squares) or existing bars.\nYou can right click them to edit a bunch of properties.\nBy hovering your mouse between 2 bars (your cursor should change), you can resize them.\n\nEverything is saved when you leave",
 
-  "skyblocker.updaterepository.failed":  "§cUpdating local repository failed. Remove files manually and restart game.",
+  "skyblocker.updateRepository.start": "§bUpdating local repository...",
+  "skyblocker.updateRepository.loading": "§cLocal repository is currently being updated by another process, please try again in a moment.",
+  "skyblocker.updateRepository.deleted": "§bDeleted local repository successfully, downloading new files... This will take a minute!",
+  "skyblocker.updateRepository.success": "§aUpdated local repository successfully.",
+  "skyblocker.updateRepository.failed": "§cUpdating local repository failed. See logs for details.",
+  "skyblocker.updateRepository.error":  "§cEncountered an error while deleting and updating local repository. Try again in a moment or remove files manually and restart game. See logs for details.",
 
   "skyblocker.dungeons.secrets.physicalEntranceNotFound": "§cDungeon Entrance Room coordinates not found. Please go back to the green Entrance Room.",
   "skyblocker.dungeons.secrets.markSecretFound": "§rMarked secret #%d as found.",

--- a/src/main/resources/assets/skyblocker/lang/es_es.json
+++ b/src/main/resources/assets/skyblocker/lang/es_es.json
@@ -71,7 +71,7 @@
     "text.autoconfig.skyblocker.option.messages.hideAOTE": "Ocultar Mensajes de la AOTE",
     "text.autoconfig.skyblocker.option.messages.hideMana": "Ocultar los Mensajes del Consumo de Maná de la Barra de Acción",
     "text.autoconfig.skyblocker.option.messages.hideMana.@Tooltip": "Da una mejor experiencia con FancyBar",
-    "skyblocker.updaterepository.failed": "§cLa actualización del repositorio local fallo. Elimina los archivos manualmente y reinicia el juego.",
+    "skyblocker.updateRepository.error": "§cLa actualización del repositorio local fallo. Elimina los archivos manualmente y reinicia el juego.",
     "text.autoconfig.skyblocker.option.general.shortcuts.enableShortcuts": "Habilitar atajos",
     "text.autoconfig.skyblocker.option.general.shortcuts.enableShortcuts.@Tooltip": "Solo funciona en Hypixel. Edita atajos ejecutando \"/skyblocker shortcuts\". Al menos una de las siguientes opciones debe ser activada para surgir efecto.",
     "text.autoconfig.skyblocker.option.general.shortcuts": "Atajos",

--- a/src/main/resources/assets/skyblocker/lang/fr_fr.json
+++ b/src/main/resources/assets/skyblocker/lang/fr_fr.json
@@ -91,7 +91,7 @@
     "text.autoconfig.skyblocker.option.richPresence.info.LOCATION": "LIEU",
     "text.autoconfig.skyblocker.category.quickNav": "Navigation rapide",
     "text.autoconfig.skyblocker.option.quickNav.enableQuickNav": "Activer la navigation rapide",
-    "skyblocker.updaterepository.failed": "§cLa mise à jour de la repository a échoué. Supprimez les fichiers manuellement et relancez le jeu.",
+    "skyblocker.updateRepository.error": "§cLa mise à jour de la repository a échoué. Supprimez les fichiers manuellement et relancez le jeu.",
     "skyblocker.fishing.reelNow": "Enroulez la ligne !",
     "text.autoconfig.skyblocker.option.general.fishing.enableFishingHelper": "Activer l'assistant de pêche",
     "text.autoconfig.skyblocker.option.general.fishing": "Assistant de pêche",

--- a/src/main/resources/assets/skyblocker/lang/pt_br.json
+++ b/src/main/resources/assets/skyblocker/lang/pt_br.json
@@ -148,7 +148,7 @@
     "text.autoconfig.skyblocker.option.general.itemTooltip.enableMotesPrice.@Tooltip": "Mostrar os preços de venda dos Motes de um item enquanto está no The Rift.",
     "text.autoconfig.skyblocker.option.general.itemInfoDisplay.attributeShardInfo.@Tooltip": "Mostra o nível do atributo como uma contagem de stack e os iniciais do nome do atributo.",
     "text.autoconfig.skyblocker.category.slayer": "Slayers",
-    "skyblocker.updaterepository.failed": "§cAtualização do repositório local falhou. Remova os arquivos manualmente e reinicie o jogo.",
+    "skyblocker.updateRepository.error": "§cAtualização do repositório local falhou. Remova os arquivos manualmente e reinicie o jogo.",
     "text.autoconfig.skyblocker.option.general.hideStatusEffectOverlay": "Esconder Overlay de Status de Efeitos",
     "text.autoconfig.skyblocker.option.general.itemList.enableItemList": "Ativar Lista de Itens",
     "text.autoconfig.skyblocker.option.general.itemList": "Lista de Itens",

--- a/src/main/resources/assets/skyblocker/lang/ru_ru.json
+++ b/src/main/resources/assets/skyblocker/lang/ru_ru.json
@@ -96,7 +96,7 @@
     "text.autoconfig.skyblocker.option.locations.barn.solveTreasureHunter": "Показывать Решение Treasure Hunter",
     "text.autoconfig.skyblocker.option.messages.chatFilterResult.FILTER": "Скрыть",
     "text.autoconfig.skyblocker.option.messages.chatFilterResult.PASS": "Не скрывать",
-    "skyblocker.updaterepository.failed": "§cОшибка в обновлении местного репозитория. Перезапустите игру, удалив файлы вручную.",
+    "skyblocker.updateRepository.error": "§cОшибка в обновлении местного репозитория. Перезапустите игру, удалив файлы вручную.",
     "text.autoconfig.skyblocker.option.richPresence.info.BITS": "BITS",
     "text.autoconfig.skyblocker.option.locations.dungeons.croesusHelper": "Помощь в меню Croesus",
     "text.autoconfig.skyblocker.option.general.experiments": "Помощь в Экспериментах",

--- a/src/main/resources/assets/skyblocker/lang/tr_tr.json
+++ b/src/main/resources/assets/skyblocker/lang/tr_tr.json
@@ -55,7 +55,7 @@
     "text.autoconfig.skyblocker.option.general.bars.barpositions.defenceBarPosition": "Defans barı konumu",
     "text.autoconfig.skyblocker.option.general.bars.barpositions.experienceBarPosition": "Tecrübe barı konumu",
     "key.categories.skyblocker": "Skyblocker",
-    "skyblocker.updaterepository.failed": "§cYerel depo güncellenemedi. Dosyaları manuel olarak silip oyunu tekrar başlatın.",
+    "skyblocker.updateRepository.error": "§cYerel depo güncellenemedi. Dosyaları manuel olarak silip oyunu tekrar başlatın.",
     "text.autoconfig.skyblocker.option.general.fishing": "Balık Tutma Yardımcısı",
     "text.autoconfig.skyblocker.option.general.fishing.enableFishingHelper": "Balık tutma yardımcısını aktifleştir",
     "text.autoconfig.skyblocker.category.messages": "Mesajlar",

--- a/src/main/resources/assets/skyblocker/lang/zh_cn.json
+++ b/src/main/resources/assets/skyblocker/lang/zh_cn.json
@@ -81,7 +81,7 @@
     "text.autoconfig.skyblocker.option.messages.hideMana.@Tooltip": "已被更好的属性条代替",
     "text.autoconfig.skyblocker.option.general.hideEmptyTooltips": "隐藏菜单中分隔符的物品信息",
     "text.autoconfig.skyblocker.option.locations.dungeons.mapScaling": "地图界面大小",
-    "skyblocker.updaterepository.failed": "§c更新本地数据存储库失败，请手动删除文件并重启游戏。",
+    "skyblocker.updateRepository.error": "§c更新本地数据存储库失败，请手动删除文件并重启游戏。",
     "text.autoconfig.skyblocker.option.general.fishing": "钓鱼助手",
     "text.autoconfig.skyblocker.option.general.fishing.enableFishingHelper": "启用钓鱼助手",
     "skyblocker.fishing.reelNow": "收竿！",

--- a/src/main/resources/assets/skyblocker/lang/zh_tw.json
+++ b/src/main/resources/assets/skyblocker/lang/zh_tw.json
@@ -415,7 +415,7 @@
     "text.autoconfig.skyblocker.option.general.teleportOverlay": "傳送類型技能目標位置顯示",
     "text.autoconfig.skyblocker.option.richPresence.info": "Skyblock訊息",
     "text.autoconfig.skyblocker.option.richPresence.cycleMode": "循環Skyblock訊息",
-    "skyblocker.updaterepository.failed": "§c更新本機資料儲存庫失敗，請手動刪除檔案並重新啟動遊戲。",
+    "skyblocker.updateRepository.error": "§c更新本機資料儲存庫失敗，請手動刪除檔案並重新啟動遊戲。",
     "skyblocker.dungeons.secrets.markSecretFoundUnable": "§c無法將秘密 #%d 標記為已找到。",
     "skyblocker.dungeons.secrets.markSecretMissingUnable": "§c無法將秘密 #%d 標記為已忽略。",
     "skyblocker.dungeons.dungeonScore.scoreText": "分數：%s",


### PR DESCRIPTION
Fix update repository and recursive delete with a big semaphore/lock.

Add extensive error handling and user feedback.

<details><summary>Testing Logs</summary>
The <code>TransportException</code> comes from me intentionally turning off my internet to test.
<p>
<pre>
/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home/bin/java -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:50638,suspend=y,server=n -Dmixin.debug.export=true -Dfabric.dli.config=/Users/********/Documents/Computer/Java/Skyblocker/.gradle/loom-cache/launch.cfg -Dfabric.dli.env=client -XstartOnFirstThread -Dfabric.dli.main=net.fabricmc.loader.impl.launch.knot.KnotClient -javaagent:/Users/********/Library/Caches/JetBrains/IntelliJIdea2024.1/captureAgent/debugger-agent.jar=file:/private/var/folders/3z/rw5w8mxn1tz2n9r7c9q9jzrw0000gp/T/capture.props -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 @/private/var/folders/3z/rw5w8mxn1tz2n9r7c9q9jzrw0000gp/T/idea_arg_file485604879 net.fabricmc.devlaunchinjector.Main
Connected to the target VM, address: '127.0.0.1:50638', transport: 'socket'
[15:44:36] [main/INFO] (FabricLoader/GameProvider) Loading Minecraft 1.20.4 with Fabric Loader 0.15.1
[15:44:37] [main/INFO] (FabricLoader) Loading 61 mods:
	- authme 8.0.0+1.20.4
	   \-- cloth-config 13.0.114
	        \-- cloth-basic-math 0.6.1
	- fabric-api 0.92.0+1.20.4
	- fabric-api-base 0.4.35+78d798af4f
	- fabric-api-lookup-api-v1 1.6.45+78d798af4f
	- fabric-biome-api-v1 13.0.15+78d798af4f
	- fabric-block-api-v1 1.0.14+78d798af4f
	- fabric-block-view-api-v2 1.0.3+78d798af4f
	- fabric-blockrenderlayer-v1 1.1.45+78d798af4f
	- fabric-client-tags-api-v1 1.1.6+78d798af4f
	- fabric-command-api-v1 1.2.40+f71b366f4f
	- fabric-command-api-v2 2.2.19+78d798af4f
	- fabric-commands-v0 0.2.57+df3654b34f
	- fabric-containers-v0 0.1.81+df3654b34f
	- fabric-content-registries-v0 5.0.9+78d798af4f
	- fabric-convention-tags-v1 1.5.9+78d798af4f
	- fabric-crash-report-info-v1 0.2.22+78d798af4f
	- fabric-data-generation-api-v1 13.1.17+78d798af4f
	- fabric-dimensions-v1 2.1.60+78d798af4f
	- fabric-entity-events-v1 1.5.28+4ced05924f
	- fabric-events-interaction-v0 0.7.0+389931eb4f
	- fabric-events-lifecycle-v0 0.2.71+df3654b34f
	- fabric-game-rule-api-v1 1.0.45+78d798af4f
	- fabric-gametest-api-v1 1.2.19+78d798af4f
	- fabric-item-api-v1 2.1.34+78d798af4f
	- fabric-item-group-api-v1 4.0.20+78d798af4f
	- fabric-key-binding-api-v1 1.0.40+78d798af4f
	- fabric-keybindings-v0 0.2.38+df3654b34f
	- fabric-lifecycle-events-v1 2.2.29+78d798af4f
	- fabric-loot-api-v2 2.1.4+78d798af4f
	- fabric-message-api-v1 6.0.4+78d798af4f
	- fabric-mining-level-api-v1 2.1.59+78d798af4f
	- fabric-model-loading-api-v1 1.0.7+78d798af4f
	- fabric-models-v0 0.4.6+9386d8a74f
	- fabric-networking-api-v1 3.1.2+78d798af4f
	- fabric-object-builder-api-v1 13.0.8+06274a474f
	- fabric-particles-v1 1.1.6+78d798af4f
	- fabric-recipe-api-v1 2.0.15+78d798af4f
	- fabric-registry-sync-v0 4.0.13+78d798af4f
	- fabric-renderer-api-v1 3.2.3+78d798af4f
	- fabric-renderer-indigo 1.5.3+78d798af4f
	- fabric-renderer-registries-v1 3.2.50+df3654b34f
	- fabric-rendering-data-attachment-v1 0.3.41+73761d2e4f
	- fabric-rendering-fluids-v1 3.0.32+78d798af4f
	- fabric-rendering-v0 1.1.53+df3654b34f
	- fabric-rendering-v1 3.0.12+78d798af4f
	- fabric-resource-conditions-api-v1 2.3.13+78d798af4f
	- fabric-resource-loader-v0 0.11.15+78d798af4f
	- fabric-screen-api-v1 2.0.16+78d798af4f
	- fabric-screen-handler-api-v1 1.3.50+78d798af4f
	- fabric-sound-api-v1 1.0.16+78d798af4f
	- fabric-transfer-api-v1 4.0.6+78d798af4f
	- fabric-transitive-access-wideners-v1 5.0.13+78d798af4f
	- fabricloader 0.15.1
	- java 21
	- minecraft 1.20.4
	- mixinextras 0.3.1
	- modmenu 9.0.0-alpha.3
	- skyblocker 1.19.1+1.20.4
	- yet_another_config_lib_v3 3.3.2+1.20.4
[15:44:41] [main/INFO] (FabricLoader/Mixin) SpongePowered MIXIN Subsystem Version=0.8.5 Source=file:/Users/********/.gradle/caches/modules-2/files-2.1/net.fabricmc/sponge-mixin/0.12.5+mixin.0.8.5/8d31fb97c3e0cd7c8dad3441851c523bcfae6d8e/sponge-mixin-0.12.5+mixin.0.8.5.jar Service=Knot/Fabric Env=CLIENT
/******************************************************************************************************************************************************************************************************************************************/
/*                                                                                                          SpongePowered MIXIN                                                                                                           */
/******************************************************************************************************************************************************************************************************************************************/
/*                                         Code source : file:/Users/********/.gradle/caches/modules-2/files-2.1/net.fabricmc/sponge-mixin/0.12.5+mixin.0.8.5/8d31fb97c3e0cd7c8dad3441851c523bcfae6d8e/sponge-mixin-0.12.5+mixin.0.8.5.jar */
/*                                    Internal Version : 0.8.5                                                                                                                                                                            */
/*                                        Java Version : 21.0 (supports compatibility 6-18)                                                                                                                                               */
/*                         Default Compatibility Level : JAVA_8                                                                                                                                                                           */
/*                                Detected ASM Version : ASM 9.6 (ASM10_EXPERIMENTAL)                                                                                                                                                     */
/*                          Detected ASM Supports Java : Up to Java 22 (class file version 66.0)                                                                                                                                          */
/******************************************************************************************************************************************************************************************************************************************/
/*                                        Service Name : Knot/Fabric                                                                                                                                                                      */
/*                                 Mixin Service Class : net.fabricmc.loader.impl.launch.knot.MixinServiceKnot                                                                                                                            */
/*                       Global Property Service Class : net.fabricmc.loader.impl.launch.knot.FabricGlobalPropertyService                                                                                                                 */
/*                                 Logger Adapter Type : Fabric Mixin Logger                                                                                                                                                              */
/******************************************************************************************************************************************************************************************************************************************/
/*                                         mixin.debug : <false>                                                                                                                                                                          */
/*                                  mixin.debug.export : - <true>                                                                                                                                                                         */
/*                           mixin.debug.export.filter : - - <null>                                                                                                                                                                       */
/*                        mixin.debug.export.decompile : - - <true>                                                                                                                                                                       */
/*                  mixin.debug.export.decompile.async : - - - <true>                                                                                                                                                                     */
/* mixin.debug.export.decompile.mergeGenericSignatures : - - - <true>                                                                                                                                                                     */
/*                                  mixin.debug.verify : - <false>                                                                                                                                                                        */
/*                                 mixin.debug.verbose : - <false>                                                                                                                                                                        */
/*                         mixin.debug.countInjections : - <false>                                                                                                                                                                        */
/*                                  mixin.debug.strict : - <false>                                                                                                                                                                        */
/*                           mixin.debug.strict.unique : - - <false>                                                                                                                                                                      */
/*                          mixin.debug.strict.targets : - - <false>                                                                                                                                                                      */
/*                                mixin.debug.profiler : - <false>                                                                                                                                                                        */
/*                           mixin.dumpTargetOnFailure : <false>                                                                                                                                                                          */
/*                                        mixin.checks : <false>                                                                                                                                                                          */
/*                             mixin.checks.interfaces : - <false>                                                                                                                                                                        */
/*                      mixin.checks.interfaces.strict : - - <false>                                                                                                                                                                      */
/*                             mixin.ignoreConstraints : <false>                                                                                                                                                                          */
/*                                       mixin.hotSwap : <false>                                                                                                                                                                          */
/*                                           mixin.env : <false>                                                                                                                                                                          */
/*                                       mixin.env.obf : - <false>                                                                                                                                                                        */
/*                             mixin.env.disableRefMap : - <false>                                                                                                                                                                        */
/*                               mixin.env.remapRefMap : - <false>                                                                                                                                                                        */
/*                       mixin.env.refMapRemappingFile : - <>                                                                                                                                                                             */
/*                        mixin.env.refMapRemappingEnv : - <searge>                                                                                                                                                                       */
/*                      mixin.env.allowPermissiveMatch : - <false>                                                                                                                                                                        */
/*                            mixin.env.ignoreRequired : - <false>                                                                                                                                                                        */
/*                               mixin.env.compatLevel : - <false>                                                                                                                                                                        */
/*                          mixin.env.shiftByViolation : - <warn>                                                                                                                                                                         */
/*                      mixin.initialiserInjectionMode : <default>                                                                                                                                                                        */
/******************************************************************************************************************************************************************************************************************************************/
/*                                       Detected Side : CLIENT                                                                                                                                                                           */
/******************************************************************************************************************************************************************************************************************************************/
[15:44:41] [main/INFO] (FabricLoader/Mixin) Attempting to load Fernflower decompiler (Threaded mode)
[15:44:41] [main/INFO] (FabricLoader/Mixin) Fernflower could not be loaded, exported classes will not be decompiled. NoClassDefFoundError: org/jetbrains/java/decompiler/main/extern/IResultSaver
[15:44:41] [main/INFO] (FabricLoader/Mixin) Loaded Fabric development mappings for mixin remapper!
[15:44:41] [main/INFO] (FabricLoader/Mixin) Compatibility level set to JAVA_17
[15:44:43] [main/INFO] (FabricLoader/MixinExtras|Service) Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.3.1).
[15:44:56] [Datafixer Bootstrap/INFO] (Minecraft) 198 Datafixer optimizations took 306 milliseconds
[15:44:58] [Render thread/INFO] (Minecraft) Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
[15:44:58] [Render thread/INFO] (Minecraft) Setting user: Player416
[15:44:58] [Render thread/INFO] (fabric-networking-api-v1) Force Packet Serialization is enabled to mimic remote connection on single player, this is the default behaviour on dev env. Add -Dfabric-api.networking.force-packet-serialization=false JVM arg to disable it.
[15:44:58] [Render thread/INFO] (YetAnotherConfigLib) Deserializing SkyblockerConfig from '/Users/********/Documents/Computer/Java/Skyblocker/run/config/skyblocker.json'
[15:44:59] [ForkJoinPool.commonPool-worker-2/INFO] (ImageRepoLoader) [Skyblocker] The Image Respository is up to date!
[15:44:59] [ForkJoinPool.commonPool-worker-3/INFO] (PlayerHeadHashCache) [Skyblocker Player Head Hash Cache] Successfully cached the hashes of all player head items!
[15:44:59] [ForkJoinPool.commonPool-worker-3/INFO] (Shortcuts) [Skyblocker] Loaded 14 command shortcuts and 3 command argument shortcuts
[15:44:59] [ForkJoinPool.commonPool-worker-3/INFO] (ChatRule) [Skyblocker Chat Rules]: {rules=[de.hysky.skyblocker.skyblock.chat.ChatRule@3d6a44db, de.hysky.skyblocker.skyblock.chat.ChatRule@21866444]}
[15:44:59] [ForkJoinPool.commonPool-worker-3/INFO] (ChatRule) [Skyblocker Chat Rules] Loaded chat rules
[15:44:59] [Worker-Main-1/INFO] (Mod Menu/Update Checker) Checking mod updates...
[15:44:59] [Render thread/INFO] (Indigo) [Indigo] Registering Indigo renderer!
[15:44:59] [ForkJoinPool.commonPool-worker-1/INFO] (NEURepoManager) [Skyblocker] NEU Repository Updated
[15:44:59] [Render thread/INFO] (Minecraft) Backend library: LWJGL version 3.3.2-snapshot
[15:44:59] [Render thread/INFO] (Minecraft) [STDERR]: [LWJGL] [ThreadLocalUtil] Unsupported JNI version detected, this may result in a crash. Please inform LWJGL developers.
[15:45:00] [ForkJoinPool.commonPool-worker-2/ERROR] (ProfileUtils) [Skyblocker Profile Utils] Failed to get Player Profile Data for players Player416, is the API Down/Limited?
 java.lang.ClassCastException: class com.google.gson.JsonNull cannot be cast to class com.google.gson.JsonArray (com.google.gson.JsonNull and com.google.gson.JsonArray are in unnamed module of loader net.fabricmc.loader.impl.launch.knot.KnotClassLoader @2286778)
	at com.google.gson.JsonObject.getAsJsonArray(JsonObject.java:209) ~[gson-2.10.1.jar:?]
	at de.hysky.skyblocker.utils.ProfileUtils.lambda$updateProfile$2(ProfileUtils.java:43) ~[main/:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run$$$capture(CompletableFuture.java:1768) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:387) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java) ~[?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312) ~[?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843) ~[?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808) ~[?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188) ~[?:?]
[15:45:02] [Render thread/INFO] (Minecraft) Reloading ResourceManager: vanilla, fabric (cloth-config, skyblocker, fabric-mining-level-api-v1, modmenu, fabric-registry-sync-v0, fabric-lifecycle-events-v1, fabric-renderer-registries-v1, fabric-rendering-data-attachment-v1, fabric-key-binding-api-v1, fabric-message-api-v1, fabric-renderer-api-v1, fabric-gametest-api-v1, fabric-command-api-v2, fabric-models-v0, fabric-commands-v0, fabric-networking-api-v1, fabric-client-tags-api-v1, fabric-api-lookup-api-v1, fabric-transfer-api-v1, fabric-item-group-api-v1, fabric-api, fabric-containers-v0, fabric-events-interaction-v0, authme, fabric-recipe-api-v1, fabric-transitive-access-wideners-v1, fabric-screen-handler-api-v1, fabric-loot-api-v2, fabric-biome-api-v1, fabric-convention-tags-v1, fabric-rendering-v1, fabric-block-api-v1, fabric-keybindings-v0, fabric-blockrenderlayer-v1, fabric-block-view-api-v2, fabric-entity-events-v1, fabric-resource-conditions-api-v1, fabric-screen-api-v1, fabric-particles-v1, fabricloader, fabric-model-loading-api-v1, fabric-data-generation-api-v1, fabric-rendering-v0, yet_another_config_lib_v3, fabric-sound-api-v1, fabric-crash-report-info-v1, fabric-resource-loader-v0, fabric-item-api-v1, fabric-rendering-fluids-v1, fabric-content-registries-v0, fabric-object-builder-api-v1, fabric-renderer-indigo, fabric-dimensions-v1, fabric-events-lifecycle-v0, fabric-api-base, fabric-game-rule-api-v1, fabric-command-api-v1), skyblocker:top_aligned
[15:45:02] [Render thread/INFO] (YetAnotherConfigLib) YACL is reloading images
[15:45:02] [Render thread/INFO] (YetAnotherConfigLib) YACL has found 0 images
[15:45:03] [Render thread/INFO] (DungeonManager) [Skyblocker Dungeon Secrets] Started loading dungeon secrets in (blocked main thread for) 11 ms
[15:45:03] [Worker-Main-1/INFO] (Minecraft) Found unifont_all_no_pua-15.1.04.hex, loading
[15:45:03] [ForkJoinPool.commonPool-worker-3/INFO] (Relics) [Skyblocker] Loaded relics locations
[15:45:03] [ForkJoinPool.commonPool-worker-6/INFO] (MuseumItemCache) [Skyblocker] Loaded museum items cache
[15:45:03] [ForkJoinPool.commonPool-worker-5/INFO] (Skyblocker Discord RPC) [Skyblocker] Discord RPC is currently disabled, will not connect
[15:45:03] [ForkJoinPool.commonPool-worker-4/INFO] (DungeonManager) [Skyblocker Dungeon Secrets] Loaded dungeon secrets for 1 dungeon(s), 8 room shapes, 132 rooms, and 0 custom secret waypoints total in 818 ms
[15:45:04] [Render thread/WARN] (Minecraft) Missing sound for event: minecraft:item.goat_horn.play
[15:45:04] [Render thread/WARN] (Minecraft) Missing sound for event: minecraft:entity.goat.screaming.horn_break
[15:45:04] [Render thread/WARN] (Minecraft) Missing sound for event: minecraft:entity.generic.wind_burst
[15:45:05] [Render thread/INFO] (Minecraft) OpenAL initialized on device MacBook Air Speakers
[15:45:05] [Render thread/INFO] (Minecraft) Sound engine started
[15:45:05] [Render thread/INFO] (Minecraft) Created: 1024x512x4 minecraft:textures/atlas/blocks.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 256x256x4 minecraft:textures/atlas/signs.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 512x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 512x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 1024x1024x4 minecraft:textures/atlas/armor_trims.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 128x64x4 minecraft:textures/atlas/decorated_pot.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
[15:45:05] [Render thread/WARN] (Minecraft) Shader rendertype_entity_translucent_emissive could not find sampler named Sampler2 in the specified shader program.
[15:45:05] [Render thread/INFO] (Minecraft) Created: 512x256x0 minecraft:textures/atlas/particles.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 128x128x0 minecraft:textures/atlas/mob_effects.png-atlas
[15:45:05] [Render thread/INFO] (Minecraft) Created: 1024x512x0 minecraft:textures/atlas/gui.png-atlas
[15:45:06] [IO-Worker-1/INFO] (Minecraft) Could not authorize you against Realms server: Invalid session id
[15:45:09] [ForkJoinPool.commonPool-worker-6/INFO] (FairySouls) [Skyblocker] Loaded 230 fairy souls across 11 locations
[15:45:21] [Render thread/INFO] (Minecraft) Loaded 7 recipes
[15:45:22] [Render thread/INFO] (Minecraft) Loaded 1271 advancements
[15:45:22] [Render thread/INFO] (BiomeModificationImpl) Applied 0 biome modifications to 0 of 64 new biomes in 894.6 μs
[15:45:22] [Server thread/INFO] (Minecraft) Starting integrated minecraft server version 1.20.4
[15:45:22] [Server thread/INFO] (Minecraft) Generating keypair
[15:45:24] [Server thread/INFO] (Minecraft) Preparing start region for dimension minecraft:overworld
[15:45:27] [Render thread/INFO] (Minecraft) Preparing spawn area: 0%
[15:45:27] [Render thread/INFO] (Minecraft) Preparing spawn area: 0%
[15:45:27] [Render thread/INFO] (Minecraft) Preparing spawn area: 0%
[15:45:27] [Render thread/INFO] (Minecraft) Preparing spawn area: 0%
[15:45:27] [Render thread/INFO] (Minecraft) Preparing spawn area: 0%
[15:45:27] [Render thread/INFO] (Minecraft) Preparing spawn area: 0%
[15:45:27] [Render thread/INFO] (Minecraft) Preparing spawn area: 0%
[15:45:28] [Render thread/INFO] (Minecraft) Preparing spawn area: 6%
[15:45:28] [Render thread/INFO] (Minecraft) Preparing spawn area: 91%
[15:45:28] [Render thread/INFO] (Minecraft) Time elapsed: 4206 ms
[15:45:29] [Server thread/INFO] (Minecraft) Changing view distance to 12, from 10
[15:45:29] [Server thread/INFO] (Minecraft) Changing simulation distance to 12, from 0
[15:45:29] [Server thread/INFO] (Minecraft) Player416[local:E:fcf921e5] logged in with entity id 194 at (-3.3612091304043004, 68.0, -15.107232752515644)
[15:45:29] [Server thread/INFO] (Minecraft) Player416 joined the game
[15:45:29] [Render thread/INFO] (Minecraft) Loaded 10 advancements
[15:45:31] [Render thread/INFO] (Minecraft) [System] [CHAT] Unknown or incomplete command, see below for error
[15:45:31] [Render thread/INFO] (Minecraft) [System] [CHAT] locraw<--[HERE]
[15:46:10] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bUpdating local repository...
[15:46:20] [ForkJoinPool.commonPool-worker-7/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bDeleted local repository successfully, downloading new files... This will take a minute!
[15:47:16] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cLocal repository is currently being updated by another process, please try again in a moment.
[15:47:34] [ForkJoinPool.commonPool-worker-7/INFO] (NEURepoManager) [Skyblocker] NEU Repository Downloaded
[15:47:52] [ForkJoinPool.commonPool-worker-7/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §aUpdated local repository successfully.
[15:48:25] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bUpdating local repository...
[15:48:40] [ForkJoinPool.commonPool-worker-4/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bDeleted local repository successfully, downloading new files... This will take a minute!
[15:48:40] [ForkJoinPool.commonPool-worker-4/ERROR] (NEURepoManager) [Skyblocker] Transport operation failed. Most likely unable to connect to the remote NEU repo on github
 org.eclipse.jgit.api.errors.TransportException: https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO.git: cannot open git-upload-pack
	at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:249) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.api.CloneCommand.fetch(CloneCommand.java:319) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.api.CloneCommand.call(CloneCommand.java:189) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at de.hysky.skyblocker.utils.NEURepoManager.lambda$loadRepository$3(NEURepoManager.java:63) ~[main/:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run$$$capture(CompletableFuture.java:1768) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:387) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java) ~[?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.helpAsyncBlocker(ForkJoinPool.java:1432) ~[?:?]
	at java.util.concurrent.ForkJoinPool.helpAsyncBlocker(ForkJoinPool.java:2415) ~[?:?]
	at java.util.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1887) ~[?:?]
	at java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2117) ~[?:?]
	at de.hysky.skyblocker.utils.NEURepoManager.lambda$deleteAndDownloadRepository$4(NEURepoManager.java:92) ~[main/:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run$$$capture(CompletableFuture.java:1804) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:387) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java) ~[?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312) ~[?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843) ~[?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808) ~[?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188) ~[?:?]
Caused by: org.eclipse.jgit.errors.TransportException: https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO.git: cannot open git-upload-pack
	at org.eclipse.jgit.transport.TransportHttp.connect(TransportHttp.java:759) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.TransportHttp.openFetch(TransportHttp.java:466) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.FetchProcess.executeImp(FetchProcess.java:153) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.FetchProcess.execute(FetchProcess.java:105) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.Transport.fetch(Transport.java:1482) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:238) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	... 22 more
Caused by: java.net.UnknownHostException: github.com
	at sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567) ~[?:?]
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327) ~[?:?]
	at java.net.Socket.connect(Socket.java:751) ~[?:?]
	at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:304) ~[?:?]
	at sun.net.NetworkClient.doConnect(NetworkClient.java:178) ~[?:?]
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:531) ~[?:?]
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:636) ~[?:?]
	at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264) ~[?:?]
	at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:377) ~[?:?]
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:193) ~[?:?]
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1282) ~[?:?]
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1123) ~[?:?]
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:179) ~[?:?]
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1675) ~[?:?]
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1599) ~[?:?]
	at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:531) ~[?:?]
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:307) ~[?:?]
	at org.eclipse.jgit.transport.http.JDKHttpConnection.getResponseCode(JDKHttpConnection.java:88) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.util.HttpSupport.response(HttpSupport.java:232) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.TransportHttp.connect(TransportHttp.java:664) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.TransportHttp.openFetch(TransportHttp.java:466) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.FetchProcess.executeImp(FetchProcess.java:153) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.FetchProcess.execute(FetchProcess.java:105) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.transport.Transport.fetch(Transport.java:1482) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:238) ~[org.eclipse.jgit-6.8.0.202311291450-r.jar:6.8.0.202311291450-r]
	... 22 more
[15:48:40] [ForkJoinPool.commonPool-worker-4/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cUpdating local repository failed. See logs for details.
[15:49:29] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bUpdating local repository...
[15:49:29] [ForkJoinPool.commonPool-worker-5/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bDeleted local repository successfully, downloading new files... This will take a minute!
[15:51:04] [ForkJoinPool.commonPool-worker-5/INFO] (NEURepoManager) [Skyblocker] NEU Repository Downloaded
[15:51:26] [ForkJoinPool.commonPool-worker-5/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §aUpdated local repository successfully.
[15:51:35] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bUpdating local repository...
[15:51:36] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cLocal repository is currently being updated by another process, please try again in a moment.
[15:51:37] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cLocal repository is currently being updated by another process, please try again in a moment.
[15:51:39] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cLocal repository is currently being updated by another process, please try again in a moment.
[15:51:40] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cLocal repository is currently being updated by another process, please try again in a moment.
[15:51:41] [Server thread/INFO] (Minecraft) Saving and pausing game...
[15:51:41] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:overworld
[15:51:41] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_end
[15:51:41] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_nether
[15:52:16] [ForkJoinPool.commonPool-worker-5/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §bDeleted local repository successfully, downloading new files... This will take a minute!
[15:52:17] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cLocal repository is currently being updated by another process, please try again in a moment.
[15:52:18] [Server thread/INFO] (Minecraft) Saving and pausing game...
[15:52:18] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:overworld
[15:52:18] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_end
[15:52:18] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_nether
[15:52:20] [Server thread/INFO] (Minecraft) Saving and pausing game...
[15:52:20] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:overworld
[15:52:20] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_end
[15:52:20] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_nether
[15:52:28] [Render thread/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §cLocal repository is currently being updated by another process, please try again in a moment.
[15:53:12] [ForkJoinPool.commonPool-worker-5/INFO] (NEURepoManager) [Skyblocker] NEU Repository Downloaded
[15:53:37] [ForkJoinPool.commonPool-worker-5/INFO] (Minecraft) [System] [CHAT] [Skyblocker] §aUpdated local repository successfully.
[15:54:15] [Server thread/INFO] (Minecraft) Saving and pausing game...
[15:54:15] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:overworld
[15:54:15] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_end
[15:54:15] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_nether
[15:54:16] [Server thread/INFO] (Minecraft) Player416 lost connection: Disconnected
[15:54:16] [Server thread/INFO] (Minecraft) Player416 left the game
[15:54:16] [Server thread/INFO] (Minecraft) Stopping singleplayer server as player logged out
[15:54:16] [Server thread/INFO] (Minecraft) Stopping server
[15:54:16] [Server thread/INFO] (Minecraft) Saving players
[15:54:16] [Server thread/INFO] (Minecraft) Saving worlds
[15:54:17] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:overworld
[15:54:17] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_end
[15:54:17] [Server thread/INFO] (Minecraft) Saving chunks for level 'ServerLevel[New World]'/minecraft:the_nether
[15:54:17] [Server thread/INFO] (Minecraft) ThreadedAnvilChunkStorage (New World): All chunks are saved
[15:54:17] [Server thread/INFO] (Minecraft) ThreadedAnvilChunkStorage (DIM1): All chunks are saved
[15:54:17] [Server thread/INFO] (Minecraft) ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
[15:54:17] [Server thread/INFO] (Minecraft) ThreadedAnvilChunkStorage: All dimensions are saved
[15:54:18] [Render thread/INFO] (Minecraft) Stopping!
[15:54:18] [Render thread/INFO] (FairySouls) [Skyblocker] Saved found fairy souls
[15:54:18] [Render thread/INFO] (Shortcuts) [Skyblocker] Saved 14 command shortcuts and 3 command argument shortcuts
[15:54:18] [Render thread/INFO] (DungeonManager) [Skyblocker Dungeon Secrets] Saved custom dungeon secret waypoints
Disconnected from the target VM, address: '127.0.0.1:50638', transport: 'socket'

Process finished with exit code 0
</pre>
</p>
</details> 