### PR TITLE
Add line smoothener

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
@@ -40,6 +40,8 @@ public class ItemTooltip {
     public static void getTooltip(ItemStack stack, Item.TooltipContext tooltipContext, TooltipType tooltipType, List<Text> lines) {
         if (!Utils.isOnSkyblock() || client.player == null) return;
 
+        smoothenLines(lines);
+
         String name = getInternalNameFromNBT(stack, false);
         String internalID = getInternalNameFromNBT(stack, true);
         String neuName = name;
@@ -390,6 +392,15 @@ public class ItemTooltip {
         message.append(Text.literal("(" + eachPriceString.replace(".0", "") + " each)").formatted(Formatting.GRAY));
 
         return message;
+    }
+
+    private static void smoothenLines(List<Text> lines) {
+        for (int i = 0; i < lines.size(); i++) {
+            Text line = lines.get(i);
+            if (line.getString().equals("-----------------")) {
+                lines.set(i, Text.literal("                      ").formatted(Formatting.DARK_GRAY, Formatting.STRIKETHROUGH, Formatting.BOLD));
+            }
+        }
     }
 
     // If these options is true beforehand, the client will get first data of these options while loading.

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
@@ -398,7 +398,7 @@ public class ItemTooltip {
         for (int i = 0; i < lines.size(); i++) {
             Text line = lines.get(i);
             if (line.getString().equals("-----------------")) {
-                lines.set(i, Text.literal("                      ").formatted(Formatting.DARK_GRAY, Formatting.STRIKETHROUGH, Formatting.BOLD));
+                lines.set(i, Text.literal("                    ").formatted(Formatting.DARK_GRAY, Formatting.STRIKETHROUGH, Formatting.BOLD));
             }
         }
     }


### PR DESCRIPTION
Turns text with `-----------------` into text with a bunch of spaces. The initial text is strikethrough, so it ends up creating bumpy lines like this:

![image](https://github.com/SkyblockerMod/Skyblocker/assets/81419447/87ba1c61-d5fa-46da-87c7-424c46ff09a6)

This pr turns that into this:

![image](https://github.com/SkyblockerMod/Skyblocker/assets/81419447/0a2c7368-0813-4cbf-a29a-e5d545e6d8a5)

Since spaces are narrower than hyphens, I chose an arbitrary amount of spaces.
Also, hypixel seems to have this standard of 17 hyphens, so this applies to pretty much any place that has a hyphen line separator.