### PR TITLE
Add compact damage

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -8,11 +8,14 @@ import de.hysky.skyblocker.config.configs.UIAndVisualsConfig;
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import dev.isxander.yacl3.api.ConfigCategory;
 import dev.isxander.yacl3.api.*;
+import dev.isxander.yacl3.api.controller.ColorControllerBuilder;
 import dev.isxander.yacl3.api.controller.FloatFieldControllerBuilder;
 import dev.isxander.yacl3.api.controller.IntegerSliderControllerBuilder;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+
+import java.awt.*;
 
 public class UIAndVisualsCategory {
     public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
@@ -354,6 +357,49 @@ public class UIAndVisualsCategory {
                                 .controller(opt -> IntegerSliderControllerBuilder.create(opt).range(0, 100).step(1))
                                 .build())
                         .build())
+
+                //Compact Damage Numbers
+                .group(OptionGroup.createBuilder()
+                        .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage"))
+                        .collapsed(true)
+                        .option(Option.<Boolean>createBuilder()
+                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.enabled"))
+                                .binding(defaults.uiAndVisuals.compactDamage.enabled,
+                                        () -> config.uiAndVisuals.compactDamage.enabled,
+                                        newValue -> config.uiAndVisuals.compactDamage.enabled = newValue)
+                                .controller(ConfigUtils::createBooleanController)
+                                .build())
+                        .option(Option.<Integer>createBuilder()
+                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.precision"))
+                                .description(OptionDescription.of(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.precision.@Tooltip")))
+                                .binding(defaults.uiAndVisuals.compactDamage.precision,
+                                        () -> config.uiAndVisuals.compactDamage.precision,
+                                        newValue -> config.uiAndVisuals.compactDamage.precision = newValue)
+                                .controller(opt -> IntegerSliderControllerBuilder.create(opt).range(1,3).step(1))
+                                .build())
+                        .option(Option.<Color>createBuilder()
+                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.normalDamageColor"))
+                                .binding(defaults.uiAndVisuals.compactDamage.normalDamageColor,
+                                        () -> config.uiAndVisuals.compactDamage.normalDamageColor,
+                                        newValue -> config.uiAndVisuals.compactDamage.normalDamageColor = newValue)
+                                .controller(ColorControllerBuilder::create)
+                                .build())
+                        .option(Option.<Color>createBuilder()
+                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientStart"))
+                                .binding(defaults.uiAndVisuals.compactDamage.critDamageGradientStart,
+                                        () -> config.uiAndVisuals.compactDamage.critDamageGradientStart,
+                                        newValue -> config.uiAndVisuals.compactDamage.critDamageGradientStart = newValue)
+                                .controller(ColorControllerBuilder::create)
+                                .build())
+                        .option(Option.<Color>createBuilder()
+                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientEnd"))
+                                .binding(defaults.uiAndVisuals.compactDamage.critDamageGradientEnd,
+                                        () -> config.uiAndVisuals.compactDamage.critDamageGradientEnd,
+                                        newValue -> config.uiAndVisuals.compactDamage.critDamageGradientEnd = newValue)
+                                .controller(ColorControllerBuilder::create)
+                                .build())
+                        .build()
+                )
 
                 .build();
     }

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -4,6 +4,7 @@ import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import net.minecraft.util.Formatting;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,6 +56,9 @@ public class UIAndVisualsConfig {
 
     @SerialEntry
     public FlameOverlay flameOverlay = new FlameOverlay();
+
+    @SerialEntry
+    public CompactDamage compactDamage = new CompactDamage();
 
     public static class ChestValue {
         @SerialEntry
@@ -247,4 +251,20 @@ public class UIAndVisualsConfig {
         public int flameOpacity = 100;
     }
 
+    public static class CompactDamage {
+        @SerialEntry
+        public boolean enabled = true;
+
+        @SerialEntry
+        public int precision = 1;
+
+        @SerialEntry
+        public Color normalDamageColor = new Color(0xFFFFFF);
+
+        @SerialEntry
+        public Color critDamageGradientStart = new Color(0xFFFF55);
+
+        @SerialEntry
+        public Color critDamageGradientEnd = new Color(0xFF5555);
+    }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
@@ -19,12 +19,12 @@ import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityStatuses;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.network.packet.s2c.play.*;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -36,6 +36,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class ClientPlayNetworkHandlerMixin {
     @Shadow
     private ClientWorld world;
+
+    @Shadow
+    @Final
+    private static Logger LOGGER;
 
     @Inject(method = "onBlockUpdate", at = @At("RETURN"))
     private void skyblocker$onBlockUpdate(BlockUpdateS2CPacket packet, CallbackInfo ci) {
@@ -111,7 +115,7 @@ public abstract class ClientPlayNetworkHandlerMixin {
         try { //Prevent packet handling fails if something goes wrong so that entity trackers still update, just without compact damage numbers
             CompactDamage.compactDamage(armorStandEntity);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("[Skyblocker Compact Damage] Failed to compact damage number", e);
         }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
@@ -107,9 +107,9 @@ public abstract class ClientPlayNetworkHandlerMixin {
 
     @Inject(method = "onEntityTrackerUpdate", at = @At("TAIL"))
     private void skyblocker$onEntityTrackerUpdate(EntityTrackerUpdateS2CPacket packet, CallbackInfo ci, @Local Entity entity) {
-        if (!SkyblockerConfigManager.get().general.compactDamage.enabled || entity == null || entity.getType() != EntityType.ARMOR_STAND) return;
+        if (!SkyblockerConfigManager.get().general.compactDamage.enabled || !(entity instanceof ArmorStandEntity armorStandEntity)) return;
         try { //Prevent packet handling fails if something goes wrong so that entity trackers still update, just without compact damage numbers
-            CompactDamage.compactDamage((ArmorStandEntity) entity);
+            CompactDamage.compactDamage(armorStandEntity);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
@@ -107,7 +107,7 @@ public abstract class ClientPlayNetworkHandlerMixin {
 
     @Inject(method = "onEntityTrackerUpdate", at = @At("TAIL"))
     private void skyblocker$onEntityTrackerUpdate(EntityTrackerUpdateS2CPacket packet, CallbackInfo ci, @Local Entity entity) {
-        if (!SkyblockerConfigManager.get().general.compactDamage.enabled || !(entity instanceof ArmorStandEntity armorStandEntity)) return;
+        if (!SkyblockerConfigManager.get().uiAndVisuals.compactDamage.enabled || !(entity instanceof ArmorStandEntity armorStandEntity)) return;
         try { //Prevent packet handling fails if something goes wrong so that entity trackers still update, just without compact damage numbers
             CompactDamage.compactDamage(armorStandEntity);
         } catch (Exception e) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -23,8 +23,6 @@ public class CompactDamage {
 	private CompactDamage() {
 	}
 
-	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat(SkyblockerConfigManager.get().general.compactDamage.format);
-
 	public static void compactDamage(ArmorStandEntity entity) {
 		if (!entity.isInvisible() || !entity.hasCustomName() || !entity.isCustomNameVisible() || entity.getFireTicks() != -1 || !entity.shouldHideBasePlate()) return;
 		//Dmg armor stands have no base plate and have a fire time of -1 (just one of these isn't enough to determine if it's a dmg armor stand)
@@ -39,7 +37,7 @@ public class CompactDamage {
 			String dmg = text.getString().replace(",", "");
 			if (!NumberUtils.isParsable(dmg)) return; //Sanity check
 			String prettifiedDmg = prettifyDamageNumber(Long.parseLong(dmg));
-			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(SkyblockerConfigManager.get().general.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF)).setStyle(customName.getStyle());
+			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF)).setStyle(customName.getStyle());
 		} else { //Crit damage
 			String dmg = siblings.subList(1, siblings.size() - 1) //First and last sibling are the crit symbols
 			                     .stream()
@@ -54,8 +52,8 @@ public class CompactDamage {
 			for (int i = 0; i < length; i++) {
 				prettierCustomName.append(Text.literal(prettifiedDmg.substring(i, i + 1)).withColor(
 						CustomArmorAnimatedDyes.interpolate(
-								SkyblockerConfigManager.get().general.compactDamage.critDamageGradientStart.getRGB() & 0x00FFFFFF,
-								SkyblockerConfigManager.get().general.compactDamage.critDamageGradientEnd.getRGB() & 0x00FFFFFF,
+								SkyblockerConfigManager.get().uiAndVisuals.compactDamage.critDamageGradientStart.getRGB() & 0x00FFFFFF,
+								SkyblockerConfigManager.get().uiAndVisuals.compactDamage.critDamageGradientEnd.getRGB() & 0x00FFFFFF,
 								i / (length - 1.0)
 						)
 				));
@@ -68,9 +66,13 @@ public class CompactDamage {
 
 	private static String prettifyDamageNumber(long damage) {
 		if (damage < 1_000) return String.valueOf(damage);
-		if (damage < 1_000_000) return DECIMAL_FORMAT.format(damage / 1_000.0) + "k";
-		if (damage < 1_000_000_000) return DECIMAL_FORMAT.format(damage / 1_000_000.0) + "m";
-		if (damage < 1_000_000_000_000L) return DECIMAL_FORMAT.format(damage / 1_000_000_000.0) + "b";
-		return DECIMAL_FORMAT.format(damage / 1_000_000_000_000.0) + "t"; //This will probably never be reached
+		if (damage < 1_000_000) return format(damage / 1_000.0) + "k";
+		if (damage < 1_000_000_000) return format(damage / 1_000_000.0) + "m";
+		if (damage < 1_000_000_000_000L) return format(damage / 1_000_000_000.0) + "b";
+		return format(damage / 1_000_000_000_000.0) + "t"; //This will probably never be reached
+	}
+
+	private static String format(double number) {
+		return ("%." + SkyblockerConfigManager.get().uiAndVisuals.compactDamage.precision + "f").formatted(number);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -1,33 +1,27 @@
 package de.hysky.skyblocker.skyblock;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.item.CustomArmorAnimatedDyes;
-import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.minecraft.entity.decoration.ArmorStandEntity;
-import net.minecraft.nbt.NbtHelper;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import net.minecraft.text.TextColor;
+import net.minecraft.util.Formatting;
 import org.apache.commons.lang3.math.NumberUtils;
 
-import java.text.DecimalFormat;
 import java.util.List;
 import java.util.regex.Pattern;
 
 
 public class CompactDamage {
+	private static final Pattern DAMAGE_PATTERN = Pattern.compile("✧?[\\d,]+✧?");
 	private CompactDamage() {
 	}
 
 	public static void compactDamage(ArmorStandEntity entity) {
-		if (!entity.isInvisible() || !entity.hasCustomName() || !entity.isCustomNameVisible() || entity.getFireTicks() != -1 || !entity.shouldHideBasePlate()) return;
-		//Dmg armor stands have no base plate and have a fire time of -1 (just one of these isn't enough to determine if it's a dmg armor stand)
-		//In fact, even this much checking might not be accurate. Needs testing, or just waiting until someone reports it as an issue
+		if (!entity.isInvisible() || !entity.hasCustomName() || !entity.isCustomNameVisible()) return;
 		Text customName = entity.getCustomName();
+		if (!DAMAGE_PATTERN.matcher(customName.getString()).matches()) return;
 		List<Text> siblings = customName.getSiblings();
 		if (siblings.isEmpty()) return;
 
@@ -37,7 +31,7 @@ public class CompactDamage {
 			String dmg = text.getString().replace(",", "");
 			if (!NumberUtils.isParsable(dmg)) return; //Sanity check
 			String prettifiedDmg = prettifyDamageNumber(Long.parseLong(dmg));
-			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF)).setStyle(customName.getStyle());
+			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(text.getStyle().getColor() == TextColor.fromFormatting(Formatting.GRAY) ? SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF : Formatting.GRAY.getColorValue())).setStyle(customName.getStyle());
 		} else { //Crit damage
 			String dmg = siblings.subList(1, siblings.size() - 1) //First and last sibling are the crit symbols
 			                     .stream()

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -37,7 +37,7 @@ public class CompactDamage {
 					color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF;
 				} else color = text.getStyle().getColor().getRgb();
 			} else color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF;
-			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(color).setStyle(customName.getStyle()));
+			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).setStyle(customName.getStyle()).withColor(color));
 		} else { //Crit damage
 			String dmg = siblings.subList(1, siblings.size() - 1) //First and last sibling are the crit symbols
 			                     .stream()

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -7,15 +7,19 @@ import com.google.gson.JsonParser;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.item.CustomArmorAnimatedDyes;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.nbt.NbtHelper;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import java.text.DecimalFormat;
+import java.util.List;
+import java.util.regex.Pattern;
 
 
 public class CompactDamage {
-
 	private CompactDamage() {
 	}
 
@@ -25,41 +29,41 @@ public class CompactDamage {
 		if (!entity.isInvisible() || !entity.hasCustomName() || !entity.isCustomNameVisible() || entity.getFireTicks() != -1 || !entity.shouldHideBasePlate()) return;
 		//Dmg armor stands have no base plate and have a fire time of -1 (just one of these isn't enough to determine if it's a dmg armor stand)
 		//In fact, even this much checking might not be accurate. Needs testing, or just waiting until someone reports it as an issue
-		JsonObject json = JsonParser.parseString(Text.Serialization.toJsonString(entity.getCustomName(), entity.getRegistryManager())).getAsJsonObject();
-		JsonElement extra = json.get("extra");
-		if (extra == null || !extra.isJsonArray()) return;
-		JsonArray extraArray = extra.getAsJsonArray();
-		if (extra.getAsJsonArray().isEmpty()) return;
+		Text customName = entity.getCustomName();
+		List<Text> siblings = customName.getSiblings();
+		if (siblings.isEmpty()) return;
 
-		if (extraArray.size() == 1) { //Non-crit damage, just formatting with no color changes
-			JsonElement first = extraArray.get(0);
-			if (!first.isJsonObject()) return;
-			JsonElement text = first.getAsJsonObject().get("text");
-			if (text == null || !text.isJsonPrimitive()) return;
-			long damage = Long.parseLong(text.getAsString().replace(",", ""));
-			first.getAsJsonObject().addProperty("text", prettifyDamageNumber(damage));
-			first.getAsJsonObject().addProperty("color", "#" + Integer.toHexString(SkyblockerConfigManager.get().general.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF));
+		MutableText prettierCustomName;
+		if (siblings.size() == 1) { //Non-crit damage
+			Text text = siblings.getFirst();
+			String dmg = text.getString().replace(",", "");
+			if (!NumberUtils.isParsable(dmg)) return; //Sanity check
+			String prettifiedDmg = prettifyDamageNumber(Long.parseLong(dmg));
+			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(SkyblockerConfigManager.get().general.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF)).setStyle(customName.getStyle());
 		} else { //Crit damage
-			//Already checked that the entity has a custom name above, ignore NPE warnings
-			String text = entity.getCustomName().getString().replace(",", "").replace("✧", "");
-			String prettyText = "✧" + prettifyDamageNumber(Long.parseLong(text)) + "✧";
-			extra.getAsJsonArray().asList().clear();
-			int length = prettyText.length();
+			String dmg = siblings.subList(1, siblings.size() - 1) //First and last sibling are the crit symbols
+			                     .stream()
+			                     .map(Text::getString)
+			                     .reduce("", String::concat) //Concatenate all the siblings to get the dmg number
+			                     .replace(",", "");
+
+			if (!NumberUtils.isParsable(dmg)) return; //Sanity check
+			String prettifiedDmg = "✧" + prettifyDamageNumber(Long.parseLong(dmg)) + "✧";
+			prettierCustomName = Text.literal("");
+			int length = prettifiedDmg.length();
 			for (int i = 0; i < length; i++) {
-				JsonObject obj = new JsonObject();
-				obj.addProperty("text", prettyText.charAt(i));
-				obj.addProperty("color", "#" + Integer.toHexString(
+				prettierCustomName.append(Text.literal(prettifiedDmg.substring(i, i + 1)).withColor(
 						CustomArmorAnimatedDyes.interpolate(
 								SkyblockerConfigManager.get().general.compactDamage.critDamageGradientStart.getRGB() & 0x00FFFFFF,
 								SkyblockerConfigManager.get().general.compactDamage.critDamageGradientEnd.getRGB() & 0x00FFFFFF,
 								i / (length - 1.0)
 						)
 				));
-				extraArray.add(obj);
 			}
+			prettierCustomName.setStyle(customName.getStyle());
 		}
 
-		entity.setCustomName(Text.Serialization.fromJsonTree(json, entity.getRegistryManager()));
+		entity.setCustomName(prettierCustomName);
 	}
 
 	private static String prettifyDamageNumber(long damage) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 
 
 public class CompactDamage {
-	private static final Pattern DAMAGE_PATTERN = Pattern.compile("✧?[\\d,]+✧?❤?");
+	private static final Pattern DAMAGE_PATTERN = Pattern.compile("(?:✧|✯)?[\\d,]+(?:✧|✯?)❤?");
 	private CompactDamage() {
 	}
 
@@ -40,7 +40,7 @@ public class CompactDamage {
 			} else color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF;
 			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).setStyle(customName.getStyle()).withColor(color));
 		} else { //Crit damage
-			boolean wasDoubled = customNameStringified.contains("❤");
+			boolean wasDoubled = customNameStringified.contains("❤"); //Ring of love ability adds a heart to the end of the damage string
 			int entriesToRemove = wasDoubled ? 2 : 1;
 
 			String dmg = siblings.subList(1, siblings.size() - entriesToRemove) //First and last sibling are the crit symbols and maybe heart
@@ -50,7 +50,8 @@ public class CompactDamage {
 			                     .replace(",", "");
 
 			if (!NumberUtils.isParsable(dmg)) return; //Sanity check
-			String prettifiedDmg = "✧" + prettifyDamageNumber(Long.parseLong(dmg)) + "✧";
+			String dmgSymbol = customNameStringified.charAt(0) != '✯' ? "✧" : "✯"; //Mega Crit ability from the Overload enchantment
+			String prettifiedDmg = dmgSymbol + prettifyDamageNumber(Long.parseLong(dmg)) + dmgSymbol;
 			prettierCustomName = Text.literal("");
 			int length = prettifiedDmg.length();
 			for (int i = 0; i < length; i++) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -34,9 +34,9 @@ public class CompactDamage {
 			int color;
 			if (text.getStyle().getColor() != null) {
 				if (text.getStyle().getColor() == TextColor.fromFormatting(Formatting.GRAY)) {
-					color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB();
+					color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF;
 				} else color = text.getStyle().getColor().getRgb();
-			} else color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB();
+			} else color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF;
 			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(color).setStyle(customName.getStyle()));
 		} else { //Crit damage
 			String dmg = siblings.subList(1, siblings.size() - 1) //First and last sibling are the crit symbols

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -1,0 +1,72 @@
+package de.hysky.skyblocker.skyblock;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import de.hysky.skyblocker.config.SkyblockerConfig;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.item.CustomArmorAnimatedDyes;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.nbt.NbtHelper;
+import net.minecraft.text.Text;
+
+import java.text.DecimalFormat;
+
+
+public class CompactDamage {
+
+	private CompactDamage() {
+	}
+
+	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat(SkyblockerConfigManager.get().general.compactDamage.format);
+
+	public static void compactDamage(ArmorStandEntity entity) {
+		if (!entity.isInvisible() || !entity.hasCustomName() || !entity.isCustomNameVisible() || entity.getFireTicks() != -1 || !entity.shouldHideBasePlate()) return;
+		//Dmg armor stands have no base plate and have a fire time of -1 (just one of these isn't enough to determine if it's a dmg armor stand)
+		//In fact, even this much checking might not be accurate. Needs testing, or just waiting until someone reports it as an issue
+		JsonObject json = JsonParser.parseString(Text.Serialization.toJsonString(entity.getCustomName(), entity.getRegistryManager())).getAsJsonObject();
+		JsonElement extra = json.get("extra");
+		if (extra == null || !extra.isJsonArray()) return;
+		JsonArray extraArray = extra.getAsJsonArray();
+		if (extra.getAsJsonArray().isEmpty()) return;
+
+		if (extraArray.size() == 1) { //Non-crit damage, just formatting with no color changes
+			JsonElement first = extraArray.get(0);
+			if (!first.isJsonObject()) return;
+			JsonElement text = first.getAsJsonObject().get("text");
+			if (text == null || !text.isJsonPrimitive()) return;
+			long damage = Long.parseLong(text.getAsString().replace(",", ""));
+			first.getAsJsonObject().addProperty("text", prettifyDamageNumber(damage));
+			first.getAsJsonObject().addProperty("color", "#" + Integer.toHexString(SkyblockerConfigManager.get().general.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF));
+		} else { //Crit damage
+			//Already checked that the entity has a custom name above, ignore NPE warnings
+			String text = entity.getCustomName().getString().replace(",", "").replace("✧", "");
+			String prettyText = "✧" + prettifyDamageNumber(Long.parseLong(text)) + "✧";
+			extra.getAsJsonArray().asList().clear();
+			int length = prettyText.length();
+			for (int i = 0; i < length; i++) {
+				JsonObject obj = new JsonObject();
+				obj.addProperty("text", prettyText.charAt(i));
+				obj.addProperty("color", "#" + Integer.toHexString(
+						CustomArmorAnimatedDyes.interpolate(
+								SkyblockerConfigManager.get().general.compactDamage.critDamageGradientStart.getRGB() & 0x00FFFFFF,
+								SkyblockerConfigManager.get().general.compactDamage.critDamageGradientEnd.getRGB() & 0x00FFFFFF,
+								i / (length - 1.0)
+						)
+				));
+				extraArray.add(obj);
+			}
+		}
+
+		entity.setCustomName(Text.Serialization.fromJsonTree(json, entity.getRegistryManager()));
+	}
+
+	private static String prettifyDamageNumber(long damage) {
+		if (damage < 1_000) return String.valueOf(damage);
+		if (damage < 1_000_000) return DECIMAL_FORMAT.format(damage / 1_000.0) + "k";
+		if (damage < 1_000_000_000) return DECIMAL_FORMAT.format(damage / 1_000_000.0) + "m";
+		if (damage < 1_000_000_000_000L) return DECIMAL_FORMAT.format(damage / 1_000_000_000.0) + "b";
+		return DECIMAL_FORMAT.format(damage / 1_000_000_000_000.0) + "t"; //This will probably never be reached
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -75,9 +75,9 @@ public class CompactDamage {
 	private static String prettifyDamageNumber(long damage) {
 		if (damage < 1_000) return String.valueOf(damage);
 		if (damage < 1_000_000) return format(damage / 1_000.0) + "k";
-		if (damage < 1_000_000_000) return format(damage / 1_000_000.0) + "m";
-		if (damage < 1_000_000_000_000L) return format(damage / 1_000_000_000.0) + "b";
-		return format(damage / 1_000_000_000_000.0) + "t"; //This will probably never be reached
+		if (damage < 1_000_000_000) return format(damage / 1_000_000.0) + "M";
+		if (damage < 1_000_000_000_000L) return format(damage / 1_000_000_000.0) + "B";
+		return format(damage / 1_000_000_000_000.0) + "T"; //This will probably never be reached
 	}
 
 	private static String format(double number) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -31,7 +31,13 @@ public class CompactDamage {
 			String dmg = text.getString().replace(",", "");
 			if (!NumberUtils.isParsable(dmg)) return; //Sanity check
 			String prettifiedDmg = prettifyDamageNumber(Long.parseLong(dmg));
-			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(text.getStyle().getColor() == TextColor.fromFormatting(Formatting.GRAY) ? SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF : Formatting.GRAY.getColorValue())).setStyle(customName.getStyle());
+			int color;
+			if (text.getStyle().getColor() != null) {
+				if (text.getStyle().getColor() == TextColor.fromFormatting(Formatting.GRAY)) {
+					color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB();
+				} else color = text.getStyle().getColor().getRgb();
+			} else color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB();
+			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).withColor(color).setStyle(customName.getStyle()));
 		} else { //Crit damage
 			String dmg = siblings.subList(1, siblings.size() - 1) //First and last sibling are the crit symbols
 			                     .stream()

--- a/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CompactDamage.java
@@ -14,14 +14,15 @@ import java.util.regex.Pattern;
 
 
 public class CompactDamage {
-	private static final Pattern DAMAGE_PATTERN = Pattern.compile("✧?[\\d,]+✧?");
+	private static final Pattern DAMAGE_PATTERN = Pattern.compile("✧?[\\d,]+✧?❤?");
 	private CompactDamage() {
 	}
 
 	public static void compactDamage(ArmorStandEntity entity) {
 		if (!entity.isInvisible() || !entity.hasCustomName() || !entity.isCustomNameVisible()) return;
 		Text customName = entity.getCustomName();
-		if (!DAMAGE_PATTERN.matcher(customName.getString()).matches()) return;
+		String customNameStringified = customName.getString();
+		if (!DAMAGE_PATTERN.matcher(customNameStringified).matches()) return;
 		List<Text> siblings = customName.getSiblings();
 		if (siblings.isEmpty()) return;
 
@@ -39,7 +40,10 @@ public class CompactDamage {
 			} else color = SkyblockerConfigManager.get().uiAndVisuals.compactDamage.normalDamageColor.getRGB() & 0x00FFFFFF;
 			prettierCustomName = Text.literal("").append(Text.literal(prettifiedDmg).setStyle(customName.getStyle()).withColor(color));
 		} else { //Crit damage
-			String dmg = siblings.subList(1, siblings.size() - 1) //First and last sibling are the crit symbols
+			boolean wasDoubled = customNameStringified.contains("❤");
+			int entriesToRemove = wasDoubled ? 2 : 1;
+
+			String dmg = siblings.subList(1, siblings.size() - entriesToRemove) //First and last sibling are the crit symbols and maybe heart
 			                     .stream()
 			                     .map(Text::getString)
 			                     .reduce("", String::concat) //Concatenate all the siblings to get the dmg number
@@ -58,6 +62,9 @@ public class CompactDamage {
 						)
 				));
 			}
+
+			if (wasDoubled) prettierCustomName.append(Text.literal("❤").formatted(Formatting.LIGHT_PURPLE));
+
 			prettierCustomName.setStyle(customName.getStyle());
 		}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/CustomArmorAnimatedDyes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/CustomArmorAnimatedDyes.java
@@ -109,7 +109,7 @@ public class CustomArmorAnimatedDyes {
 	}
 
 	//Credit to https://codepen.io/OliverBalfour/post/programmatically-making-gradients
-	private static int interpolate(int firstColor, int secondColor, double percentage) {
+	public static int interpolate(int firstColor, int secondColor, double percentage) {
 		int r1 = MathHelper.square((firstColor >> 16) & 0xFF);
 		int g1 = MathHelper.square((firstColor >> 8) & 0xFF);
 		int b1 = MathHelper.square(firstColor & 0xFF);

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -504,6 +504,14 @@
   "skyblocker.config.uiAndVisuals.chestValue.incompleteColor": "Incomplete Color",
   "skyblocker.config.uiAndVisuals.chestValue.incompleteColor.@Tooltip": "The color to display when the price data is incomplete.",
 
+  "skyblocker.config.uiAndVisuals.compactDamage": "Compact Damage",
+  "skyblocker.config.uiAndVisuals.compactDamage.enabled": "Enabled",
+  "skyblocker.config.uiAndVisuals.compactDamage.precision": "Precision",
+  "skyblocker.config.uiAndVisuals.compactDamage.precision.@Tooltip" : "The number of digits to display after the decimal point.",
+  "skyblocker.config.uiAndVisuals.compactDamage.normalDamageColor": "Normal Damage Color",
+  "skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientStart": "Crit Damage Gradient Start Color",
+  "skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientEnd": "Crit Damage Gradient End Color",
+
   "skyblocker.config.uiAndVisuals.compactorDeletorPreview": "Enable Compactor/Deletor Preview",
 
   "skyblocker.config.uiAndVisuals.dontStripSkinAlphaValues": "Correct Transparent Skin Pixels",


### PR DESCRIPTION
Shortens damage numbers with letters (k, m, b, t). For example, 1234567 would turn into 1.2m. Also allows changing the color of dmg numbers, normal and critical.