### PR TITLE
Remove the development environment branch from the isInLocation methods

### DIFF
--- a/src/main/java/de/hysky/skyblocker/utils/Utils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Utils.java
@@ -95,15 +95,15 @@ public class Utils {
     }
 
     public static boolean isInDungeons() {
-        return location == Location.DUNGEON || FabricLoader.getInstance().isDevelopmentEnvironment();
+        return location == Location.DUNGEON;
     }
 
     public static boolean isInCrystalHollows() {
-        return location == Location.CRYSTAL_HOLLOWS || FabricLoader.getInstance().isDevelopmentEnvironment();
+        return location == Location.CRYSTAL_HOLLOWS;
     }
 
     public static boolean isInDwarvenMines() {
-        return location == Location.DWARVEN_MINES || location == Location.GLACITE_MINESHAFT || FabricLoader.getInstance().isDevelopmentEnvironment();
+        return location == Location.DWARVEN_MINES || location == Location.GLACITE_MINESHAFT;
     }
 
     public static boolean isInTheRift() {


### PR DESCRIPTION
It's quite annoying when you're trying to debug something else and your logs get spammed by incorrect regex matches and unnecessary commission & map hud stuff show up. This PR disables that.