### PR TITLE
Multiply npc price tooltip by the amount of items in the sack

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -20,9 +21,18 @@ public class NpcPriceTooltip extends TooltipAdder {
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
 		final String internalID = stack.getSkyblockId();
 		if (internalID != null && TooltipInfoType.NPC.isTooltipEnabledAndHasOrNullWarning(internalID)) {
+			int amount;
+			if (lines.get(1).getString().endsWith("Sack")) {
+				//The amount is in the 2nd sibling of the 3rd line of the lore.                                              here V
+				//Example line: empty[style={color=dark_purple,!italic}, siblings=[literal{Stored: }[style={color=gray}], literal{0}[style={color=dark_gray}], literal{/20k}[style={color=gray}]]
+				String line = lines.get(3).getSiblings().get(1).getString().replace(",", "");
+				amount = NumberUtils.isParsable(line) && !line.equals("0") ? Integer.parseInt(line) : stack.getCount();
+			} else {
+				amount = stack.getCount();
+			}
 			lines.add(Text.literal(String.format("%-21s", "NPC Sell Price:"))
 			              .formatted(Formatting.YELLOW)
-			              .append(ItemTooltip.getCoinsMessage(TooltipInfoType.NPC.getData().get(internalID).getAsDouble(), stack.getCount())));
+			              .append(ItemTooltip.getCoinsMessage(TooltipInfoType.NPC.getData().get(internalID).getAsDouble(), amount)));
 		}
 	}
 }


### PR DESCRIPTION
I stole the code from the bz price tooltip (that already works) and a quick test gave me positive results.