### PR TITLE
Improve search overlay

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/OverlayScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/OverlayScreen.java
@@ -93,17 +93,17 @@ public class OverlayScreen extends Screen {
             maxPetButton = ButtonWidget.builder(Text.literal("temp"), a -> {
                         SearchOverManager.maxPetLevel = !SearchOverManager.maxPetLevel;
                         if (SearchOverManager.maxPetLevel) {
-                            maxPetButton.setMessage(Text.literal("Max Pet Level ✔").formatted(Formatting.GREEN));
+                            maxPetButton.setMessage(Text.translatable("skyblocker.config.general.searchOverlay.maxPet").append(Text.literal(" ✔")).formatted(Formatting.GREEN));
                         } else {
-                            maxPetButton.setMessage(Text.literal("Max Pet Level ❌").formatted(Formatting.RED));
+                            maxPetButton.setMessage(Text.translatable("skyblocker.config.general.searchOverlay.maxPet").append(Text.literal(" ❌")).formatted(Formatting.RED));
                         }
                     })
                     .position(startX + rowWidth, startY)
                     .size(rowWidth / 2, rowHeight).build();
             if (SearchOverManager.maxPetLevel) {
-                maxPetButton.setMessage(Text.literal("Max Pet Level ✔").formatted(Formatting.GREEN));
+                maxPetButton.setMessage(Text.translatable("skyblocker.config.general.searchOverlay.maxPet").append(Text.literal(" ✔")).formatted(Formatting.GREEN));
             } else {
-                maxPetButton.setMessage(Text.literal("Max Pet Level ❌").formatted(Formatting.RED));
+                maxPetButton.setMessage(Text.translatable("skyblocker.config.general.searchOverlay.maxPet").append(Text.literal(" ❌")).formatted(Formatting.RED));
             }
 
             //dungeon star input
@@ -112,7 +112,7 @@ public class OverlayScreen extends Screen {
                 dungeonStarField.setText(String.valueOf(SearchOverManager.dungeonStars));
             }
             dungeonStarField.setMaxLength(2);
-            dungeonStarField.setTooltip(Tooltip.of(Text.of("Star count for dungeon items")));
+            dungeonStarField.setTooltip(Tooltip.of(Text.translatable("skyblocker.config.general.searchOverlay.starsTooltip")));
             dungeonStarField.setChangedListener(SearchOverManager::updateDungeonStars);
         }
 
@@ -150,7 +150,7 @@ public class OverlayScreen extends Screen {
             context.drawText(textRenderer, Text.translatable("skyblocker.config.general.searchOverlay.historyLabel"), historyButtons[0].getX() + renderOffset, historyButtons[0].getY() - rowHeight / 2, 0xFFFFFFFF, true);
         }
         if (SearchOverManager.isAuction) {
-            context.drawText(textRenderer, Text.literal("Stars:"), dungeonStarField.getX() - dungeonStarField.getWidth() + renderOffset, dungeonStarField.getY() + rowHeight / 4, 0xFFFFFFFF, true);
+            context.drawText(textRenderer, Text.translatable("skyblocker.config.general.searchOverlay.starsLabel"), dungeonStarField.getX() - dungeonStarField.getWidth() + renderOffset, dungeonStarField.getY() + rowHeight / 4, 0xFFFFFFFF, true);
         }
 
         //draw item stacks and tooltip to buttons

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/OverlayScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/OverlayScreen.java
@@ -122,7 +122,6 @@ public class OverlayScreen extends Screen {
         if (SearchOverManager.isAuction) {
             addDrawableChild(maxPetButton);
             addDrawableChild(dungeonStarButton);
-
         }
 
         //focus the search box
@@ -130,7 +129,7 @@ public class OverlayScreen extends Screen {
     }
 
     /**
-     * finds if the mouse is clicked on the dungeon star button and if so works out amount of stars to set
+     * Finds if the mouse is clicked on the dungeon star button and if so works out what stars the user clicked on
      *
      * @param mouseX the X coordinate of the mouse
      * @param mouseY the Y coordinate of the mouse
@@ -156,6 +155,9 @@ public class OverlayScreen extends Screen {
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
+    /**
+     * Updates the text displayed on the max pet level button to represent the settings current state
+     */
     private void updateMaxPetText() {
         if (SearchOverManager.maxPetLevel) {
             maxPetButton.setMessage(Text.translatable("skyblocker.config.general.searchOverlay.maxPet").append(Text.literal(" ✔")).formatted(Formatting.GREEN));
@@ -164,6 +166,9 @@ public class OverlayScreen extends Screen {
         }
     }
 
+    /**
+     * Updates stars in dungeon star input to represent the current star value
+     */
     private void updateStars() {
         MutableText stars = Text.empty();
         for (int i = 0; i < SearchOverManager.dungeonStars; i++) {
@@ -175,6 +180,13 @@ public class OverlayScreen extends Screen {
         dungeonStarButton.setMessage(stars);
     }
 
+    /**
+     * Renders the background for the search using the social interactions background
+     * @param context context
+     * @param mouseX mouseX
+     * @param mouseY mouseY
+     * @param delta delta
+     */
     @Override
     public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
         super.renderBackground(context, mouseX, mouseY, delta);
@@ -194,7 +206,6 @@ public class OverlayScreen extends Screen {
         super.render(context, mouseX, mouseY, delta);
         int renderOffset = (rowHeight - 16) / 2;
         context.drawGuiTexture(SEARCH_ICON_TEXTURE, finishedButton.getX() + renderOffset, finishedButton.getY() + renderOffset, 16, 16);
-        //labels
         if (historyButtons.length > 0 && historyButtons[0] != null) {
             context.drawText(textRenderer, Text.translatable("skyblocker.config.general.searchOverlay.historyLabel"), historyButtons[0].getX() + renderOffset, historyButtons[0].getY() - rowHeight / 2, 0xFFFFFFFF, true);
         }

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/OverlayScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/OverlayScreen.java
@@ -49,7 +49,7 @@ public class OverlayScreen extends Screen {
         searchField.setMaxLength(30);
 
         // finish buttons
-        finishedButton = ButtonWidget.builder(Text.literal("").setStyle(Style.EMPTY.withColor(Formatting.GREEN)), a -> close())
+        finishedButton = ButtonWidget.builder(Text.literal(""), a -> close())
                 .position(startX + rowWidth - rowHeight, startY)
                 .size(rowHeight, rowHeight).build();
 
@@ -89,7 +89,7 @@ public class OverlayScreen extends Screen {
         //auction only elements
         if (SearchOverManager.isAuction) {
             //max pet level button
-            maxPetButton = ButtonWidget.builder(Text.literal("temp"), a -> {
+            maxPetButton = ButtonWidget.builder(Text.literal(""), a -> {
                         SearchOverManager.maxPetLevel = !SearchOverManager.maxPetLevel;
                         updateMaxPetText();
                     })
@@ -144,7 +144,7 @@ public class OverlayScreen extends Screen {
             double textOffset = (dungeonStarButton.getWidth() - actualTextWidth) / 2;
             double offset = mouseX - (dungeonStarButton.getX() + textOffset);
             int starCount = (int) ((offset / actualTextWidth) * 10);
-            starCount = Math.clamp(0, starCount + 1, 10);
+            starCount = Math.clamp(starCount + 1, 0, 10);
             //if same as old value set stars to 0 else set to selected amount
             if (starCount == SearchOverManager.dungeonStars) {
                 SearchOverManager.dungeonStars = 0;
@@ -167,7 +167,7 @@ public class OverlayScreen extends Screen {
     private void updateStars() {
         MutableText stars = Text.empty();
         for (int i = 0; i < SearchOverManager.dungeonStars; i++) {
-            stars.append(Text.literal("✪").formatted(Formatting.GREEN));
+            stars.append(Text.literal("✪").formatted(i < 5 ? Formatting.YELLOW : Formatting.RED));
         }
         for (int i = SearchOverManager.dungeonStars; i < 10; i++) {
             stars.append(Text.literal("✪"));

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -229,7 +229,24 @@ public class SearchOverManager {
         //update the suggestion values
         int totalSuggestions = SkyblockerConfigManager.get().uiAndVisuals.searchOverlay.maxSuggestions;
         if (newValue.isBlank() || totalSuggestions == 0) return; //do not search for empty value
-        suggestionsArray = (isAuction ? auctionItems : bazaarItems).stream().filter(item -> item.toLowerCase().contains(search.toLowerCase())).limit(totalSuggestions).toArray(String[]::new);
+        suggestionsArray = (isAuction ? auctionItems : bazaarItems).stream().sorted(Comparator.comparing(SearchOverManager::shouldFrontLoad, Comparator.reverseOrder())).filter(item -> item.toLowerCase().contains(search.toLowerCase())).limit(totalSuggestions).toArray(String[]::new);
+    }
+
+    /**
+     * determines if a value should be moved to the front of the search
+     * @param name name of the suggested item
+     * @return if the value should be at the front of the search queue
+     */
+    private static boolean shouldFrontLoad(String name) {
+        if (!isAuction) {
+            return false;
+        }
+        //do nothing to non pets
+        if (!auctionPets.contains(name.toLowerCase())) {
+            return  false;
+        }
+        //only front load pets when there is enough of the pet typed, so it does not spoil searching for other items
+        return (double) search.length() / name.length() > 0.5;
     }
 
     protected static void updateDungeonStars(String newValue) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -356,7 +356,7 @@ public class SearchOverManager {
             }
         } else {
             // still filter for only pets
-            if (auctionPets.contains(search)) {
+            if (auctionPets.contains(search.toLowerCase())) {
                 // add bracket so only get pets
                 search = "] " + search;
             }

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -10,6 +10,7 @@ import de.hysky.skyblocker.skyblock.item.tooltip.TooltipInfoType;
 import de.hysky.skyblocker.utils.NEURepoManager;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
 import io.github.moulberry.repo.data.NEUItem;
+import io.github.moulberry.repo.util.NEUId;
 import it.unimi.dsi.fastutil.Pair;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
@@ -24,10 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -40,8 +38,7 @@ public class SearchOverManager {
     private static final Logger LOGGER = LoggerFactory.getLogger("Skyblocker Search Overlay");
 
     private static final Pattern BAZAAR_ENCHANTMENT_PATTERN = Pattern.compile("ENCHANTMENT_(\\D*)_(\\d+)");
-    private static final Pattern AUCTION_PET_AND_RUNE_PATTERN = Pattern.compile("([A-Z0-9_]+);(\\d+)");
-
+    private static final String PET_NAME_START = "[Lvl {LVL}] ";
     /**
      * converts index (in array) +1 to a roman numeral
      */
@@ -52,14 +49,18 @@ public class SearchOverManager {
 
     private static @Nullable SignBlockEntity sign = null;
     private static boolean signFront = true;
-    private static boolean isAuction;
+    protected static boolean isAuction;
     private static boolean isCommand;
 
     protected static String search = "";
+    protected static Boolean maxPetLevel = false;
+    protected static int dungeonStars = -1;
 
     // Use non-final variables and swap them to prevent concurrent modification
     private static HashSet<String> bazaarItems;
     private static HashSet<String> auctionItems;
+    private static HashSet<String> auctionPets;
+    private static HashSet<String> starableItems;
     private static HashMap<String, String> namesToId;
 
     public static String[] suggestionsArray = {};
@@ -91,6 +92,8 @@ public class SearchOverManager {
     private static void loadItems() {
         HashSet<String> bazaarItems = new HashSet<>();
         HashSet<String> auctionItems = new HashSet<>();
+        HashSet<String> auctionPets = new HashSet<>();
+        HashSet<String> starableItems = new HashSet<>();
         HashMap<String, String> namesToId = new HashMap<>();
 
         //get bazaar items
@@ -138,29 +141,29 @@ public class SearchOverManager {
         }
 
         //get auction items
+        Set<@NEUId String> essenceCosts = NEURepoManager.NEU_REPO.getConstants().getEssenceCost().getCosts().keySet();
         try {
             if (TooltipInfoType.THREE_DAY_AVERAGE.getData() == null) {
                 TooltipInfoType.THREE_DAY_AVERAGE.run();
             }
             for (Map.Entry<String, JsonElement> entry : TooltipInfoType.THREE_DAY_AVERAGE.getData().entrySet()) {
                 String id = entry.getKey();
-
-                Matcher matcher = AUCTION_PET_AND_RUNE_PATTERN.matcher(id);
-                if (matcher.find()) {//is a pet or rune convert id to name
-                    String name = matcher.group(1).replace("_", " ");
-                    name = capitalizeFully(name);
-                    auctionItems.add(name);
-                    namesToId.put(name, id);
-                    continue;
-                }
-                //something else look up in NEU repo.
+                //look up in NEU repo.
                 id = id.split("[+-]")[0];
                 NEUItem neuItem = NEURepoManager.NEU_REPO.getItems().getItemBySkyblockId(id);
                 if (neuItem != null) {
                     String name = Formatting.strip(neuItem.getDisplayName());
+                    //add names that are pets to the list of pets to work with the lvl 100 button
+                    if (name != null && name.startsWith(PET_NAME_START)) {
+                        name = name.replace(PET_NAME_START, "");
+                        auctionPets.add(name);
+                    }
+                    //if it has essence cost add to starable items
+                    if (essenceCosts.contains(neuItem.getSkyblockItemId())) {
+                        starableItems.add(name);
+                    }
                     auctionItems.add(name);
                     namesToId.put(name, id);
-                    continue;
                 }
             }
         } catch (Exception e) {
@@ -169,11 +172,14 @@ public class SearchOverManager {
 
         SearchOverManager.bazaarItems = bazaarItems;
         SearchOverManager.auctionItems = auctionItems;
+        SearchOverManager.auctionPets = auctionPets;
+        SearchOverManager.starableItems = starableItems;
         SearchOverManager.namesToId = namesToId;
     }
 
     /**
      * Capitalizes the first letter off every word in a string
+     *
      * @param str string to capitalize
      */
     private static String capitalizeFully(String str) {
@@ -188,8 +194,9 @@ public class SearchOverManager {
 
     /**
      * Receives data when a search is started and resets values
-     * @param sign the sign that is being edited
-     * @param front if it's the front of the sign
+     *
+     * @param sign      the sign that is being edited
+     * @param front     if it's the front of the sign
      * @param isAuction if the sign is loaded from the auction house menu or bazaar
      */
     public static void updateSign(@NotNull SignBlockEntity sign, boolean front, boolean isAuction) {
@@ -214,6 +221,7 @@ public class SearchOverManager {
 
     /**
      * Updates the search value and the suggestions based on that value.
+     *
      * @param newValue new search value
      */
     protected static void updateSearch(String newValue) {
@@ -224,8 +232,18 @@ public class SearchOverManager {
         suggestionsArray = (isAuction ? auctionItems : bazaarItems).stream().filter(item -> item.toLowerCase().contains(search.toLowerCase())).limit(totalSuggestions).toArray(String[]::new);
     }
 
+    protected static void updateDungeonStars(String newValue) {
+        try {
+            dungeonStars = Math.min(Integer.parseInt(newValue), 10);
+        } catch (Exception e) {
+            //not parsable number just set to 0
+            dungeonStars = 0;
+        }
+    }
+
     /**
      * Gets the suggestion in the suggestion array at the index
+     *
      * @param index index of suggestion
      */
     protected static String getSuggestion(int index) {
@@ -242,6 +260,7 @@ public class SearchOverManager {
 
     /**
      * Gets the item name in the history array at the index
+     *
      * @param index index of suggestion
      */
     protected static String getHistory(int index) {
@@ -286,17 +305,61 @@ public class SearchOverManager {
     }
 
     /**
-     *Saves the current value of ({@link SearchOverManager#search}) then pushes it to a command or sign depending on how the gui was opened
+     * Saves the current value of ({@link SearchOverManager#search}) then pushes it to a command or sign depending on how the gui was opened
      */
     protected static void pushSearch() {
         //save to history
         if (!search.isEmpty()) {
             saveHistory();
         }
+        //add pet level or dungeon starts if in ah
+        if (isAuction) {
+            addExtras();
+        }
+        //push
         if (isCommand) {
             pushCommand();
         } else {
             pushSign();
+        }
+    }
+
+    /**
+     * Adds pet level 100 or necessary dungeon starts if needed
+     */
+    private static void addExtras() {
+        // pet level
+        if (maxPetLevel) {
+            if (auctionPets.contains(search)) {
+                if (search.equals("Golden Dragon")) {
+                    search = "[Lvl 200] " + search;
+                } else {
+                    search = "[Lvl 100] " + search;
+                }
+            }
+        } else {
+            // still filter for only pets
+            if (auctionPets.contains(search)) {
+                // add bracket so only get pets
+                search = "] " + search;
+            }
+        }
+
+        // dungeon stars
+        // check if it's a dungeon item and if so add correct stars
+        if (dungeonStars > 0 && starableItems.contains(search)) {
+            StringBuilder starString = new StringBuilder(" ");
+            //add stars up to 5
+            starString.append("✪".repeat(Math.max(0, Math.min(dungeonStars, 5))));
+            //add number for other stars
+            switch (dungeonStars) {
+                case 6 -> starString.append("➊");
+                case 7 -> starString.append("➋");
+                case 8 -> starString.append("➌");
+                case 9 -> starString.append("➍");
+                case 10 -> starString.append("➎");
+            }
+            search += starString.toString();
         }
     }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -234,6 +234,7 @@ public class SearchOverManager {
 
     /**
      * determines if a value should be moved to the front of the search
+     *
      * @param name name of the suggested item
      * @return if the value should be at the front of the search queue
      */
@@ -243,7 +244,7 @@ public class SearchOverManager {
         }
         //do nothing to non pets
         if (!auctionPets.contains(name.toLowerCase())) {
-            return  false;
+            return false;
         }
         //only front load pets when there is enough of the pet typed, so it does not spoil searching for other items
         return (double) search.length() / name.length() > 0.5;

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -156,11 +156,11 @@ public class SearchOverManager {
                     //add names that are pets to the list of pets to work with the lvl 100 button
                     if (name != null && name.startsWith(PET_NAME_START)) {
                         name = name.replace(PET_NAME_START, "");
-                        auctionPets.add(name);
+                        auctionPets.add(name.toLowerCase());
                     }
                     //if it has essence cost add to starable items
-                    if (essenceCosts.contains(neuItem.getSkyblockItemId())) {
-                        starableItems.add(name);
+                    if (name != null && essenceCosts.contains(neuItem.getSkyblockItemId())) {
+                        starableItems.add(name.toLowerCase());
                     }
                     auctionItems.add(name);
                     namesToId.put(name, id);
@@ -330,8 +330,8 @@ public class SearchOverManager {
     private static void addExtras() {
         // pet level
         if (maxPetLevel) {
-            if (auctionPets.contains(search)) {
-                if (search.equals("Golden Dragon")) {
+            if (auctionPets.contains(search.toLowerCase())) {
+                if (search.equalsIgnoreCase("golden dragon")) {
                     search = "[Lvl 200] " + search;
                 } else {
                     search = "[Lvl 100] " + search;
@@ -347,7 +347,7 @@ public class SearchOverManager {
 
         // dungeon stars
         // check if it's a dungeon item and if so add correct stars
-        if (dungeonStars > 0 && starableItems.contains(search)) {
+        if (dungeonStars > 0 && starableItems.contains(search.toLowerCase())) {
             StringBuilder starString = new StringBuilder(" ");
             //add stars up to 5
             starString.append("✪".repeat(Math.max(0, Math.min(dungeonStars, 5))));

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -141,8 +141,8 @@ public class SearchOverManager {
         }
 
         //get auction items
-        Set<@NEUId String> essenceCosts = NEURepoManager.NEU_REPO.getConstants().getEssenceCost().getCosts().keySet();
         try {
+            Set<@NEUId String> essenceCosts = NEURepoManager.NEU_REPO.getConstants().getEssenceCost().getCosts().keySet();
             if (TooltipInfoType.THREE_DAY_AVERAGE.getData() == null) {
                 TooltipInfoType.THREE_DAY_AVERAGE.run();
             }

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -54,7 +54,7 @@ public class SearchOverManager {
 
     protected static String search = "";
     protected static Boolean maxPetLevel = false;
-    protected static int dungeonStars = -1;
+    protected static int dungeonStars = 0;
 
     // Use non-final variables and swap them to prevent concurrent modification
     private static HashSet<String> bazaarItems;
@@ -248,15 +248,6 @@ public class SearchOverManager {
         }
         //only front load pets when there is enough of the pet typed, so it does not spoil searching for other items
         return (double) search.length() / name.length() > 0.5;
-    }
-
-    protected static void updateDungeonStars(String newValue) {
-        try {
-            dungeonStars = Math.min(Integer.parseInt(newValue), 10);
-        } catch (Exception e) {
-            //not parsable number just set to 0
-            dungeonStars = 0;
-        }
     }
 
     /**

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -251,6 +251,9 @@
   "skyblocker.config.general.quiverWarning.enableQuiverWarningInDungeons": "Enable Quiver Warning In Dungeons",
 
   "skyblocker.config.general.searchOverlay.historyLabel": "History:",
+  "skyblocker.config.general.searchOverlay.starsLabel": "Stars:",
+  "skyblocker.config.general.searchOverlay.starsTooltip": "Star count for dungeon items",
+  "skyblocker.config.general.searchOverlay.maxPet": "Max Pet Level",
 
   "skyblocker.config.general.shortcuts": "Shortcuts",
   "skyblocker.config.general.shortcuts.config": "Shortcuts Config...",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -251,9 +251,9 @@
   "skyblocker.config.general.quiverWarning.enableQuiverWarningInDungeons": "Enable Quiver Warning In Dungeons",
 
   "skyblocker.config.general.searchOverlay.historyLabel": "History:",
-  "skyblocker.config.general.searchOverlay.starsLabel": "Stars:",
   "skyblocker.config.general.searchOverlay.starsTooltip": "Star count for dungeon items",
   "skyblocker.config.general.searchOverlay.maxPet": "Max Pet Level",
+  "skyblocker.config.general.searchOverlay.maxPet.@Tooltip": "Only show pets that are max level",
 
   "skyblocker.config.general.shortcuts": "Shortcuts",
   "skyblocker.config.general.shortcuts.config": "Shortcuts Config...",


### PR DESCRIPTION
improve look of search overlay and added pet and star options.
# added background
![image](https://github.com/SkyblockerMod/Skyblocker/assets/70377847/f5265fb1-7a8d-488c-bc60-a20f254c912e)
![image](https://github.com/SkyblockerMod/Skyblocker/assets/70377847/75385ca4-5f9a-4c4f-bff5-dd488271ae51)
# added max pet level and  otherwise add ```]``` to only get pets when searching for them
![image](https://github.com/SkyblockerMod/Skyblocker/assets/70377847/f8d841fb-48ef-4bd1-8df6-0d271a48ee2c)
![image](https://github.com/SkyblockerMod/Skyblocker/assets/70377847/e9648cec-ab2b-480b-bddb-721c4b251a20)
# added dungeon stars
![image](https://github.com/SkyblockerMod/Skyblocker/assets/70377847/58f1de7e-1489-4a2a-ba30-0dfd532535c9)
![image](https://github.com/SkyblockerMod/Skyblocker/assets/70377847/79d7317a-37b6-403a-9b83-21083771e0a6)
# prioritise pets in auction house to show above skins
![image](https://github.com/SkyblockerMod/Skyblocker/assets/70377847/109730d5-180e-48cc-b28b-bdbec02e1d6f)
