### PR TITLE
chat rules - fix bugs + refactor 

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRule.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRule.java
@@ -232,19 +232,19 @@ public class ChatRule {
             return true;
         }
 
-        String rawLocation = Utils.getLocationRaw();
+        String cleanedMapLocation = Utils.getMap().toLowerCase().replace(" ", "");
         Boolean isLocationValid = null;
-
-        for (String validLocation : validLocations.replace(" ", "").toLowerCase().split(",")) {//the locations are raw locations split by "," and start with ! if not locations
-            String rawValidLocation = ChatRulesHandler.locations.get(validLocation.replace("!",""));
-            if (rawValidLocation == null) continue;
+        for (String validLocation : validLocations.replace(" ", "").toLowerCase().split(",")) {//the locations are split by "," and start with ! if not locations
+            if (validLocation == null) continue;
             if (validLocation.startsWith("!")) {//not location
-                if (Objects.equals(rawValidLocation, rawLocation.toLowerCase())) {
+                if (Objects.equals(validLocation.substring(1), cleanedMapLocation)) {
                     isLocationValid = false;
                     break;
+                } else {
+                    isLocationValid = true;
                 }
             } else {
-                if (Objects.equals(rawValidLocation, rawLocation.toLowerCase())) { //normal location
+                if (Objects.equals(validLocation, cleanedMapLocation)) { //normal location
                     isLocationValid = true;
                     break;
                 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRuleConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRuleConfigScreen.java
@@ -156,6 +156,7 @@ public class ChatRuleConfigScreen extends Screen {
         locationLabelTextPos = currentPos;
         lineXOffset = client.textRenderer.getWidth(Text.translatable("skyblocker.config.chat.chatRules.screen.ruleScreen.locations")) + SPACER_X;
         locationsInput = new TextFieldWidget(client.textRenderer, currentPos.leftInt() + lineXOffset, currentPos.rightInt(), 200, 20, Text.of(""));
+        locationsInput.setMaxLength(96);
         locationsInput.setText(chatRule.getValidLocations());
         MutableText locationToolTip = Text.translatable("skyblocker.config.chat.chatRules.screen.ruleScreen.locations.@Tooltip");
         locationToolTip.append("\n");

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRulesConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRulesConfigListWidget.java
@@ -45,7 +45,7 @@ public class ChatRulesConfigListWidget extends ElementListWidget<ChatRulesConfig
 
     protected void addRuleAfterSelected() {
         hasChanged = true;
-        int newIndex = children().indexOf(getSelectedOrNull()) + 1;
+        int newIndex = Math.max(children().indexOf(getSelectedOrNull()), 0);
 
         ChatRulesHandler.chatRuleList.add(newIndex, new ChatRule());
         children().add(newIndex + 1, new ChatRuleConfigEntry(newIndex));


### PR DESCRIPTION
- fix crash when adding new rule after selecting last rule #717 
- add mineshaft location (requested on discord)
- let location input length be 96 (requested on discord)
- fix "!" in locations not working properly
- create a pre set list of map locations (only used in tool tip now)

the list of map locations could be moved to a value in utils Location enum if that makes sense