### PR TITLE
Block Incorrect Terminal Clicks

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -252,6 +252,13 @@ public class DungeonsCategory {
                                         newValue -> config.dungeons.terminals.solveStartsWith = newValue)
                                 .controller(ConfigUtils::createBooleanController)
                                 .build())
+                        .option(Option.<Boolean>createBuilder()
+                                .name(Text.translatable("skyblocker.config.dungeons.terminals.blockIncorrectClicks"))
+                                .binding(defaults.dungeons.terminals.blockIncorrectClicks,
+                                        () -> config.dungeons.terminals.blockIncorrectClicks,
+                                        newValue -> config.dungeons.terminals.blockIncorrectClicks = newValue)
+                                .controller(ConfigUtils::createBooleanController)
+                                .build())
                         .build())
 
                 // Dungeon Secret Waypoints

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -127,6 +127,9 @@ public class DungeonsConfig {
 
         @SerialEntry
         public boolean solveStartsWith = true;
+
+        @SerialEntry
+        public boolean blockIncorrectClicks = false;
     }
 
     public static class SecretWaypoints {

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
-import de.hysky.skyblocker.skyblock.dungeon.terminal.TerminalSolver;
 import de.hysky.skyblocker.skyblock.experiment.ChronomatronSolver;
 import de.hysky.skyblocker.skyblock.experiment.ExperimentSolver;
 import de.hysky.skyblocker.skyblock.experiment.SuperpairsSolver;
@@ -216,7 +215,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
             }
         }
 
-        if (currentSolver instanceof TerminalSolver) {
+        if (currentSolver != null) {
             boolean disallowed = SkyblockerMod.getInstance().containerSolverManager.onSlotClick(slotId, stack);
 
             if (disallowed) ci.cancel();

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.dungeon.terminal.TerminalSolver;
 import de.hysky.skyblocker.skyblock.experiment.ChronomatronSolver;
 import de.hysky.skyblocker.skyblock.experiment.ExperimentSolver;
 import de.hysky.skyblocker.skyblock.experiment.SuperpairsSolver;
@@ -215,8 +216,10 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
             }
         }
 
-        if (currentSolver != null) {
-            SkyblockerMod.getInstance().containerSolverManager.onSlotClick(slotId, stack);
+        if (currentSolver instanceof TerminalSolver) {
+            boolean disallowed = SkyblockerMod.getInstance().containerSolverManager.onSlotClick(slotId, stack);
+
+            if (disallowed) ci.cancel();
         }
 
         // Experiment Solvers

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/ColorTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/ColorTerminal.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 
-public class ColorTerminal extends ContainerSolver {
+public class ColorTerminal extends ContainerSolver implements TerminalSolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(ColorTerminal.class.getName());
     private static final Map<String, DyeColor> colorFromName;
     private DyeColor targetColor;
@@ -53,6 +53,14 @@ public class ColorTerminal extends ContainerSolver {
         return highlights;
     }
 
+    @Override
+    protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
+        if (stack.hasGlint() || !targetColor.equals(itemColor.get(stack.getItem()))) {
+            return shouldBlockIncorrectClicks();
+        }
+
+        return false;
+    }
 
     static {
         colorFromName = new HashMap<>();

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/LightsOnTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/LightsOnTerminal.java
@@ -1,0 +1,37 @@
+package de.hysky.skyblocker.skyblock.dungeon.terminal;
+
+import java.util.List;
+
+import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
+import de.hysky.skyblocker.utils.render.gui.ContainerSolver;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+
+/**
+ * The terminal where you change all the panes that are red to green.
+ * 
+ * This doesn't solve the terminal because you don't need a solver for it, but rather to simply allow for click blocking.
+ */
+public class LightsOnTerminal extends ContainerSolver implements TerminalSolver {
+	private static final List<ColorHighlight> EMPTY = List.of();
+
+	public LightsOnTerminal() {
+		super("^Correct all the panes!$");
+	}
+
+	@Override
+	protected boolean isEnabled() {
+		return shouldBlockIncorrectClicks();
+	}
+
+	@Override
+	protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
+		return EMPTY;
+	}
+
+	@Override
+	protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
+		return stack.isOf(Items.LIME_STAINED_GLASS_PANE);
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/OrderTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/OrderTerminal.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class OrderTerminal extends ContainerSolver {
+public class OrderTerminal extends ContainerSolver implements TerminalSolver {
     private final int PANES_NUM = 14;
     private int[] orderedSlots;
     private int currentNum = Integer.MAX_VALUE;
@@ -54,5 +54,16 @@ public class OrderTerminal extends ContainerSolver {
         }
         currentNum = 0;
         return true;
+    }
+
+    @Override
+    protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
+        if (stack == null || stack.isEmpty()) return false;
+
+        if (!stack.isOf(Items.RED_STAINED_GLASS_PANE) || stack.getCount() != currentNum + 1) {
+            return shouldBlockIncorrectClicks();
+        }
+
+        return false;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/TerminalSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/TerminalSolver.java
@@ -1,0 +1,10 @@
+package de.hysky.skyblocker.skyblock.dungeon.terminal;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+
+public interface TerminalSolver {
+
+	default boolean shouldBlockIncorrectClicks() {
+		return SkyblockerConfigManager.get().dungeons.terminals.blockIncorrectClicks;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolver.java
@@ -20,7 +20,7 @@ public abstract class ContainerSolver {
 
     protected abstract boolean isEnabled();
 
-    public Pattern getName() {
+    public final Pattern getName() {
         return containerName;
     }
 
@@ -34,12 +34,13 @@ public abstract class ContainerSolver {
         SkyblockerMod.getInstance().containerSolverManager.markDirty();
     }
 
-    protected void onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
+    protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
+        return false;
     }
 
     protected abstract List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots);
 
-    protected void trimEdges(Int2ObjectMap<ItemStack> slots, int rows) {
+    protected final void trimEdges(Int2ObjectMap<ItemStack> slots, int rows) {
         for (int i = 0; i < rows; i++) {
             slots.remove(9 * i);
             slots.remove(9 * i + 8);

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
@@ -8,6 +8,7 @@ import de.hysky.skyblocker.skyblock.accessories.newyearcakes.NewYearCakesHelper;
 import de.hysky.skyblocker.skyblock.dungeon.CroesusHelper;
 import de.hysky.skyblocker.skyblock.dungeon.CroesusProfit;
 import de.hysky.skyblocker.skyblock.dungeon.terminal.ColorTerminal;
+import de.hysky.skyblocker.skyblock.dungeon.terminal.LightsOnTerminal;
 import de.hysky.skyblocker.skyblock.dungeon.terminal.OrderTerminal;
 import de.hysky.skyblocker.skyblock.dungeon.terminal.StartsWithTerminal;
 import de.hysky.skyblocker.skyblock.experiment.ChronomatronSolver;
@@ -47,6 +48,7 @@ public class ContainerSolverManager {
                 new ColorTerminal(),
                 new OrderTerminal(),
                 new StartsWithTerminal(),
+                new LightsOnTerminal(),
                 new CroesusHelper(),
                 new CroesusProfit(),
                 new ChronomatronSolver(),
@@ -114,10 +116,15 @@ public class ContainerSolverManager {
         highlights = null;
     }
 
-    public void onSlotClick(int slot, ItemStack stack) {
+    /**
+     * @return Whether the click should be disallowed.
+     */
+    public boolean onSlotClick(int slot, ItemStack stack) {
         if (currentSolver != null) {
-            currentSolver.onClickSlot(slot, stack, screenId, groups);
+            return currentSolver.onClickSlot(slot, stack, screenId, groups);
         }
+
+        return false;
     }
 
     public void onDraw(DrawContext context, List<Slot> slots) {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -168,6 +168,7 @@
   "skyblocker.config.dungeons.starredMobGlow.@Tooltip": "Applies the glowing effect to starred mobs that are visible.\n\nWARNING: This feature is experimental and you may encounter issues with it.",
 
   "skyblocker.config.dungeons.terminals": "Terminal Solvers (F7/M7)",
+  "skyblocker.config.dungeons.terminals.blockIncorrectClicks": "Block Incorrect Clicks",
   "skyblocker.config.dungeons.terminals.solveColor": "Solve Select Colored",
   "skyblocker.config.dungeons.terminals.solveOrder": "Solve Click In Order",
   "skyblocker.config.dungeons.terminals.solveStartsWith": "Solve Starts With",


### PR DESCRIPTION
Blocks incorrect clicks in F7/M7 terminals when enabled. Tested

This supports all the terminals that the mod has solvers for and also the lights on terminal. The colours terminal isn't supported because we don't have a solver for it yet (and thus no way to know if a click is good/bad).