### PR TITLE
fix bugs

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/calculators/SignCalculator.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/calculators/SignCalculator.java
@@ -47,7 +47,7 @@ public class SignCalculator {
 
         //price can except decimals and exponents
         if (isPrice) {
-            return FORMATTER.format(output);
+            return String.valueOf(output);
         }
         //amounts want an integer number so round
         return Long.toString(Math.round(output));

--- a/src/main/java/de/hysky/skyblocker/utils/Calculator.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Calculator.java
@@ -202,7 +202,7 @@ public class Calculator {
 
     public static double calculate(String equation) {
         //custom bit for replacing purse with its value
-        equation = equation.toLowerCase().replaceAll("p(urse)?", String.valueOf(Utils.getPurse()));
+        equation = equation.toLowerCase().replaceAll("p(urse)?", String.valueOf((int)Utils.getPurse()));
         return evaluate(shunt(lex(equation)));
     }
 }

--- a/src/main/java/de/hysky/skyblocker/utils/Calculator.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Calculator.java
@@ -202,7 +202,7 @@ public class Calculator {
 
     public static double calculate(String equation) {
         //custom bit for replacing purse with its value
-        equation = equation.toLowerCase().replaceAll("p(urse)?", String.valueOf((int)Utils.getPurse()));
+        equation = equation.toLowerCase().replaceAll("p(urse)?", String.valueOf((long) Utils.getPurse()));
         return evaluate(shunt(lex(equation)));
     }
 }


### PR DESCRIPTION
- # fix inputting price 
when kevin used ```FORMATTER.format(output);``` for the output  it imputed commas to the sign confusing it. reverted bat to using ```String.valueOf```
- # fix purse value 
the purse value got changed  to convert double to string added a exponent value e.g. ("1.23E5") witch the calculator can not read properly. reverted back to changing to int before converting