### PR TITLE
Refactor AbstractContainerMatcher to allow using Predicates as well as Patterns

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -214,6 +214,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 *
 	 * @implNote This runs before {@link ScreenHandler#onSlotClick(int, int, SlotActionType, net.minecraft.entity.player.PlayerEntity)}
 	 */
+	@SuppressWarnings("unchecked") //Umm ackshually, it's a checked cast. Poor intellij just doesn't know.
 	@Inject(method = "onMouseClick(Lnet/minecraft/screen/slot/Slot;IILnet/minecraft/screen/slot/SlotActionType;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;clickSlot(IIILnet/minecraft/screen/slot/SlotActionType;Lnet/minecraft/entity/player/PlayerEntity;)V"), cancellable = true)
 	private void skyblocker$onSlotClick(Slot slot, int slotId, int button, SlotActionType actionType, CallbackInfo ci) {
 		if (!Utils.isOnSkyblock()) return;
@@ -231,9 +232,11 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 		ContainerSolver currentSolver = SkyblockerMod.getInstance().containerSolverManager.getCurrentSolver();
 
 		// Prevent clicks on filler items
-		if (SkyblockerConfigManager.get().uiAndVisuals.hideEmptyTooltips && FILLER_ITEMS.contains(stack.getName().getString()) &&
+		// This is not always false like intellij says. It assumes the cast will fail, so the method will return false.
+		if (SkyblockerConfigManager.get().uiAndVisuals.hideEmptyTooltips
+				&& FILLER_ITEMS.contains(stack.getName().getString())
 				// Allow clicks in Ultrasequencer and Superpairs
-				(!UltrasequencerSolver.INSTANCE.getName().matcher(title).matches() || SkyblockerConfigManager.get().helpers.experiments.enableUltrasequencerSolver)) {
+				&& (!UltrasequencerSolver.INSTANCE.test((HandledScreen<T>) (Object) this) || SkyblockerConfigManager.get().helpers.experiments.enableUltrasequencerSolver)) {
 			ci.cancel();
 			return;
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/accessories/newyearcakes/NewYearCakeBagHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/accessories/newyearcakes/NewYearCakeBagHelper.java
@@ -11,23 +11,23 @@ import net.minecraft.screen.slot.Slot;
 import java.util.List;
 
 public class NewYearCakeBagHelper extends ContainerSolver {
-    public NewYearCakeBagHelper() {
-        super("New Year Cake Bag");
-    }
+	public NewYearCakeBagHelper() {
+		super("New Year Cake Bag");
+	}
 
-    @Override
-    protected boolean isEnabled() {
-        return SkyblockerConfigManager.get().helpers.enableNewYearCakesHelper;
-    }
+	@Override
+	protected boolean isEnabled() {
+		return SkyblockerConfigManager.get().helpers.enableNewYearCakesHelper;
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        MinecraftClient client = MinecraftClient.getInstance();
-        if (client.player != null) {
-            for (Slot slot : client.player.currentScreenHandler.slots) {
-                NewYearCakesHelper.INSTANCE.addCake(NewYearCakesHelper.getCakeYear(slot.getStack()));
-            }
-        }
-        return List.of();
-    }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		if (client.player != null) {
+			for (Slot slot : client.player.currentScreenHandler.slots) {
+				NewYearCakesHelper.INSTANCE.addCake(NewYearCakesHelper.getCakeYear(slot.getStack()));
+			}
+		}
+		return List.of();
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/accessories/newyearcakes/NewYearCakesHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/accessories/newyearcakes/NewYearCakesHelper.java
@@ -20,61 +20,61 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class NewYearCakesHelper extends ContainerSolver {
-    private static final Logger LOGGER = LoggerFactory.getLogger(NewYearCakeBagHelper.class);
-    private static final Pattern NEW_YEAR_CAKE = Pattern.compile("New Year Cake \\(Year (?<year>\\d+)\\)");
-    private static final Pattern NEW_YEAR_CAKE_PURCHASE = Pattern.compile("You purchased New Year Cake \\(Year (?<year>\\d+)\\) for .+ coins!");
-    private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance(Locale.US);
-    public static final NewYearCakesHelper INSTANCE = new NewYearCakesHelper();
-    private final Map<String, IntSet> cakes = new HashMap<>();
+	private static final Logger LOGGER = LoggerFactory.getLogger(NewYearCakesHelper.class);
+	private static final Pattern NEW_YEAR_CAKE = Pattern.compile("New Year Cake \\(Year (?<year>\\d+)\\)");
+	private static final Pattern NEW_YEAR_CAKE_PURCHASE = Pattern.compile("You purchased New Year Cake \\(Year (?<year>\\d+)\\) for .+ coins!");
+	private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance(Locale.US);
+	public static final NewYearCakesHelper INSTANCE = new NewYearCakesHelper();
+	private final Map<String, IntSet> cakes = new HashMap<>();
 
-    private NewYearCakesHelper() {
-        super("Auctions: \".*\"");
-        ClientReceiveMessageEvents.GAME.register(this::onChatMessage);
-    }
+	private NewYearCakesHelper() {
+		super("Auctions: \".*\"");
+		ClientReceiveMessageEvents.GAME.register(this::onChatMessage);
+	}
 
-    public static int getCakeYear(ItemStack stack) {
-        return getCakeYear(NEW_YEAR_CAKE, stack.getName().getString());
-    }
+	public static int getCakeYear(ItemStack stack) {
+		return getCakeYear(NEW_YEAR_CAKE, stack.getName().getString());
+	}
 
-    public static int getCakeYear(Pattern pattern, String name) {
-        Matcher matcher = pattern.matcher(name);
-        if (matcher.matches()) {
-            try {
-                return NUMBER_FORMAT.parse(matcher.group("year")).intValue();
-            } catch (ParseException e) {
-                LOGGER.info("Failed to parse year from New Year Cake: " + name, e);
-            }
-        }
-        return -1;
-    }
+	public static int getCakeYear(Pattern pattern, String name) {
+		Matcher matcher = pattern.matcher(name);
+		if (matcher.matches()) {
+			try {
+				return NUMBER_FORMAT.parse(matcher.group("year")).intValue();
+			} catch (ParseException e) {
+				LOGGER.info("Failed to parse year from New Year Cake: " + name, e);
+			}
+		}
+		return -1;
+	}
 
-    @Override
-    protected boolean isEnabled() {
-        return SkyblockerConfigManager.get().helpers.enableNewYearCakesHelper;
-    }
+	@Override
+	protected boolean isEnabled() {
+		return SkyblockerConfigManager.get().helpers.enableNewYearCakesHelper;
+	}
 
-    public boolean addCake(int year) {
-        if (year < 0) return false;
-        return cakes.computeIfAbsent(Utils.getProfile(), _profile -> new IntOpenHashSet()).add(year);
-    }
+	public boolean addCake(int year) {
+		if (year < 0) return false;
+		return cakes.computeIfAbsent(Utils.getProfile(), _profile -> new IntOpenHashSet()).add(year);
+	}
 
-    private void onChatMessage(Text message, boolean overlay) {
-        if (isEnabled()) {
-            addCake(getCakeYear(NEW_YEAR_CAKE_PURCHASE, message.getString()));
-        }
-    }
+	private void onChatMessage(Text message, boolean overlay) {
+		if (isEnabled()) {
+			addCake(getCakeYear(NEW_YEAR_CAKE_PURCHASE, message.getString()));
+		}
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        String profile = Utils.getProfile();
-        if (cakes.isEmpty() || !cakes.containsKey(profile) || cakes.containsKey(profile) && cakes.get(profile).isEmpty()) return List.of();
-        List<ColorHighlight> highlights = new ArrayList<>();
-        for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
-            int year = getCakeYear(entry.getValue());
-            if (year >= 0 && cakes.containsKey(profile)) {
-                highlights.add(cakes.get(profile).contains(year) ? ColorHighlight.red(entry.getIntKey()) : ColorHighlight.green(entry.getIntKey()));
-            }
-        }
-        return highlights;
-    }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		String profile = Utils.getProfile();
+		if (cakes.isEmpty() || !cakes.containsKey(profile) || cakes.containsKey(profile) && cakes.get(profile).isEmpty()) return List.of();
+		List<ColorHighlight> highlights = new ArrayList<>();
+		for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
+			int year = getCakeYear(entry.getValue());
+			if (year >= 0 && cakes.containsKey(profile)) {
+				highlights.add(cakes.get(profile).contains(year) ? ColorHighlight.red(entry.getIntKey()) : ColorHighlight.green(entry.getIntKey()));
+			}
+		}
+		return highlights;
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/ChocolateFactorySolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/ChocolateFactorySolver.java
@@ -1,11 +1,10 @@
 package de.hysky.skyblocker.skyblock.chocolatefactory;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
-import de.hysky.skyblocker.skyblock.item.tooltip.adders.LineSmoothener;
 import de.hysky.skyblocker.skyblock.item.tooltip.TooltipAdder;
+import de.hysky.skyblocker.skyblock.item.tooltip.adders.LineSmoothener;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.RegexUtils;
-import de.hysky.skyblocker.utils.RomanNumerals;
 import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import de.hysky.skyblocker.utils.render.gui.ContainerSolver;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -89,7 +88,7 @@ public class ChocolateFactorySolver extends ContainerSolver {
 	}
 
 	@Override
-	protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
 		updateFactoryInfo(slots);
 		List<ColorHighlight> highlights = new ArrayList<>();
 
@@ -252,7 +251,8 @@ public class ChocolateFactorySolver extends ContainerSolver {
 		return highlights;
 	}
 
-	private record Rabbit(double cpsIncrease, int cost, int slot) { }
+	private record Rabbit(double cpsIncrease, int cost, int slot) {
+	}
 
 	public static final class Tooltip extends TooltipAdder {
 		public Tooltip() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/CroesusHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/CroesusHelper.java
@@ -13,28 +13,28 @@ import java.util.List;
 
 public class CroesusHelper extends ContainerSolver {
 
-    public CroesusHelper() {
-        super("^Croesus$");
-    }
+	public CroesusHelper() {
+		super("^Croesus$");
+	}
 
-    @Override
-    protected boolean isEnabled() {
-        return SkyblockerConfigManager.get().dungeons.croesusHelper;
-    }
+	@Override
+	protected boolean isEnabled() {
+		return SkyblockerConfigManager.get().dungeons.croesusHelper;
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        List<ColorHighlight> highlights = new ArrayList<>();
-        for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
-            ItemStack stack = entry.getValue();
-            if (stack != null && stack.contains(DataComponentTypes.LORE)) {
-                if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Opened Chest:")) != null) {
-                    highlights.add(ColorHighlight.gray(entry.getIntKey()));
-                } else if (ItemUtils.getLoreLineIf(stack, s -> s.contains("No more Chests to open!")) != null) {
-                    highlights.add(ColorHighlight.red(entry.getIntKey()));
-                }
-            }
-        }
-        return highlights;
-    }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		List<ColorHighlight> highlights = new ArrayList<>();
+		for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
+			ItemStack stack = entry.getValue();
+			if (stack != null && stack.contains(DataComponentTypes.LORE)) {
+				if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Opened Chest:")) != null) {
+					highlights.add(ColorHighlight.gray(entry.getIntKey()));
+				} else if (ItemUtils.getLoreLineIf(stack, s -> s.contains("No more Chests to open!")) != null) {
+					highlights.add(ColorHighlight.red(entry.getIntKey()));
+				}
+			}
+		}
+		return highlights;
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/CroesusProfit.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/CroesusProfit.java
@@ -1,8 +1,6 @@
 package de.hysky.skyblocker.skyblock.dungeon;
 
-import com.google.gson.JsonObject;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
-import de.hysky.skyblocker.skyblock.item.tooltip.TooltipInfoType;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import de.hysky.skyblocker.utils.render.gui.ContainerSolver;
@@ -10,7 +8,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.Util;
-
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -21,236 +18,237 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CroesusProfit extends ContainerSolver {
-    private static final Pattern ESSENCE_PATTERN = Pattern.compile("(?<type>[A-Za-z]+) Essence x(?<amount>[0-9]+)");
-    public CroesusProfit() {
-        super(".*Catacombs - Floor.*");
-    }
+	private static final Pattern ESSENCE_PATTERN = Pattern.compile("(?<type>[A-Za-z]+) Essence x(?<amount>[0-9]+)");
 
-    @Override
-    protected boolean isEnabled() {
-        return SkyblockerConfigManager.get().dungeons.dungeonChestProfit.croesusProfit;
-    }
+	public CroesusProfit() {
+		super(".*Catacombs - Floor.*");
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        List<ColorHighlight> highlights = new ArrayList<>();
-        ItemStack bestChest = null, secondBestChest = null;
-        double bestValue = 0, secondBestValue = 0;    // If negative value of chest - it is out of the question
-        double dungeonKeyPriceData = getItemPrice("DUNGEON_CHEST_KEY") * 2; // lesser ones don't worth the hassle
+	@Override
+	protected boolean isEnabled() {
+		return SkyblockerConfigManager.get().dungeons.dungeonChestProfit.croesusProfit;
+	}
 
-        for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
-            ItemStack stack = entry.getValue();
-            if (stack.getName().getString().contains("Chest")) {
-                double value = valueChest(stack);
-                if (value > bestValue) {
-                    secondBestChest = bestChest;
-                    secondBestValue = bestValue;
-                    bestChest = stack;
-                    bestValue = value;
-                } else if (value > secondBestValue) {
-                    secondBestChest = stack;
-                    secondBestValue = value;
-                }
-            }
-        }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		List<ColorHighlight> highlights = new ArrayList<>();
+		ItemStack bestChest = null, secondBestChest = null;
+		double bestValue = 0, secondBestValue = 0;    // If negative value of chest - it is out of the question
+		double dungeonKeyPriceData = getItemPrice("DUNGEON_CHEST_KEY") * 2; // lesser ones don't worth the hassle
 
-        for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
-            ItemStack stack = entry.getValue();
-            if (stack != null) {
-                if (stack.equals(bestChest)) {
-                    highlights.add(ColorHighlight.green(entry.getIntKey()));
-                } else if (stack.equals(secondBestChest) && secondBestValue > dungeonKeyPriceData) {
-                    highlights.add(ColorHighlight.yellow(entry.getIntKey()));
-                }
-            }
-        }
-        return highlights;
-    }
+		for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
+			ItemStack stack = entry.getValue();
+			if (stack.getName().getString().contains("Chest")) {
+				double value = valueChest(stack);
+				if (value > bestValue) {
+					secondBestChest = bestChest;
+					secondBestValue = bestValue;
+					bestChest = stack;
+					bestValue = value;
+				} else if (value > secondBestValue) {
+					secondBestChest = stack;
+					secondBestValue = value;
+				}
+			}
+		}
 
-
-    private double valueChest(@NotNull ItemStack chest) {
-        double chestValue = 0;
-        int chestPrice = 0;
-        List<String> chestItems = new ArrayList<>();
-
-        boolean processingContents = false;
-        for (Text line : ItemUtils.getLore(chest)) {
-            String lineString = line.getString();
-            if (lineString.contains("Contents")) {
-                processingContents = true;
-                continue;
-            } else if (lineString.isEmpty()) {
-                processingContents = false;
-            } else if (lineString.contains("Coins") && !processingContents) {
-                chestPrice = Integer.parseInt(lineString.replaceAll(",", "").replaceAll("\\D", ""));
-            }
-
-            if (processingContents) {
-                if (lineString.contains("Essence")) {
-                    Matcher matcher = ESSENCE_PATTERN.matcher(lineString);
-                    if (matcher.matches()) {    // add to chest value result of multiplying price of essence on it's amount
-                        chestValue += getItemPrice(("ESSENCE_" + matcher.group("type")).toUpperCase()) * Integer.parseInt(matcher.group("amount"));
-                    }
-                } else {
-                    if (lineString.contains("Spirit")) {    // TODO: make code like this to detect recombed gear (it can drop with 1% chance, according to wiki, tho I never saw any?)
-                        chestValue += line.getStyle().toString().contains("color=dark_purple") ? getItemPrice("Spirit Epic") : getItemPrice(lineString);
-                    } else {
-                        chestItems.add(lineString);
-                    }
-                }
-            }
-        }
-        for (String item : chestItems){
-            chestValue += getItemPrice(item);
-        }
-        return chestValue-chestPrice;
-    }
+		for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
+			ItemStack stack = entry.getValue();
+			if (stack != null) {
+				if (stack.equals(bestChest)) {
+					highlights.add(ColorHighlight.green(entry.getIntKey()));
+				} else if (stack.equals(secondBestChest) && secondBestValue > dungeonKeyPriceData) {
+					highlights.add(ColorHighlight.yellow(entry.getIntKey()));
+				}
+			}
+		}
+		return highlights;
+	}
 
 
-    private double getItemPrice(String itemDisplayName) {
-        return ItemUtils.getItemPrice(dungeonDropsNameToId.get(itemDisplayName)).leftDouble();
-    }
+	private double valueChest(@NotNull ItemStack chest) {
+		double chestValue = 0;
+		int chestPrice = 0;
+		List<String> chestItems = new ArrayList<>();
+
+		boolean processingContents = false;
+		for (Text line : ItemUtils.getLore(chest)) {
+			String lineString = line.getString();
+			if (lineString.contains("Contents")) {
+				processingContents = true;
+				continue;
+			} else if (lineString.isEmpty()) {
+				processingContents = false;
+			} else if (lineString.contains("Coins") && !processingContents) {
+				chestPrice = Integer.parseInt(lineString.replaceAll(",", "").replaceAll("\\D", ""));
+			}
+
+			if (processingContents) {
+				if (lineString.contains("Essence")) {
+					Matcher matcher = ESSENCE_PATTERN.matcher(lineString);
+					if (matcher.matches()) {    // add to chest value result of multiplying price of essence on it's amount
+						chestValue += getItemPrice(("ESSENCE_" + matcher.group("type")).toUpperCase()) * Integer.parseInt(matcher.group("amount"));
+					}
+				} else {
+					if (lineString.contains("Spirit")) {    // TODO: make code like this to detect recombed gear (it can drop with 1% chance, according to wiki, tho I never saw any?)
+						chestValue += line.getStyle().toString().contains("color=dark_purple") ? getItemPrice("Spirit Epic") : getItemPrice(lineString);
+					} else {
+						chestItems.add(lineString);
+					}
+				}
+			}
+		}
+		for (String item : chestItems) {
+			chestValue += getItemPrice(item);
+		}
+		return chestValue - chestPrice;
+	}
 
 
-    // I did a thing :(
-    private final Map<String, String> dungeonDropsNameToId = Util.make(new HashMap<>(), map -> {
-    	map.put("Enchanted Book (Ultimate Jerry I)", "ENCHANTMENT_ULTIMATE_JERRY_1");    // ultimate books start
-    	map.put("Enchanted Book (Ultimate Jerry II)", "ENCHANTMENT_ULTIMATE_JERRY_2");
-    	map.put("Enchanted Book (Ultimate Jerry III)", "ENCHANTMENT_ULTIMATE_JERRY_3");
-    	map.put("Enchanted Book (Bank I)", "ENCHANTMENT_ULTIMATE_BANK_1");
-    	map.put("Enchanted Book (Bank II)", "ENCHANTMENT_ULTIMATE_BANK_2");
-    	map.put("Enchanted Book (Bank III)", "ENCHANTMENT_ULTIMATE_BANK_3");
-    	map.put("Enchanted Book (Combo I)", "ENCHANTMENT_ULTIMATE_COMBO_1");
-    	map.put("Enchanted Book (Combo II)", "ENCHANTMENT_ULTIMATE_COMBO_2");
-    	map.put("Enchanted Book (No Pain No Gain I)", "ENCHANTMENT_ULTIMATE_NO_PAIN_NO_GAIN_1");
-    	map.put("Enchanted Book (No Pain No Gain II)", "ENCHANTMENT_ULTIMATE_NO_PAIN_NO_GAIN_2");
-    	map.put("Enchanted Book (Ultimate Wise I)", "ENCHANTMENT_ULTIMATE_WISE_1");
-    	map.put("Enchanted Book (Ultimate Wise II)", "ENCHANTMENT_ULTIMATE_WISE_2");
-    	map.put("Enchanted Book (Wisdom I)", "ENCHANTMENT_ULTIMATE_WISDOM_1");
-        map.put("Enchanted Book (Wisdom II)", "ENCHANTMENT_ULTIMATE_WISDOM_2");
-        map.put("Enchanted Book (Last Stand I)", "ENCHANTMENT_ULTIMATE_LAST_STAND_1");
-        map.put("Enchanted Book (Last Stand II)", "ENCHANTMENT_ULTIMATE_LAST_STAND_2");
-        map.put("Enchanted Book (Rend I)", "ENCHANTMENT_ULTIMATE_REND_1");
-        map.put("Enchanted Book (Rend II)", "ENCHANTMENT_ULTIMATE_REND_2");
-        map.put("Enchanted Book (Legion I)", "ENCHANTMENT_ULTIMATE_LEGION_1");
-        map.put("Enchanted Book (Swarm I)", "ENCHANTMENT_ULTIMATE_SWARM_1");
-        map.put("Enchanted Book (One For All I)", "ENCHANTMENT_ULTIMATE_ONE_FOR_ALL_1");
-        map.put("Enchanted Book (Soul Eater I)", "ENCHANTMENT_ULTIMATE_SOUL_EATER_1");  // ultimate books end
-        map.put("Enchanted Book (Infinite Quiver VI)", "ENCHANTMENT_INFINITE_QUIVER_6");  // enchanted books start
-        map.put("Enchanted Book (Infinite Quiver VII)", "ENCHANTMENT_INFINITE_QUIVER_7");
-        map.put("Enchanted Book (Feather Falling VI)", "ENCHANTMENT_FEATHER_FALLING_6");
-        map.put("Enchanted Book (Feather Falling VII)", "ENCHANTMENT_FEATHER_FALLING_7");
-        map.put("Enchanted Book (Rejuvenate I)", "ENCHANTMENT_REJUVENATE_1");
-        map.put("Enchanted Book (Rejuvenate II)", "ENCHANTMENT_REJUVENATE_2");
-        map.put("Enchanted Book (Rejuvenate III)", "ENCHANTMENT_REJUVENATE_3");
-        map.put("Enchanted Book (Overload)", "ENCHANTMENT_OVERLOAD_1");
-        map.put("Enchanted Book (Lethality VI)", "ENCHANTMENT_LETHALITY_6");
-        map.put("Enchanted Book (Thunderlord VII)", "ENCHANTMENT_THUNDERLORD_7");  // enchanted books end
+	private double getItemPrice(String itemDisplayName) {
+		return ItemUtils.getItemPrice(dungeonDropsNameToId.get(itemDisplayName)).leftDouble();
+	}
 
-        map.put("Hot Potato Book", "HOT_POTATO_BOOK");  // HPB, FPB, Recomb (universal drops)
-        map.put("Fuming Potato Book", "FUMING_POTATO_BOOK");
-        map.put("Recombobulator 3000", "RECOMBOBULATOR_3000");
-        map.put("Necromancer's Brooch", "NECROMANCER_BROOCH");
-        map.put("ESSENCE_WITHER","ESSENCE_WITHER");     // Essences. Really stupid way of doing this
-        map.put("ESSENCE_UNDEAD", "ESSENCE_UNDEAD");
-        map.put("ESSENCE_DRAGON", "ESSENCE_DRAGON");
-        map.put("ESSENCE_SPIDER", "ESSENCE_SPIDER");
-        map.put("ESSENCE_ICE", "ESSENCE_ICE");
-        map.put("ESSENCE_DIAMOND", "ESSENCE_DIAMOND");
-        map.put("ESSENCE_GOLD", "ESSENCE_GOLD");
-        map.put("ESSENCE_CRIMSON", "ESSENCE_CRIMSON");
-        map.put("DUNGEON_CHEST_KEY", "DUNGEON_CHEST_KEY");
 
-        map.put("Bonzo's Staff", "BONZO_STAFF");    // F1 M1
-        map.put("Master Skull - Tier 1", "MASTER_SKULL_TIER_1");
-        map.put("Bonzo's Mask", "BONZO_MASK");
-        map.put("Balloon Snake", "BALLOON_SNAKE");
-        map.put("Red Nose", "RED_NOSE");
+	// I did a thing :(
+	private final Map<String, String> dungeonDropsNameToId = Util.make(new HashMap<>(), map -> {
+		map.put("Enchanted Book (Ultimate Jerry I)", "ENCHANTMENT_ULTIMATE_JERRY_1");    // ultimate books start
+		map.put("Enchanted Book (Ultimate Jerry II)", "ENCHANTMENT_ULTIMATE_JERRY_2");
+		map.put("Enchanted Book (Ultimate Jerry III)", "ENCHANTMENT_ULTIMATE_JERRY_3");
+		map.put("Enchanted Book (Bank I)", "ENCHANTMENT_ULTIMATE_BANK_1");
+		map.put("Enchanted Book (Bank II)", "ENCHANTMENT_ULTIMATE_BANK_2");
+		map.put("Enchanted Book (Bank III)", "ENCHANTMENT_ULTIMATE_BANK_3");
+		map.put("Enchanted Book (Combo I)", "ENCHANTMENT_ULTIMATE_COMBO_1");
+		map.put("Enchanted Book (Combo II)", "ENCHANTMENT_ULTIMATE_COMBO_2");
+		map.put("Enchanted Book (No Pain No Gain I)", "ENCHANTMENT_ULTIMATE_NO_PAIN_NO_GAIN_1");
+		map.put("Enchanted Book (No Pain No Gain II)", "ENCHANTMENT_ULTIMATE_NO_PAIN_NO_GAIN_2");
+		map.put("Enchanted Book (Ultimate Wise I)", "ENCHANTMENT_ULTIMATE_WISE_1");
+		map.put("Enchanted Book (Ultimate Wise II)", "ENCHANTMENT_ULTIMATE_WISE_2");
+		map.put("Enchanted Book (Wisdom I)", "ENCHANTMENT_ULTIMATE_WISDOM_1");
+		map.put("Enchanted Book (Wisdom II)", "ENCHANTMENT_ULTIMATE_WISDOM_2");
+		map.put("Enchanted Book (Last Stand I)", "ENCHANTMENT_ULTIMATE_LAST_STAND_1");
+		map.put("Enchanted Book (Last Stand II)", "ENCHANTMENT_ULTIMATE_LAST_STAND_2");
+		map.put("Enchanted Book (Rend I)", "ENCHANTMENT_ULTIMATE_REND_1");
+		map.put("Enchanted Book (Rend II)", "ENCHANTMENT_ULTIMATE_REND_2");
+		map.put("Enchanted Book (Legion I)", "ENCHANTMENT_ULTIMATE_LEGION_1");
+		map.put("Enchanted Book (Swarm I)", "ENCHANTMENT_ULTIMATE_SWARM_1");
+		map.put("Enchanted Book (One For All I)", "ENCHANTMENT_ULTIMATE_ONE_FOR_ALL_1");
+		map.put("Enchanted Book (Soul Eater I)", "ENCHANTMENT_ULTIMATE_SOUL_EATER_1");  // ultimate books end
+		map.put("Enchanted Book (Infinite Quiver VI)", "ENCHANTMENT_INFINITE_QUIVER_6");  // enchanted books start
+		map.put("Enchanted Book (Infinite Quiver VII)", "ENCHANTMENT_INFINITE_QUIVER_7");
+		map.put("Enchanted Book (Feather Falling VI)", "ENCHANTMENT_FEATHER_FALLING_6");
+		map.put("Enchanted Book (Feather Falling VII)", "ENCHANTMENT_FEATHER_FALLING_7");
+		map.put("Enchanted Book (Rejuvenate I)", "ENCHANTMENT_REJUVENATE_1");
+		map.put("Enchanted Book (Rejuvenate II)", "ENCHANTMENT_REJUVENATE_2");
+		map.put("Enchanted Book (Rejuvenate III)", "ENCHANTMENT_REJUVENATE_3");
+		map.put("Enchanted Book (Overload)", "ENCHANTMENT_OVERLOAD_1");
+		map.put("Enchanted Book (Lethality VI)", "ENCHANTMENT_LETHALITY_6");
+		map.put("Enchanted Book (Thunderlord VII)", "ENCHANTMENT_THUNDERLORD_7");  // enchanted books end
 
-        map.put("Red Scarf", "RED_SCARF");  // F2 M2
-        map.put("Adaptive Blade", "STONE_BLADE");
-        map.put("Master Skull - Tier 2", "MASTER_SKULL_TIER_2");
-        map.put("Adaptive Belt", "ADAPTIVE_BELT");
-        map.put("Scarf's Studies", "SCARF_STUDIES");
+		map.put("Hot Potato Book", "HOT_POTATO_BOOK");  // HPB, FPB, Recomb (universal drops)
+		map.put("Fuming Potato Book", "FUMING_POTATO_BOOK");
+		map.put("Recombobulator 3000", "RECOMBOBULATOR_3000");
+		map.put("Necromancer's Brooch", "NECROMANCER_BROOCH");
+		map.put("ESSENCE_WITHER", "ESSENCE_WITHER");     // Essences. Really stupid way of doing this
+		map.put("ESSENCE_UNDEAD", "ESSENCE_UNDEAD");
+		map.put("ESSENCE_DRAGON", "ESSENCE_DRAGON");
+		map.put("ESSENCE_SPIDER", "ESSENCE_SPIDER");
+		map.put("ESSENCE_ICE", "ESSENCE_ICE");
+		map.put("ESSENCE_DIAMOND", "ESSENCE_DIAMOND");
+		map.put("ESSENCE_GOLD", "ESSENCE_GOLD");
+		map.put("ESSENCE_CRIMSON", "ESSENCE_CRIMSON");
+		map.put("DUNGEON_CHEST_KEY", "DUNGEON_CHEST_KEY");
 
-        map.put("First Master Star", "FIRST_MASTER_STAR");  // F3 M3
-        map.put("Adaptive Helmet", "ADAPTIVE_HELMET");
-        map.put("Adaptive Chestplate", "ADAPTIVE_CHESTPLATE");
-        map.put("Adaptive Leggings", "ADAPTIVE_LEGGINGS");
-        map.put("Adaptive Boots", "ADAPTIVE_BOOTS");
-        map.put("Master Skull - Tier 3", "MASTER_SKULL_TIER_3");
-        map.put("Suspicious Vial", "SUSPICIOUS_VIAL");
+		map.put("Bonzo's Staff", "BONZO_STAFF");    // F1 M1
+		map.put("Master Skull - Tier 1", "MASTER_SKULL_TIER_1");
+		map.put("Bonzo's Mask", "BONZO_MASK");
+		map.put("Balloon Snake", "BALLOON_SNAKE");
+		map.put("Red Nose", "RED_NOSE");
 
-        map.put("Spirit Sword", "SPIRIT_SWORD");    // F4 M4
-        map.put("Spirit Shortbow", "ITEM_SPIRIT_BOW");
-        map.put("Spirit Boots", "THORNS_BOOTS");
-        map.put("Spirit", "LVL_1_LEGENDARY_SPIRIT");    // Spirit pet (Legendary)
-        map.put("Spirit Epic", "LVL_1_EPIC_SPIRIT");
+		map.put("Red Scarf", "RED_SCARF");  // F2 M2
+		map.put("Adaptive Blade", "STONE_BLADE");
+		map.put("Master Skull - Tier 2", "MASTER_SKULL_TIER_2");
+		map.put("Adaptive Belt", "ADAPTIVE_BELT");
+		map.put("Scarf's Studies", "SCARF_STUDIES");
 
-        map.put("Second Master Star", "SECOND_MASTER_STAR");
-        map.put("Spirit Wing", "SPIRIT_WING");
-        map.put("Spirit Bone", "SPIRIT_BONE");
-        map.put("Spirit Stone", "SPIRIT_DECOY");
+		map.put("First Master Star", "FIRST_MASTER_STAR");  // F3 M3
+		map.put("Adaptive Helmet", "ADAPTIVE_HELMET");
+		map.put("Adaptive Chestplate", "ADAPTIVE_CHESTPLATE");
+		map.put("Adaptive Leggings", "ADAPTIVE_LEGGINGS");
+		map.put("Adaptive Boots", "ADAPTIVE_BOOTS");
+		map.put("Master Skull - Tier 3", "MASTER_SKULL_TIER_3");
+		map.put("Suspicious Vial", "SUSPICIOUS_VIAL");
 
-        map.put("Shadow Fury", "SHADOW_FURY");  // F5 M5
-        map.put("Last Breath", "LAST_BREATH");
-        map.put("Third Master Star", "THIRD_MASTER_STAR");
-        map.put("Warped Stone", "AOTE_STONE");
-        map.put("Livid Dagger", "LIVID_DAGGER");
-        map.put("Shadow Assassin Helmet", "SHADOW_ASSASSIN_HELMET");
-        map.put("Shadow Assassin Chestplate", "SHADOW_ASSASSIN_CHESTPLATE");
-        map.put("Shadow Assassin Leggings", "SHADOW_ASSASSIN_LEGGINGS");
-        map.put("Shadow Assassin Boots", "SHADOW_ASSASSIN_BOOTS");
-        map.put("Shadow Assassin Cloak", "SHADOW_ASSASSIN_CLOAK");
-        map.put("Master Skull - Tier 4", "MASTER_SKULL_TIER_4");
-        map.put("Dark Orb", "DARK_ORB");
+		map.put("Spirit Sword", "SPIRIT_SWORD");    // F4 M4
+		map.put("Spirit Shortbow", "ITEM_SPIRIT_BOW");
+		map.put("Spirit Boots", "THORNS_BOOTS");
+		map.put("Spirit", "LVL_1_LEGENDARY_SPIRIT");    // Spirit pet (Legendary)
+		map.put("Spirit Epic", "LVL_1_EPIC_SPIRIT");
 
-        map.put("Precursor Eye", "PRECURSOR_EYE");  // F6 M6
-        map.put("Giant's Sword", "GIANTS_SWORD");
-        map.put("Necromancer Lord Helmet", "NECROMANCER_LORD_HELMET");
-        map.put("Necromancer Lord Chestplate", "NECROMANCER_LORD_CHESTPLATE");
-        map.put("Necromancer Lord Leggings", "NECROMANCER_LORD_LEGGINGS");
-        map.put("Necromancer Lord Boots", "NECROMANCER_LORD_BOOTS");
-        map.put("Fourth Master Star", "FOURTH_MASTER_STAR");
-        map.put("Summoning Ring", "SUMMONING_RING");
-        map.put("Fel Skull", "FEL_SKULL");
-        map.put("Necromancer Sword", "NECROMANCER_SWORD");
-        map.put("Soulweaver Gloves", "SOULWEAVER_GLOVES");
-        map.put("Sadan's Brooch", "SADAN_BROOCH");
-        map.put("Giant Tooth", "GIANT_TOOTH");
+		map.put("Second Master Star", "SECOND_MASTER_STAR");
+		map.put("Spirit Wing", "SPIRIT_WING");
+		map.put("Spirit Bone", "SPIRIT_BONE");
+		map.put("Spirit Stone", "SPIRIT_DECOY");
 
-        map.put("Precursor Gear", "PRECURSOR_GEAR");    // F7 M7
-        map.put("Necron Dye", "DYE_NECRON");
-        map.put("Storm the Fish", "STORM_THE_FISH");
-        map.put("Maxor the Fish", "MAXOR_THE_FISH");
-        map.put("Goldor the Fish", "GOLDOR_THE_FISH");
-        map.put("Dark Claymore", "DARK_CLAYMORE");
-        map.put("Necron's Handle", "NECRON_HANDLE");
-        map.put("Master Skull - Tier 5", "MASTER_SKULL_TIER_5");
-        map.put("Shadow Warp", "SHADOW_WARP_SCROLL");
-        map.put("Wither Shield", "WITHER_SHIELD_SCROLL");
-        map.put("Implosion", "IMPLOSION_SCROLL");
-        map.put("Fifth Master Star", "FIFTH_MASTER_STAR");
-        map.put("Auto Recombobulator", "AUTO_RECOMBOBULATOR");
-        map.put("Wither Helmet", "WITHER_HELMET");
-        map.put("Wither Chestplate", "WITHER_CHESTPLATE");
-        map.put("Wither Leggings", "WITHER_LEGGINGS");
-        map.put("Wither Boots", "WITHER_BOOTS");
-        map.put("Wither Catalyst", "WITHER_CATALYST");
-        map.put("Wither Cloak Sword", "WITHER_CLOAK");
-        map.put("Wither Blood", "WITHER_BLOOD");
+		map.put("Shadow Fury", "SHADOW_FURY");  // F5 M5
+		map.put("Last Breath", "LAST_BREATH");
+		map.put("Third Master Star", "THIRD_MASTER_STAR");
+		map.put("Warped Stone", "AOTE_STONE");
+		map.put("Livid Dagger", "LIVID_DAGGER");
+		map.put("Shadow Assassin Helmet", "SHADOW_ASSASSIN_HELMET");
+		map.put("Shadow Assassin Chestplate", "SHADOW_ASSASSIN_CHESTPLATE");
+		map.put("Shadow Assassin Leggings", "SHADOW_ASSASSIN_LEGGINGS");
+		map.put("Shadow Assassin Boots", "SHADOW_ASSASSIN_BOOTS");
+		map.put("Shadow Assassin Cloak", "SHADOW_ASSASSIN_CLOAK");
+		map.put("Master Skull - Tier 4", "MASTER_SKULL_TIER_4");
+		map.put("Dark Orb", "DARK_ORB");
 
-        map.put("Shiny Wither Helmet", "SHINY_WITHER_HELMET");  // M7 shiny drops
-        map.put("Shiny Wither Chestplate", "SHINY_WITHER_CHESTPLATE");
-        map.put("Shiny Wither Leggings", "SHINY_WITHER_LEGGINGS");
-        map.put("Shiny Wither Boots", "SHINY_WITHER_BOOTS");
-        map.put("Shiny Necron's Handle", "SHINY_NECRON_HANDLE");    // cool thing
+		map.put("Precursor Eye", "PRECURSOR_EYE");  // F6 M6
+		map.put("Giant's Sword", "GIANTS_SWORD");
+		map.put("Necromancer Lord Helmet", "NECROMANCER_LORD_HELMET");
+		map.put("Necromancer Lord Chestplate", "NECROMANCER_LORD_CHESTPLATE");
+		map.put("Necromancer Lord Leggings", "NECROMANCER_LORD_LEGGINGS");
+		map.put("Necromancer Lord Boots", "NECROMANCER_LORD_BOOTS");
+		map.put("Fourth Master Star", "FOURTH_MASTER_STAR");
+		map.put("Summoning Ring", "SUMMONING_RING");
+		map.put("Fel Skull", "FEL_SKULL");
+		map.put("Necromancer Sword", "NECROMANCER_SWORD");
+		map.put("Soulweaver Gloves", "SOULWEAVER_GLOVES");
+		map.put("Sadan's Brooch", "SADAN_BROOCH");
+		map.put("Giant Tooth", "GIANT_TOOTH");
 
-        map.put("Dungeon Disc", "DUNGEON_DISC_1");
-        map.put("Clown Disc", "DUNGEON_DISC_2");
-        map.put("Watcher Disc", "DUNGEON_DISC_3");
-        map.put("Old Disc", "DUNGEON_DISC_4");
-        map.put("Necron Disc", "DUNGEON_DISC_5");
-    });
+		map.put("Precursor Gear", "PRECURSOR_GEAR");    // F7 M7
+		map.put("Necron Dye", "DYE_NECRON");
+		map.put("Storm the Fish", "STORM_THE_FISH");
+		map.put("Maxor the Fish", "MAXOR_THE_FISH");
+		map.put("Goldor the Fish", "GOLDOR_THE_FISH");
+		map.put("Dark Claymore", "DARK_CLAYMORE");
+		map.put("Necron's Handle", "NECRON_HANDLE");
+		map.put("Master Skull - Tier 5", "MASTER_SKULL_TIER_5");
+		map.put("Shadow Warp", "SHADOW_WARP_SCROLL");
+		map.put("Wither Shield", "WITHER_SHIELD_SCROLL");
+		map.put("Implosion", "IMPLOSION_SCROLL");
+		map.put("Fifth Master Star", "FIFTH_MASTER_STAR");
+		map.put("Auto Recombobulator", "AUTO_RECOMBOBULATOR");
+		map.put("Wither Helmet", "WITHER_HELMET");
+		map.put("Wither Chestplate", "WITHER_CHESTPLATE");
+		map.put("Wither Leggings", "WITHER_LEGGINGS");
+		map.put("Wither Boots", "WITHER_BOOTS");
+		map.put("Wither Catalyst", "WITHER_CATALYST");
+		map.put("Wither Cloak Sword", "WITHER_CLOAK");
+		map.put("Wither Blood", "WITHER_BLOOD");
+
+		map.put("Shiny Wither Helmet", "SHINY_WITHER_HELMET");  // M7 shiny drops
+		map.put("Shiny Wither Chestplate", "SHINY_WITHER_CHESTPLATE");
+		map.put("Shiny Wither Leggings", "SHINY_WITHER_LEGGINGS");
+		map.put("Shiny Wither Boots", "SHINY_WITHER_BOOTS");
+		map.put("Shiny Necron's Handle", "SHINY_NECRON_HANDLE");    // cool thing
+
+		map.put("Dungeon Disc", "DUNGEON_DISC_1");
+		map.put("Clown Disc", "DUNGEON_DISC_2");
+		map.put("Watcher Disc", "DUNGEON_DISC_3");
+		map.put("Old Disc", "DUNGEON_DISC_4");
+		map.put("Necron Disc", "DUNGEON_DISC_5");
+	});
 }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/ColorTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/ColorTerminal.java
@@ -17,65 +17,65 @@ import java.util.*;
 
 
 public final class ColorTerminal extends ContainerSolver implements TerminalSolver {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ColorTerminal.class.getName());
-    private static final Map<String, DyeColor> colorFromName;
-    private DyeColor targetColor;
-    private static final Map<Item, DyeColor> itemColor;
+	private static final Logger LOGGER = LoggerFactory.getLogger(ColorTerminal.class.getName());
+	private static final Map<String, DyeColor> colorFromName;
+	private DyeColor targetColor;
+	private static final Map<Item, DyeColor> itemColor;
 
-    public ColorTerminal() {
-        super("^Select all the ([A-Z ]+) items!$");
-    }
+	public ColorTerminal() {
+		super("^Select all the ([A-Z ]+) items!$");
+	}
 
-    @Override
-    protected boolean isEnabled() {
-        targetColor = null;
-        return SkyblockerConfigManager.get().dungeons.terminals.solveColor;
-    }
+	@Override
+	protected boolean isEnabled() {
+		targetColor = null;
+		return SkyblockerConfigManager.get().dungeons.terminals.solveColor;
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        trimEdges(slots, 6);
-        List<ColorHighlight> highlights = new ArrayList<>();
-        String colorString = groups[0];
-        if (targetColor == null) {
-            targetColor = colorFromName.get(colorString);
-            if (targetColor == null) {
-                LOGGER.error("[Skyblocker] Couldn't find dye color corresponding to \"" + colorString + "\"");
-                return Collections.emptyList();
-            }
-        }
-        for (Int2ObjectMap.Entry<ItemStack> slot : slots.int2ObjectEntrySet()) {
-            ItemStack itemStack = slot.getValue();
-            if (!itemStack.hasGlint() && targetColor.equals(itemColor.get(itemStack.getItem()))) {
-                highlights.add(ColorHighlight.green(slot.getIntKey()));
-            }
-        }
-        return highlights;
-    }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		trimEdges(slots, 6);
+		List<ColorHighlight> highlights = new ArrayList<>();
+		String colorString = groups[0];
+		if (targetColor == null) {
+			targetColor = colorFromName.get(colorString);
+			if (targetColor == null) {
+				LOGGER.error("[Skyblocker] Couldn't find dye color corresponding to \"{}\"", colorString);
+				return List.of();
+			}
+		}
+		for (Int2ObjectMap.Entry<ItemStack> slot : slots.int2ObjectEntrySet()) {
+			ItemStack itemStack = slot.getValue();
+			if (!itemStack.hasGlint() && targetColor.equals(itemColor.get(itemStack.getItem()))) {
+				highlights.add(ColorHighlight.green(slot.getIntKey()));
+			}
+		}
+		return highlights;
+	}
 
-    @Override
-    protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
-        if (stack.hasGlint() || !targetColor.equals(itemColor.get(stack.getItem()))) {
-            return shouldBlockIncorrectClicks();
-        }
+	@Override
+	protected boolean onClickSlot(int slot, ItemStack stack, int screenId) {
+		if (stack.hasGlint() || !targetColor.equals(itemColor.get(stack.getItem()))) {
+			return shouldBlockIncorrectClicks();
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    static {
-        colorFromName = new HashMap<>();
-        for (DyeColor color : DyeColor.values())
-            colorFromName.put(color.getName().toUpperCase(Locale.ENGLISH), color);
-        colorFromName.put("SILVER", DyeColor.LIGHT_GRAY);
-        colorFromName.put("LIGHT BLUE", DyeColor.LIGHT_BLUE);
+	static {
+		colorFromName = new HashMap<>();
+		for (DyeColor color : DyeColor.values())
+			colorFromName.put(color.getName().toUpperCase(Locale.ENGLISH), color);
+		colorFromName.put("SILVER", DyeColor.LIGHT_GRAY);
+		colorFromName.put("LIGHT BLUE", DyeColor.LIGHT_BLUE);
 
-        itemColor = new HashMap<>();
-        for (DyeColor color : DyeColor.values())
-            for (String item : new String[]{"dye", "wool", "stained_glass", "terracotta"})
-                itemColor.put(Registries.ITEM.get(new Identifier(color.getName() + '_' + item)), color);
-        itemColor.put(Items.BONE_MEAL, DyeColor.WHITE);
-        itemColor.put(Items.LAPIS_LAZULI, DyeColor.BLUE);
-        itemColor.put(Items.COCOA_BEANS, DyeColor.BROWN);
-        itemColor.put(Items.INK_SAC, DyeColor.BLACK);
-    }
+		itemColor = new HashMap<>();
+		for (DyeColor color : DyeColor.values())
+			for (String item : new String[]{"dye", "wool", "stained_glass", "terracotta"})
+				itemColor.put(Registries.ITEM.get(new Identifier(color.getName() + '_' + item)), color);
+		itemColor.put(Items.BONE_MEAL, DyeColor.WHITE);
+		itemColor.put(Items.LAPIS_LAZULI, DyeColor.BLUE);
+		itemColor.put(Items.COCOA_BEANS, DyeColor.BROWN);
+		itemColor.put(Items.INK_SAC, DyeColor.BLACK);
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/LightsOnTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/LightsOnTerminal.java
@@ -1,21 +1,15 @@
 package de.hysky.skyblocker.skyblock.dungeon.terminal;
 
-import java.util.List;
-
-import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import de.hysky.skyblocker.utils.render.gui.ContainerSolver;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 
 /**
  * The terminal where you change all the panes that are red to green.
- * 
+ * <p>
  * This doesn't solve the terminal because you don't need a solver for it, but rather to simply allow for click blocking.
  */
 public final class LightsOnTerminal extends ContainerSolver implements TerminalSolver {
-	private static final List<ColorHighlight> EMPTY = List.of();
-
 	public LightsOnTerminal() {
 		super("^Correct all the panes!$");
 	}
@@ -26,12 +20,7 @@ public final class LightsOnTerminal extends ContainerSolver implements TerminalS
 	}
 
 	@Override
-	protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-		return EMPTY;
-	}
-
-	@Override
-	protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
+	protected boolean onClickSlot(int slot, ItemStack stack, int screenId) {
 		return stack.isOf(Items.LIME_STAINED_GLASS_PANE);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/OrderTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/OrderTerminal.java
@@ -8,62 +8,60 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public final class OrderTerminal extends ContainerSolver implements TerminalSolver {
-    private final int PANES_NUM = 14;
-    private int[] orderedSlots;
-    private int currentNum = Integer.MAX_VALUE;
+	private final int PANES_NUM = 14;
+	private int[] orderedSlots;
+	private int currentNum = Integer.MAX_VALUE;
 
-    public OrderTerminal() {
-        super("^Click in order!$");
-    }
+	public OrderTerminal() {
+		super("^Click in order!$");
+	}
 
-    @Override
-    protected boolean isEnabled() {
-        orderedSlots = null;
-        currentNum = 0;
-        return SkyblockerConfigManager.get().dungeons.terminals.solveOrder;
-    }
+	@Override
+	protected boolean isEnabled() {
+		orderedSlots = null;
+		currentNum = 0;
+		return SkyblockerConfigManager.get().dungeons.terminals.solveOrder;
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        if(orderedSlots == null && !orderSlots(slots))
-            return Collections.emptyList();
-        while(currentNum < PANES_NUM && Items.LIME_STAINED_GLASS_PANE.equals(slots.get(orderedSlots[currentNum]).getItem()))
-            currentNum++;
-        List<ColorHighlight> highlights = new ArrayList<>(3);
-        int last = Integer.min(3, PANES_NUM - currentNum);
-        for(int i = 0; i < last; i++) {
-            highlights.add(new ColorHighlight(orderedSlots[currentNum + i], (224 - 64 * i) << 24 | 64 << 16 | 96 << 8 | 255));
-        }
-        return highlights;
-    }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		if (orderedSlots == null && !orderSlots(slots))
+			return List.of();
+		while (currentNum < PANES_NUM && Items.LIME_STAINED_GLASS_PANE.equals(slots.get(orderedSlots[currentNum]).getItem()))
+			currentNum++;
+		List<ColorHighlight> highlights = new ArrayList<>(3);
+		int last = Integer.min(3, PANES_NUM - currentNum);
+		for (int i = 0; i < last; i++) {
+			highlights.add(new ColorHighlight(orderedSlots[currentNum + i], (224 - 64 * i) << 24 | 64 << 16 | 96 << 8 | 255));
+		}
+		return highlights;
+	}
 
-    public boolean orderSlots(Int2ObjectMap<ItemStack> slots) {
-        trimEdges(slots, 4);
-        orderedSlots = new int[PANES_NUM];
-        for(Int2ObjectMap.Entry<ItemStack> slot : slots.int2ObjectEntrySet()) {
-            if(Items.AIR.equals(slot.getValue().getItem())) {
-                orderedSlots = null;
-                return false;
-            }
-            else
-                orderedSlots[slot.getValue().getCount() - 1] = slot.getIntKey();
-        }
-        currentNum = 0;
-        return true;
-    }
+	public boolean orderSlots(Int2ObjectMap<ItemStack> slots) {
+		trimEdges(slots, 4);
+		orderedSlots = new int[PANES_NUM];
+		for (Int2ObjectMap.Entry<ItemStack> slot : slots.int2ObjectEntrySet()) {
+			if (Items.AIR.equals(slot.getValue().getItem())) {
+				orderedSlots = null;
+				return false;
+			} else
+				orderedSlots[slot.getValue().getCount() - 1] = slot.getIntKey();
+		}
+		currentNum = 0;
+		return true;
+	}
 
-    @Override
-    protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
-        if (stack == null || stack.isEmpty()) return false;
+	@Override
+	protected boolean onClickSlot(int slot, ItemStack stack, int screenId) {
+		if (stack == null || stack.isEmpty()) return false;
 
-        if (!stack.isOf(Items.RED_STAINED_GLASS_PANE) || stack.getCount() != currentNum + 1) {
-            return shouldBlockIncorrectClicks();
-        }
+		if (!stack.isOf(Items.RED_STAINED_GLASS_PANE) || stack.getCount() != currentNum + 1) {
+			return shouldBlockIncorrectClicks();
+		}
 
-        return false;
-    }
+		return false;
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/StartsWithTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/StartsWithTerminal.java
@@ -27,7 +27,7 @@ public final class StartsWithTerminal extends ContainerSolver implements Termina
 	}
 
 	@Override
-	protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
 		trimEdges(slots, 6);
 		setupState(slots);
 
@@ -50,9 +50,9 @@ public final class StartsWithTerminal extends ContainerSolver implements Termina
 	}
 
 	@Override
-	protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
+	protected boolean onClickSlot(int slot, ItemStack stack, int screenId) {
 		//Some random glass pane was clicked or something
-		if (!trackedItemStates.containsKey(slot) || stack == null || stack.isEmpty()) return false;
+		if (!trackedItemStates.containsKey(slot) || stack == null || stack.isEmpty() || groups == null) return false;
 
 		ItemState state = trackedItemStates.get(slot);
 		String prefix = groups[0];

--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/ChronomatronSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/ChronomatronSolver.java
@@ -1,7 +1,6 @@
 package de.hysky.skyblocker.skyblock.experiment;
 
 import com.google.common.collect.ImmutableMap;
-
 import de.hysky.skyblocker.config.configs.HelperConfig;
 import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -17,113 +16,114 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class ChronomatronSolver extends ExperimentSolver {
-    public static final ImmutableMap<Item, Item> TERRACOTTA_TO_GLASS = ImmutableMap.ofEntries(
-            new AbstractMap.SimpleImmutableEntry<>(Items.RED_TERRACOTTA, Items.RED_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.ORANGE_TERRACOTTA, Items.ORANGE_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.YELLOW_TERRACOTTA, Items.YELLOW_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.LIME_TERRACOTTA, Items.LIME_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.GREEN_TERRACOTTA, Items.GREEN_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.CYAN_TERRACOTTA, Items.CYAN_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.LIGHT_BLUE_TERRACOTTA, Items.LIGHT_BLUE_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.BLUE_TERRACOTTA, Items.BLUE_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.PURPLE_TERRACOTTA, Items.PURPLE_STAINED_GLASS),
-            new AbstractMap.SimpleImmutableEntry<>(Items.PINK_TERRACOTTA, Items.PINK_STAINED_GLASS)
-    );
+	public static final ImmutableMap<Item, Item> TERRACOTTA_TO_GLASS = ImmutableMap.ofEntries(
+			new AbstractMap.SimpleImmutableEntry<>(Items.RED_TERRACOTTA, Items.RED_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.ORANGE_TERRACOTTA, Items.ORANGE_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.YELLOW_TERRACOTTA, Items.YELLOW_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.LIME_TERRACOTTA, Items.LIME_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.GREEN_TERRACOTTA, Items.GREEN_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.CYAN_TERRACOTTA, Items.CYAN_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.LIGHT_BLUE_TERRACOTTA, Items.LIGHT_BLUE_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.BLUE_TERRACOTTA, Items.BLUE_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.PURPLE_TERRACOTTA, Items.PURPLE_STAINED_GLASS),
+			new AbstractMap.SimpleImmutableEntry<>(Items.PINK_TERRACOTTA, Items.PINK_STAINED_GLASS)
+	);
 
-    private final List<Item> chronomatronSlots = new ArrayList<>();
-    private int chronomatronChainLengthCount;
-    private int chronomatronCurrentSlot;
-    private int chronomatronCurrentOrdinal;
+	private final List<Item> chronomatronSlots = new ArrayList<>();
+	private int chronomatronChainLengthCount;
+	private int chronomatronCurrentSlot;
+	private int chronomatronCurrentOrdinal;
 
-    public ChronomatronSolver() {
-        super("^Chronomatron \\(\\w+\\)$");
-    }
+	public ChronomatronSolver() {
+		super("^Chronomatron \\(\\w+\\)$");
+	}
 
-    public List<Item> getChronomatronSlots() {
-        return chronomatronSlots;
-    }
+	public List<Item> getChronomatronSlots() {
+		return chronomatronSlots;
+	}
 
-    public int getChronomatronCurrentOrdinal() {
-        return chronomatronCurrentOrdinal;
-    }
+	public int getChronomatronCurrentOrdinal() {
+		return chronomatronCurrentOrdinal;
+	}
 
-    public int incrementChronomatronCurrentOrdinal() {
-        return ++chronomatronCurrentOrdinal;
-    }
+	public int incrementChronomatronCurrentOrdinal() {
+		return ++chronomatronCurrentOrdinal;
+	}
 
-    @Override
-    protected boolean isEnabled(HelperConfig.Experiments experimentsConfig) {
-        return experimentsConfig.enableChronomatronSolver;
-    }
+	@Override
+	protected boolean isEnabled(HelperConfig.Experiments experimentsConfig) {
+		return experimentsConfig.enableChronomatronSolver;
+	}
 
-    @Override
-    protected void tick(Screen screen) {
-        if (isEnabled() && screen instanceof GenericContainerScreen genericContainerScreen && genericContainerScreen.getTitle().getString().startsWith("Chronomatron (")) {
-            switch (getState()) {
-                case REMEMBER -> {
-                    Inventory inventory = genericContainerScreen.getScreenHandler().getInventory();
-                    if (chronomatronCurrentSlot == 0) {
-                        for (int index = 10; index < 43; index++) {
-                            if (inventory.getStack(index).hasGlint()) {
-                                if (chronomatronSlots.size() <= chronomatronChainLengthCount) {
-                                    chronomatronSlots.add(TERRACOTTA_TO_GLASS.get(inventory.getStack(index).getItem()));
-                                    setState(State.WAIT);
-                                } else {
-                                    chronomatronChainLengthCount++;
-                                }
-                                chronomatronCurrentSlot = index;
-                                return;
-                            }
-                        }
-                    } else if (!inventory.getStack(chronomatronCurrentSlot).hasGlint()) {
-                        chronomatronCurrentSlot = 0;
-                    }
-                }
-                case WAIT -> {
-                    if (genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString().startsWith("Timer: ")) {
-                        setState(State.SHOW);
-                    }
-                }
-                case END -> {
-                    String name = genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString();
-                    if (!name.startsWith("Timer: ")) {
-                        if (name.equals("Remember the pattern!")) {
-                            chronomatronChainLengthCount = 0;
-                            chronomatronCurrentOrdinal = 0;
-                            setState(State.REMEMBER);
-                        } else {
-                            reset();
-                        }
-                    }
-                }
-            }
-        } else {
-            reset();
-        }
-    }
+	@Override
+	protected void tick(Screen screen) {
+		if (isEnabled() && screen instanceof GenericContainerScreen genericContainerScreen && genericContainerScreen.getTitle().getString().startsWith("Chronomatron (")) {
+			switch (getState()) {
+				case REMEMBER -> {
+					Inventory inventory = genericContainerScreen.getScreenHandler().getInventory();
+					if (chronomatronCurrentSlot == 0) {
+						for (int index = 10; index < 43; index++) {
+							if (inventory.getStack(index).hasGlint()) {
+								if (chronomatronSlots.size() <= chronomatronChainLengthCount) {
+									chronomatronSlots.add(TERRACOTTA_TO_GLASS.get(inventory.getStack(index).getItem()));
+									setState(State.WAIT);
+								} else {
+									chronomatronChainLengthCount++;
+								}
+								chronomatronCurrentSlot = index;
+								return;
+							}
+						}
+					} else if (!inventory.getStack(chronomatronCurrentSlot).hasGlint()) {
+						chronomatronCurrentSlot = 0;
+					}
+				}
+				case WAIT -> {
+					if (genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString().startsWith("Timer: ")) {
+						setState(State.SHOW);
+					}
+				}
+				case END -> {
+					String name = genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString();
+					if (!name.startsWith("Timer: ")) {
+						if (name.equals("Remember the pattern!")) {
+							chronomatronChainLengthCount = 0;
+							chronomatronCurrentOrdinal = 0;
+							setState(State.REMEMBER);
+						} else {
+							reset();
+						}
+					}
+				}
+			}
+		} else {
+			reset();
+		}
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        List<ColorHighlight> highlights = new ArrayList<>();
-        if (getState() == State.SHOW && chronomatronSlots.size() > chronomatronCurrentOrdinal) {
-            for (Int2ObjectMap.Entry<ItemStack> indexStack : slots.int2ObjectEntrySet()) {
-                int index = indexStack.getIntKey();
-                ItemStack stack = indexStack.getValue();
-                Item item = chronomatronSlots.get(chronomatronCurrentOrdinal);
-                if (stack.isOf(item) || TERRACOTTA_TO_GLASS.get(stack.getItem()) == item) {
-                    highlights.add(ColorHighlight.green(index));
-                }
-            }
-        }
-        return highlights;
-    }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		if (getState() != State.SHOW || chronomatronSlots.size() <= chronomatronCurrentOrdinal) return List.of();
 
-    @Override
-    protected void reset() {
-        super.reset();
-        chronomatronSlots.clear();
-        chronomatronChainLengthCount = 0;
-        chronomatronCurrentSlot = 0;
-        chronomatronCurrentOrdinal = 0;
-    }
+		List<ColorHighlight> highlights = new ArrayList<>();
+		for (Int2ObjectMap.Entry<ItemStack> indexStack : slots.int2ObjectEntrySet()) {
+			int index = indexStack.getIntKey();
+			ItemStack stack = indexStack.getValue();
+			Item item = chronomatronSlots.get(chronomatronCurrentOrdinal);
+			if (stack.isOf(item) || TERRACOTTA_TO_GLASS.get(stack.getItem()) == item) {
+				highlights.add(ColorHighlight.green(index));
+			}
+		}
+
+		return highlights;
+	}
+
+	@Override
+	protected void reset() {
+		super.reset();
+		chronomatronSlots.clear();
+		chronomatronChainLengthCount = 0;
+		chronomatronCurrentSlot = 0;
+		chronomatronCurrentOrdinal = 0;
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/ExperimentSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/ExperimentSolver.java
@@ -7,54 +7,55 @@ import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.item.ItemStack;
+import org.intellij.lang.annotations.Language;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public sealed abstract class ExperimentSolver extends ContainerSolver permits ChronomatronSolver, SuperpairsSolver, UltrasequencerSolver {
-    public enum State {
-        REMEMBER, WAIT, SHOW, END
-    }
+public abstract sealed class ExperimentSolver extends ContainerSolver permits ChronomatronSolver, SuperpairsSolver, UltrasequencerSolver {
+	public enum State {
+		REMEMBER, WAIT, SHOW, END
+	}
 
-    private State state = State.REMEMBER;
-    private final Map<Integer, ItemStack> slots = new HashMap<>();
+	private State state = State.REMEMBER;
+	private final Map<Integer, ItemStack> slots = new HashMap<>();
 
-    protected ExperimentSolver(String containerName) {
-        super(containerName);
-    }
+	protected ExperimentSolver(@Language("RegExp") String titlePattern) {
+		super(titlePattern);
+	}
 
-    public State getState() {
-        return state;
-    }
+	public State getState() {
+		return state;
+	}
 
-    public void setState(State state) {
-        this.state = state;
-    }
+	public void setState(State state) {
+		this.state = state;
+	}
 
-    public Map<Integer, ItemStack> getSlots() {
-        return slots;
-    }
+	public Map<Integer, ItemStack> getSlots() {
+		return slots;
+	}
 
-    @Override
-    protected final boolean isEnabled() {
-        return isEnabled(SkyblockerConfigManager.get().helpers.experiments);
-    }
+	@Override
+	protected final boolean isEnabled() {
+		return isEnabled(SkyblockerConfigManager.get().helpers.experiments);
+	}
 
-    protected abstract boolean isEnabled(HelperConfig.Experiments experimentsConfig);
+	protected abstract boolean isEnabled(HelperConfig.Experiments experimentsConfig);
 
-    @Override
-    protected void start(GenericContainerScreen screen) {
-        super.start(screen);
-        state = State.REMEMBER;
-        ScreenEvents.afterTick(screen).register(this::tick);
-    }
+	@Override
+	protected void start(GenericContainerScreen screen) {
+		super.start(screen);
+		state = State.REMEMBER;
+		ScreenEvents.afterTick(screen).register(this::tick);
+	}
 
-    @Override
-    protected void reset() {
-        super.reset();
-        state = State.REMEMBER;
-        slots.clear();
-    }
+	@Override
+	protected void reset() {
+		super.reset();
+		state = State.REMEMBER;
+		slots.clear();
+	}
 
-    protected abstract void tick(Screen screen);
+	protected abstract void tick(Screen screen);
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
@@ -8,75 +8,74 @@ import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public final class UltrasequencerSolver extends ExperimentSolver {
-    public static final UltrasequencerSolver INSTANCE = new UltrasequencerSolver();
-    private int ultrasequencerNextSlot;
+	public static final UltrasequencerSolver INSTANCE = new UltrasequencerSolver();
+	private int ultrasequencerNextSlot;
 
-    private UltrasequencerSolver() {
-        super("^Ultrasequencer \\(\\w+\\)$");
-    }
+	private UltrasequencerSolver() {
+		super("^Ultrasequencer \\(\\w+\\)$");
+	}
 
-    public int getUltrasequencerNextSlot() {
-        return ultrasequencerNextSlot;
-    }
+	public int getUltrasequencerNextSlot() {
+		return ultrasequencerNextSlot;
+	}
 
-    public void setUltrasequencerNextSlot(int ultrasequencerNextSlot) {
-        this.ultrasequencerNextSlot = ultrasequencerNextSlot;
-    }
+	public void setUltrasequencerNextSlot(int ultrasequencerNextSlot) {
+		this.ultrasequencerNextSlot = ultrasequencerNextSlot;
+	}
 
-    @Override
-    protected boolean isEnabled(HelperConfig.Experiments experimentsConfig) {
-        return experimentsConfig.enableUltrasequencerSolver;
-    }
+	@Override
+	protected boolean isEnabled(HelperConfig.Experiments experimentsConfig) {
+		return experimentsConfig.enableUltrasequencerSolver;
+	}
 
-    @Override
-    protected void tick(Screen screen) {
-        if (isEnabled() && screen instanceof GenericContainerScreen genericContainerScreen && genericContainerScreen.getTitle().getString().startsWith("Ultrasequencer (")) {
-            switch (getState()) {
-                case REMEMBER -> {
-                    Inventory inventory = genericContainerScreen.getScreenHandler().getInventory();
-                    if (inventory.getStack(49).getName().getString().equals("Remember the pattern!")) {
-                        for (int index = 9; index < 45; index++) {
-                            ItemStack itemStack = inventory.getStack(index);
-                            String name = itemStack.getName().getString();
-                            if (name.matches("\\d+")) {
-                                if (name.equals("1")) {
-                                    ultrasequencerNextSlot = index;
-                                }
-                                getSlots().put(index, itemStack);
-                            }
-                        }
-                        setState(State.WAIT);
-                    }
-                }
-                case WAIT -> {
-                    if (genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString().startsWith("Timer: ")) {
-                        setState(State.SHOW);
-                        markHighlightsDirty();
-                    }
-                }
-                case END -> {
-                    String name = genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString();
-                    if (!name.startsWith("Timer: ")) {
-                        if (name.equals("Remember the pattern!")) {
-                            getSlots().clear();
-                            setState(State.REMEMBER);
-                        } else {
-                            reset();
-                        }
-                    }
-                }
-            }
-        } else {
-            reset();
-        }
-    }
+	@Override
+	protected void tick(Screen screen) {
+		if (isEnabled() && screen instanceof GenericContainerScreen genericContainerScreen && genericContainerScreen.getTitle().getString().startsWith("Ultrasequencer (")) {
+			switch (getState()) {
+				case REMEMBER -> {
+					Inventory inventory = genericContainerScreen.getScreenHandler().getInventory();
+					if (inventory.getStack(49).getName().getString().equals("Remember the pattern!")) {
+						for (int index = 9; index < 45; index++) {
+							ItemStack itemStack = inventory.getStack(index);
+							String name = itemStack.getName().getString();
+							if (name.matches("\\d+")) {
+								if (name.equals("1")) {
+									ultrasequencerNextSlot = index;
+								}
+								getSlots().put(index, itemStack);
+							}
+						}
+						setState(State.WAIT);
+					}
+				}
+				case WAIT -> {
+					if (genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString().startsWith("Timer: ")) {
+						setState(State.SHOW);
+						markHighlightsDirty();
+					}
+				}
+				case END -> {
+					String name = genericContainerScreen.getScreenHandler().getInventory().getStack(49).getName().getString();
+					if (!name.startsWith("Timer: ")) {
+						if (name.equals("Remember the pattern!")) {
+							getSlots().clear();
+							setState(State.REMEMBER);
+						} else {
+							reset();
+						}
+					}
+				}
+			}
+		} else {
+			reset();
+		}
+	}
 
-    @Override
-    protected List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots) {
-        return getState() == State.SHOW && ultrasequencerNextSlot != 0 ? List.of(ColorHighlight.green(ultrasequencerNextSlot)) : new ArrayList<>();
-    }
+	@Override
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		return getState() == State.SHOW && ultrasequencerNextSlot != 0 ? List.of(ColorHighlight.green(ultrasequencerNextSlot)) : List.of();
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextAdder.java
@@ -2,17 +2,23 @@ package de.hysky.skyblocker.skyblock.item.slottext;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.render.gui.AbstractContainerMatcher;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.screen.slot.Slot;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
  * Extend this class and add it to {@link SlotTextManager#adders} to add text to any arbitrary slot.
  */
 public abstract class SlotTextAdder extends AbstractContainerMatcher {
+	protected SlotTextAdder(@NotNull Predicate<HandledScreen<?>> screenPredicate) {
+		super(screenPredicate);
+	}
+
 	/**
 	 * Utility constructor that will compile the given string into a pattern.
 	 *
@@ -49,6 +55,7 @@ public abstract class SlotTextAdder extends AbstractContainerMatcher {
 
 	/**
 	 * Override this method to add conditions to enable or disable this adder.
+	 *
 	 * @return Whether this adder is enabled.
 	 * @implNote The slot text adders only work while in skyblock, so no need to check for that again.
 	 */

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
@@ -3,7 +3,6 @@ package de.hysky.skyblocker.skyblock.item.slottext;
 import de.hysky.skyblocker.skyblock.item.slottext.adders.*;
 import de.hysky.skyblocker.utils.Utils;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.screen.slot.Slot;
 import org.jetbrains.annotations.NotNull;
@@ -35,18 +34,16 @@ public class SlotTextManager {
 
 	public static void init() {
 		ScreenEvents.AFTER_INIT.register((client, screen, width, height) -> {
-			if (screen instanceof HandledScreen<?> && Utils.isOnSkyblock()) {
-				onScreenChange(screen);
+			if (screen instanceof HandledScreen<?> handledScreen && Utils.isOnSkyblock()) {
+				onScreenChange(handledScreen);
 				ScreenEvents.remove(screen).register(ignored -> currentScreenAdders.clear());
 			}
 		});
 	}
 
-	private static void onScreenChange(Screen screen) {
-		final String title = screen.getTitle().getString();
+	private static void onScreenChange(HandledScreen<?> screen) {
 		for (SlotTextAdder adder : adders) {
-			if (!adder.isEnabled()) continue;
-			if (adder.titlePattern == null || adder.titlePattern.matcher(title).find()) {
+			if (adder.isEnabled() && adder.test(screen)) {
 				currentScreenAdders.add(adder);
 			}
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipAdder.java
@@ -1,12 +1,15 @@
 package de.hysky.skyblocker.skyblock.item.tooltip;
 
 import de.hysky.skyblocker.utils.render.gui.AbstractContainerMatcher;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
+import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
@@ -15,11 +18,17 @@ import java.util.regex.Pattern;
 public abstract class TooltipAdder extends AbstractContainerMatcher {
 	/**
 	 * The priority of this adder. Lower priority means it will be applied first.
+	 *
 	 * @apiNote Consider taking this value on your class' constructor and setting it from {@link TooltipManager#adders} to make it easy to read and maintain.
 	 */
 	public final int priority;
 
-	protected TooltipAdder(String titlePattern, int priority) {
+	protected TooltipAdder(Predicate<HandledScreen<?>> screenPredicate, int priority) {
+		super(screenPredicate);
+		this.priority = priority;
+	}
+
+	protected TooltipAdder(@Language("RegExp") String titlePattern, int priority) {
 		super(titlePattern);
 		this.priority = priority;
 	}

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/AbstractContainerMatcher.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/AbstractContainerMatcher.java
@@ -1,29 +1,54 @@
 package de.hysky.skyblocker.utils.render.gui;
 
-import de.hysky.skyblocker.skyblock.ChestValue;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public abstract class AbstractContainerMatcher {
-    /**
-     * The title of the screen must match this pattern for this to be applied. Null means it will be applied to all screens.
-     * @implNote Don't end your regex with a {@code $} as {@link ChestValue} appends text to the end of the title,
-     * so the regex will stop matching if the player uses chest value.
-     */
-    @Nullable
-    public final Pattern titlePattern;
+	private final Predicate<HandledScreen<?>> screenPredicate;
+	/**
+	 * This will be filled in with the groups from the title pattern if a regex approach was used.
+	 */
+	protected @Nullable String[] groups;
 
-    protected AbstractContainerMatcher() {
-        this((Pattern) null);
-    }
+	protected AbstractContainerMatcher() {
+		this(screen -> true);
+	}
 
-    protected AbstractContainerMatcher(@NotNull String titlePattern) {
-        this(Pattern.compile(titlePattern));
-    }
+	protected AbstractContainerMatcher(@NotNull String titlePattern) {
+		this(Pattern.compile(titlePattern));
+	}
 
-    protected AbstractContainerMatcher(@Nullable Pattern titlePattern) {
-        this.titlePattern = titlePattern;
-    }
+	protected AbstractContainerMatcher(@NotNull Pattern titlePattern) {
+		screenPredicate = screen -> {
+			Matcher matcher = titlePattern.matcher(screen.getTitle().getString());
+			if (matcher.matches()) {
+				groups = new String[matcher.groupCount()];
+				for (int i = 0; i < groups.length; i++) {
+					groups[i] = matcher.group(i + 1);
+				}
+				return true;
+			}
+			return false;
+		};
+	}
+
+	protected AbstractContainerMatcher(@NotNull Predicate<HandledScreen<?>> screenPredicate) {
+		this.screenPredicate = screenPredicate;
+	}
+
+	/**
+	 * This method will be called after screen initialization.
+	 * This could be used to check for certain things in the screen and do stuff based on them by overriding this method.
+	 *
+	 * @param screen The screen that was just opened.
+	 * @return {@code true} if this container matcher should apply on this screen, {@code false} otherwise.
+	 */
+	public boolean test(HandledScreen<?> screen) {
+		return screenPredicate.test(screen);
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolver.java
@@ -4,48 +4,46 @@ import de.hysky.skyblocker.SkyblockerMod;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.item.ItemStack;
+import org.intellij.lang.annotations.Language;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Abstract class for gui solvers. Extend this class to add a new gui solver, like terminal solvers or experiment solvers.
  */
 public abstract class ContainerSolver extends AbstractContainerMatcher {
-    protected ContainerSolver(String titlePattern) {
-        super(titlePattern);
-    }
+	protected ContainerSolver(@Language("RegExp") String titlePattern) {
+		super(titlePattern);
+	}
 
-    protected abstract boolean isEnabled();
+	protected abstract boolean isEnabled();
 
-    public final Pattern getName() {
-        return titlePattern;
-    }
+	protected void start(GenericContainerScreen screen) {
+	}
 
-    protected void start(GenericContainerScreen screen) {
-    }
+	protected void reset() {
+	}
 
-    protected void reset() {
-    }
+	protected void markHighlightsDirty() {
+		SkyblockerMod.getInstance().containerSolverManager.markDirty();
+	}
 
-    protected void markHighlightsDirty() {
-        SkyblockerMod.getInstance().containerSolverManager.markDirty();
-    }
+	protected boolean onClickSlot(int slot, ItemStack stack, int screenId) {
+		return false;
+	}
 
-    protected boolean onClickSlot(int slot, ItemStack stack, int screenId, String[] groups) {
-        return false;
-    }
+	protected List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		return List.of();
+	}
 
-    protected abstract List<ColorHighlight> getColors(String[] groups, Int2ObjectMap<ItemStack> slots);
-
-    protected final void trimEdges(Int2ObjectMap<ItemStack> slots, int rows) {
-        for (int i = 0; i < rows; i++) {
-            slots.remove(9 * i);
-            slots.remove(9 * i + 8);
-        }
-        for (int i = 1; i < 8; i++) {
-            slots.remove(i);
-            slots.remove((rows - 1) * 9 + i);
-        }
-    }
+	protected final void trimEdges(Int2ObjectMap<ItemStack> slots, int rows) {
+		for (int i = 0; i < rows; i++) {
+			slots.remove(9 * i);
+			slots.remove(9 * i + 8);
+		}
+		for (int i = 1; i < 8; i++) {
+			slots.remove(i);
+			slots.remove((rows - 1) * 9 + i);
+		}
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/ContainerSolverManager.java
@@ -1,7 +1,6 @@
 package de.hysky.skyblocker.utils.render.gui;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-
 import de.hysky.skyblocker.mixins.accessors.HandledScreenAccessor;
 import de.hysky.skyblocker.skyblock.accessories.newyearcakes.NewYearCakeBagHelper;
 import de.hysky.skyblocker.skyblock.accessories.newyearcakes.NewYearCakesHelper;
@@ -27,128 +26,108 @@ import net.minecraft.screen.slot.Slot;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
- * Manager class for {@link ContainerSolver}s like terminal solvers and experiment solvers. To add a new gui solver, extend {@link ContainerSolver} and register it in {@link #ContainerSolverManager()}.
+ * Manager class for {@link ContainerSolver}s like terminal solvers and experiment solvers.
+ * To add a new gui solver, extend {@link ContainerSolver} and add it to {@link ContainerSolverManager#solvers}.
  */
 public class ContainerSolverManager {
-    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("");
-    private final ContainerSolver[] solvers;
-    private ContainerSolver currentSolver = null;
-    private String[] groups;
-    private List<ColorHighlight> highlights;
-    /**
-     * Useful for keeping track of a solver's state in a Screen instance, such as if Hypixel closes & reopens a screen after every click (as they do with terminals).
-     */
-    private int screenId = 0;
+	private final ContainerSolver[] solvers = new ContainerSolver[]{
+			new ColorTerminal(),
+			new OrderTerminal(),
+			new StartsWithTerminal(),
+			new LightsOnTerminal(),
+			new CroesusHelper(),
+			new CroesusProfit(),
+			new ChronomatronSolver(),
+			new SuperpairsSolver(),
+			UltrasequencerSolver.INSTANCE,
+			new NewYearCakeBagHelper(),
+			NewYearCakesHelper.INSTANCE,
+			new ChocolateFactorySolver()
+	};
+	private ContainerSolver currentSolver = null;
+	private List<ColorHighlight> highlights;
+	/**
+	 * Useful for keeping track of a solver's state in a Screen instance, such as if Hypixel closes & reopens a screen after every click (as they do with terminals).
+	 */
+	private int screenId = 0;
 
-    public ContainerSolverManager() {
-        solvers = new ContainerSolver[]{
-                new ColorTerminal(),
-                new OrderTerminal(),
-                new StartsWithTerminal(),
-                new LightsOnTerminal(),
-                new CroesusHelper(),
-                new CroesusProfit(),
-                new ChronomatronSolver(),
-                new SuperpairsSolver(),
-                UltrasequencerSolver.INSTANCE,
-                new NewYearCakeBagHelper(),
-                NewYearCakesHelper.INSTANCE,
-                new ChocolateFactorySolver()
-        };
-    }
+	public ContainerSolver getCurrentSolver() {
+		return currentSolver;
+	}
 
-    public ContainerSolver getCurrentSolver() {
-        return currentSolver;
-    }
+	public void init() {
+		ScreenEvents.BEFORE_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+			if (Utils.isOnSkyblock() && screen instanceof GenericContainerScreen genericContainerScreen) {
+				ScreenEvents.afterRender(screen).register((screen1, context, mouseX, mouseY, delta) -> {
+					MatrixStack matrices = context.getMatrices();
+					matrices.push();
+					matrices.translate(((HandledScreenAccessor) genericContainerScreen).getX(), ((HandledScreenAccessor) genericContainerScreen).getY(), 300);
+					onDraw(context, genericContainerScreen.getScreenHandler().slots.subList(0, genericContainerScreen.getScreenHandler().getRows() * 9));
+					matrices.pop();
+				});
+				ScreenEvents.remove(screen).register(screen1 -> clearScreen());
+				onSetScreen(genericContainerScreen);
+			} else {
+				clearScreen();
+			}
+		});
+	}
 
-    public void init() {
-        ScreenEvents.BEFORE_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
-            if (Utils.isOnSkyblock() && screen instanceof GenericContainerScreen genericContainerScreen) {
-                ScreenEvents.afterRender(screen).register((screen1, context, mouseX, mouseY, delta) -> {
-                    MatrixStack matrices = context.getMatrices();
-                    matrices.push();
-                    matrices.translate(((HandledScreenAccessor) genericContainerScreen).getX(), ((HandledScreenAccessor) genericContainerScreen).getY(), 300);
-                    onDraw(context, genericContainerScreen.getScreenHandler().slots.subList(0, genericContainerScreen.getScreenHandler().getRows() * 9));
-                    matrices.pop();
-                });
-                ScreenEvents.remove(screen).register(screen1 -> clearScreen());
-                onSetScreen(genericContainerScreen);
-            } else {
-                clearScreen();
-            }
-        });
-    }
+	public void onSetScreen(@NotNull GenericContainerScreen screen) {
+		for (ContainerSolver solver : solvers) {
+			if (solver.isEnabled() && solver.test(screen)) {
+				++screenId;
+				currentSolver = solver;
+				currentSolver.start(screen);
+				markDirty();
+				return;
+			}
+		}
+		clearScreen();
+	}
 
-    public void onSetScreen(@NotNull GenericContainerScreen screen) {
-        String screenName = screen.getTitle().getString();
-        Matcher matcher = PLACEHOLDER_PATTERN.matcher(screenName);
-        for (ContainerSolver solver : solvers) {
-            if (solver.isEnabled()) {
-                matcher.usePattern(solver.getName());
-                matcher.reset();
-                if (matcher.matches()) {
-                    ++screenId;
-                    currentSolver = solver;
-                    groups = new String[matcher.groupCount()];
-                    for (int i = 0; i < groups.length; i++) {
-                        groups[i] = matcher.group(i + 1);
-                    }
-                    currentSolver.start(screen);
-                    markDirty();
+	public void clearScreen() {
+		if (currentSolver != null) {
+			currentSolver.reset();
+			currentSolver = null;
+		}
+	}
 
-                    return;
-                }
-            }
-        }
-        clearScreen();
-    }
+	public void markDirty() {
+		highlights = null;
+	}
 
-    public void clearScreen() {
-        if (currentSolver != null) {
-            currentSolver.reset();
-            currentSolver = null;
-        }
-    }
+	/**
+	 * @return Whether the click should be disallowed.
+	 */
+	public boolean onSlotClick(int slot, ItemStack stack) {
+		if (currentSolver != null) {
+			return currentSolver.onClickSlot(slot, stack, screenId);
+		}
 
-    public void markDirty() {
-        highlights = null;
-    }
+		return false;
+	}
 
-    /**
-     * @return Whether the click should be disallowed.
-     */
-    public boolean onSlotClick(int slot, ItemStack stack) {
-        if (currentSolver != null) {
-            return currentSolver.onClickSlot(slot, stack, screenId, groups);
-        }
+	public void onDraw(DrawContext context, List<Slot> slots) {
+		if (currentSolver == null) return;
+		if (highlights == null) highlights = currentSolver.getColors(slotMap(slots));
+		RenderSystem.enableDepthTest();
+		RenderSystem.colorMask(true, true, true, false);
+		for (ColorHighlight highlight : highlights) {
+			Slot slot = slots.get(highlight.slot());
+			int color = highlight.color();
+			context.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, color);
+		}
+		RenderSystem.colorMask(true, true, true, true);
+	}
 
-        return false;
-    }
-
-    public void onDraw(DrawContext context, List<Slot> slots) {
-        if (currentSolver == null)
-            return;
-        if (highlights == null)
-            highlights = currentSolver.getColors(groups, slotMap(slots));
-        RenderSystem.enableDepthTest();
-        RenderSystem.colorMask(true, true, true, false);
-        for (ColorHighlight highlight : highlights) {
-            Slot slot = slots.get(highlight.slot());
-            int color = highlight.color();
-            context.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, color);
-        }
-        RenderSystem.colorMask(true, true, true, true);
-    }
-
-    private Int2ObjectMap<ItemStack> slotMap(List<Slot> slots) {
-    	Int2ObjectMap<ItemStack> slotMap = new Int2ObjectRBTreeMap<>();
-        for (int i = 0; i < slots.size(); i++) {
-            slotMap.put(i, slots.get(i).getStack());
-        }
-        return slotMap;
-    }
+	private Int2ObjectMap<ItemStack> slotMap(List<Slot> slots) {
+		Int2ObjectMap<ItemStack> slotMap = new Int2ObjectRBTreeMap<>();
+		for (int i = 0; i < slots.size(); i++) {
+			slotMap.put(i, slots.get(i).getStack());
+		}
+		return slotMap;
+	}
 }


### PR DESCRIPTION
Title. The predicate check is a method inside of `AbstractContainerSolver`, so inheritors can override to check stuff with the given screen after screen initialization and do stuff based on that. This allows making solvers for screens that don't have a fixed title but have distinguishable traits that are possible to obtain from the `HandledScreen` (most likely via the inventory).

The chances of this breaking anything is very low. The most crucial part is probably the container solvers, and I've tested a few easy things such as enchanting experiments myself but stuff like terminal solvers might need testing.

I've also *cleaned up* some code wantonly, such as:
- Making `ContainerSolver` not abstract and having a default return value of `List.of()` for solvers that don't need highlights (like just blocking clicks)
- Moving `groups` of `ContainerSolver` into `AbstractContainerMatcher` when the matcher uses a regex predicate (this removes the extra argument on all implementors that just didn't care about them. There was only 1 class that did care: ColorTerminal, and it's still functional)
- Adding `@Language("RegExp)` to some classes' constructors that receive a `String` that will be compiled into a `Pattern`
- Probably more

Oh and you might want to set your diff view to ignore whitespace changes.