### PR TITLE
Fix egg found message being sent twice

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
@@ -25,7 +25,6 @@ import java.util.regex.Pattern;
 
 public class EggFinder {
 	private static final Pattern eggFoundPattern = Pattern.compile("^(?:HOPPITY'S HUNT You found a Chocolate|You have already collected this Chocolate) (Breakfast|Lunch|Dinner)");
-	private static final Pattern newEggPattern = Pattern.compile("^HOPPITY'S HUNT A Chocolate (Breakfast|Lunch|Dinner) Egg has appeared!$");
 	private static final Logger logger = LoggerFactory.getLogger("Skyblocker Egg Finder");
 	private static final LinkedList<ArmorStandEntity> armorStandQueue = new LinkedList<>();
 	private static final Location[] possibleLocations = {Location.CRIMSON_ISLE, Location.CRYSTAL_HOLLOWS, Location.DUNGEON_HUB, Location.DWARVEN_MINES, Location.HUB, Location.THE_END, Location.THE_PARK, Location.GOLD_MINE};
@@ -122,16 +121,6 @@ public class EggFinder {
 				if (egg != null) egg.waypoint.setFound();
 			} catch (IllegalArgumentException e) {
 				logger.error("[Skyblocker Egg Finder] Failed to find egg type for egg found message. Tried to match against: " + matcher.group(0), e);
-			}
-		}
-
-		//There's only one egg of the same type at any given time, so we can set the changed egg to null
-		matcher = newEggPattern.matcher(text.getString());
-		if (matcher.find()) {
-			try {
-				EggType.valueOf(matcher.group(1).toUpperCase()).egg.setValue(null);
-			} catch (IllegalArgumentException e) {
-				logger.error("[Skyblocker Egg Finder] Failed to find egg type for egg spawn message. Tried to match against: " + matcher.group(0), e);
 			}
 		}
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/TimeTowerReminder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/TimeTowerReminder.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.skyblock.chocolatefactory;
 
 import com.mojang.brigadier.Message;
 import de.hysky.skyblocker.SkyblockerMod;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
@@ -49,7 +50,7 @@ public class TimeTowerReminder {
 		}
 
 		try (FileWriter writer = new FileWriter(tempFile)) {
-			writer.write(String.valueOf(System.currentTimeMillis()));
+			writer.write(String.valueOf(System.currentTimeMillis())); //Overwrites the file so no need to handle case where the file already exists and has text
 		} catch (IOException e) {
 			LOGGER.error("[Skyblocker Time Tower Reminder] Failed to write to temp file for Time Tower Reminder!", e);
 		}
@@ -57,8 +58,9 @@ public class TimeTowerReminder {
 
 	private static void sendMessage() {
 		if (MinecraftClient.getInstance().player == null || !Utils.isOnSkyblock()) return;
-		MinecraftClient.getInstance().player.sendMessage(Constants.PREFIX.get().append(Text.literal("Your Chocolate Factory's Time Tower has deactivated!").formatted(Formatting.RED)));
-
+		if (SkyblockerConfigManager.get().helpers.chocolateFactory.enableTimeTowerReminder) {
+			MinecraftClient.getInstance().player.sendMessage(Constants.PREFIX.get().append(Text.literal("Your Chocolate Factory's Time Tower has deactivated!").formatted(Formatting.RED)));
+		}
 		File tempFile = SkyblockerMod.CONFIG_DIR.resolve(TIME_TOWER_FILE).toFile();
 		try {
 			scheduled = false;


### PR DESCRIPTION
This should, *in theory*, fix it since the issue only happens when eggs move around and the eggs get reset to `null`. With this, there's no more null setting on new egg spawn (so only on world change, which is irrelevant to this), so the location comparison happens and since the 2nd message's egg location is the same as the 1st one it just doesn't get sent.

Might need testing though, maybe there's something I overlooked.