### PR TITLE
emi/rei, Quicknav, livid and nukekubi head (eman boss head) fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ mod_menu_version = 11.0.0-beta.1
 ## REI (https://modrinth.com/mod/rei/versions?l=fabric)
 rei_version = 13.0.666
 ## EMI (https://modrinth.com/mod/emi/versions)
-emi_version = 1.0.22+1.20.2
+emi_version = 1.1.10+1.21
 
 # Minecraft and Related Libraries
 ## McDev Annotations (https://central.sonatype.com/artifact/com.demonwav.mcdev/annotations)

--- a/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
+++ b/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
@@ -203,7 +203,6 @@ public class SkyblockerMod implements ClientModInitializer {
 
         Scheduler.INSTANCE.scheduleCyclic(Utils::update, 20);
         Scheduler.INSTANCE.scheduleCyclic(DiscordRPCManager::updateDataAndPresence, 200);
-        Scheduler.INSTANCE.scheduleCyclic(LividColor::update, 10);
         Scheduler.INSTANCE.scheduleCyclic(BackpackPreview::tick, 50);
         Scheduler.INSTANCE.scheduleCyclic(DwarvenHud::update, 40);
         Scheduler.INSTANCE.scheduleCyclic(CrystalsHud::update, 40);

--- a/src/main/java/de/hysky/skyblocker/compatibility/emi/SkyblockerEMIPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/emi/SkyblockerEMIPlugin.java
@@ -24,7 +24,7 @@ public class SkyblockerEMIPlugin implements EmiPlugin {
     public void register(EmiRegistry registry) {
         ItemRepository.getItemsStream().map(EmiStack::of).forEach(emiStack -> {
             registry.addEmiStack(emiStack);
-            registry.setDefaultComparison(emiStack, Comparison.compareNbt());
+            registry.setDefaultComparison(emiStack, Comparison.compareComponents());
         });
         registry.addCategory(SKYBLOCK);
         registry.addWorkstation(SKYBLOCK, EmiStack.of(Items.CRAFTING_TABLE));

--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -202,6 +202,14 @@ public class DungeonsCategory {
                         .name(Text.translatable("skyblocker.config.dungeons.livid"))
                         .collapsed(true)
                         .option(Option.<Boolean>createBuilder()
+                                .name(Text.translatable("skyblocker.config.dungeons.livid.enableSolidColor"))
+                                .description(OptionDescription.of(Text.translatable("skyblocker.config.dungeons.livid.enableSolidColor.@Tooltip")))
+                                .binding(defaults.dungeons.livid.enableSolidColor,
+                                        () -> config.dungeons.livid.enableSolidColor,
+                                        newValue -> config.dungeons.livid.enableSolidColor = newValue)
+                                .controller(ConfigUtils::createBooleanController)
+                                .build())
+                        .option(Option.<Boolean>createBuilder()
                                 .name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorGlow"))
                                 .description(OptionDescription.of(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorGlow.@Tooltip")))
                                 .binding(defaults.dungeons.livid.enableLividColorGlow,

--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -210,6 +210,14 @@ public class DungeonsCategory {
                                 .controller(ConfigUtils::createBooleanController)
                                 .build())
                         .option(Option.<Boolean>createBuilder()
+                                .name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorBoundingBox"))
+                                .description(OptionDescription.of(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorBoundingBox.@Tooltip")))
+                                .binding(defaults.dungeons.livid.enableLividColorBoundingBox,
+                                        () -> config.dungeons.livid.enableLividColorBoundingBox,
+                                        newValue -> config.dungeons.livid.enableLividColorBoundingBox = newValue)
+                                .controller(ConfigUtils::createBooleanController)
+                                .build())
+                        .option(Option.<Boolean>createBuilder()
                                 .name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorText"))
                                 .description(OptionDescription.of(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorText.@Tooltip")))
                                 .binding(defaults.dungeons.livid.enableLividColorText,

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -112,7 +112,10 @@ public class DungeonsConfig {
 
     public static class Livid {
         @SerialEntry
-        public boolean enableLividColorGlow = true;
+        public boolean enableLividColorGlow = false;
+
+        @SerialEntry
+        public boolean enableLividColorBoundingBox = true;
 
         @SerialEntry
         public boolean enableLividColorText = true;

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -112,6 +112,9 @@ public class DungeonsConfig {
 
     public static class Livid {
         @SerialEntry
+        public boolean enableSolidColor = false;
+
+        @SerialEntry
         public boolean enableLividColorGlow = false;
 
         @SerialEntry

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -46,10 +46,12 @@ public class LividColor {
     );
     public static final Set<String> LIVID_NAMES = Set.copyOf(LIVID_TO_FORMATTING.keySet());
     public static final DungeonsConfig.Livid CONFIG = SkyblockerConfigManager.get().dungeons.livid;
-    private static Formatting color;
+    private static Formatting color = Formatting.AQUA;
     private static Block lastColor = Blocks.AIR;
+    private static int lividID = 0;
 
     private static boolean isInitialized = false;
+    private static boolean originLividFound = false;
     private static final long OFFSET_DURATION = 2000;
     private static long toggleTime = 0;
 
@@ -74,6 +76,18 @@ public class LividColor {
             isInitialized = true;
         } else if (isInitialized && System.currentTimeMillis() - toggleTime >= OFFSET_DURATION) {
             onLividColorFound(client, currentColor);
+            if (!originLividFound) {
+                String lividName = LIVID_TO_FORMATTING.entrySet().stream()
+                        .filter(entry -> entry.getValue() == color)
+                        .map(Map.Entry::getKey)
+                        .findFirst()
+                        .orElse("unknown");
+                client.world.getPlayers().stream()
+                        .filter(entity -> entity.getName().getString().equals(lividName))
+                        .findFirst()
+                        .ifPresent(entity -> lividID = entity.getId());
+                originLividFound = true;
+            }
             lastColor = currentColor;
         }
 
@@ -114,9 +128,16 @@ public class LividColor {
         return Formatting.WHITE.getColorValue();
     }
 
+    public static int getLividID(){
+        return lividID;
+    }
+
     private static void reset() {
         lastColor = Blocks.AIR;
         toggleTime = 0;
         isInitialized = false;
+        originLividFound = false;
+        lividID = 0;
+        color = Formatting.AQUA;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -19,7 +19,6 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.Map;
-import java.util.Set;
 
 public class LividColor {
     private static final Map<Block, Formatting> WOOL_TO_FORMATTING = Map.of(
@@ -44,14 +43,16 @@ public class LividColor {
             "Doctor Livid", Formatting.GRAY,
             "Vendetta Livid", Formatting.WHITE
     );
-    public static final Set<String> LIVID_NAMES = Set.copyOf(LIVID_TO_FORMATTING.keySet());
     public static final DungeonsConfig.Livid CONFIG = SkyblockerConfigManager.get().dungeons.livid;
     private static Formatting color = Formatting.AQUA;
     private static Block lastColor = Blocks.AIR;
-    private static int lividID = 0;
 
     private static boolean isInitialized = false;
-    private static boolean originLividFound = false;
+    /**
+     * The correct livid may change color in M5, so we use the entity id to track the correct original livid.
+     */
+    private static boolean correctLividIdFound = false;
+    private static int correctLividId = 0;
     private static final long OFFSET_DURATION = 2000;
     private static long toggleTime = 0;
 
@@ -76,7 +77,7 @@ public class LividColor {
             isInitialized = true;
         } else if (isInitialized && System.currentTimeMillis() - toggleTime >= OFFSET_DURATION) {
             onLividColorFound(client, currentColor);
-            if (!originLividFound) {
+            if (!correctLividIdFound) {
                 String lividName = LIVID_TO_FORMATTING.entrySet().stream()
                         .filter(entry -> entry.getValue() == color)
                         .map(Map.Entry::getKey)
@@ -85,8 +86,8 @@ public class LividColor {
                 client.world.getPlayers().stream()
                         .filter(entity -> entity.getName().getString().equals(lividName))
                         .findFirst()
-                        .ifPresent(entity -> lividID = entity.getId());
-                originLividFound = true;
+                        .ifPresent(entity -> correctLividId = entity.getId());
+                correctLividIdFound = true;
             }
             lastColor = currentColor;
         }
@@ -128,16 +129,16 @@ public class LividColor {
         return Formatting.WHITE.getColorValue();
     }
 
-    public static int getLividID(){
-        return lividID;
+    public static int getCorrectLividId() {
+        return correctLividId;
     }
 
     private static void reset() {
         lastColor = Blocks.AIR;
         toggleTime = 0;
         isInitialized = false;
-        originLividFound = false;
-        lividID = 0;
+        correctLividIdFound = false;
+        correctLividId = 0;
         color = Formatting.AQUA;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -109,7 +109,9 @@ public class LividColor {
 
     @SuppressWarnings("DataFlowIssue")
     public static int getGlowColor(String name) {
-        return LIVID_TO_FORMATTING.containsKey(name) ? LIVID_TO_FORMATTING.get(name).getColorValue() : Formatting.WHITE.getColorValue();
+        if (SkyblockerConfigManager.get().dungeons.livid.enableSolidColor) return Formatting.RED.getColorValue();
+        if (LIVID_TO_FORMATTING.containsKey(name)) return LIVID_TO_FORMATTING.get(name).getColorValue();
+        return Formatting.WHITE.getColorValue();
     }
 
     private static void reset() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -6,7 +6,6 @@ import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -16,7 +15,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.registry.Registries;
 import net.minecraft.text.MutableText;
-import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
 
@@ -50,14 +48,12 @@ public class LividColor {
     public static final DungeonsConfig.Livid CONFIG = SkyblockerConfigManager.get().dungeons.livid;
     private static Formatting color;
     private static Block lastColor = Blocks.AIR;
-    private static boolean inBoss = false;
 
     private static boolean isInitialized = false;
     private static final long OFFSET_DURATION = 2000;
     private static long toggleTime = 0;
 
     public static void init() {
-        ClientReceiveMessageEvents.GAME.register(LividColor::onChatMessage);
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> LividColor.reset());
         WorldRenderEvents.AFTER_ENTITIES.register(LividColor::update);
     }
@@ -68,7 +64,7 @@ public class LividColor {
 
         MinecraftClient client = MinecraftClient.getInstance();
 
-        if (!(Utils.isInDungeons() && inBoss && client.player != null && client.world != null)) return;
+        if (!(Utils.isInDungeons() && DungeonManager.isInBoss() && client.player != null && client.world != null)) return;
 
         Block currentColor = client.world.getBlockState(new BlockPos(5, 110, 42)).getBlock();
         if (!(WOOL_TO_FORMATTING.containsKey(currentColor) && !currentColor.equals(lastColor))) return;
@@ -117,18 +113,8 @@ public class LividColor {
     }
 
     private static void reset() {
-        inBoss = false;
         lastColor = Blocks.AIR;
         toggleTime = 0;
         isInitialized = false;
-    }
-
-    private static void onChatMessage(Text text, boolean overlay) {
-        DungeonsConfig.Livid config = SkyblockerConfigManager.get().dungeons.livid;
-        if (Utils.isInDungeons() && (config.enableLividColorText || config.enableLividColorTitle || config.enableLividColorGlow || config.enableLividColorBoundingBox) && !inBoss) {
-            String unformatted = Formatting.strip(text.getString());
-
-            inBoss = unformatted.equals("[BOSS] Livid: Welcome, you've arrived right on time. I am Livid, the Master of Shadows.");
-        }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
@@ -32,7 +32,7 @@ public class MobBoundingBoxes {
 
 			return switch (entity) {
 				case PlayerEntity _p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") -> SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes;
-				case PlayerEntity p when entity.getId() == LividColor.getLividID() -> LividColor.shouldDrawBoundingBox(name);
+				case PlayerEntity p when entity.getId() == LividColor.getCorrectLividId() -> LividColor.shouldDrawBoundingBox(name);
 				case ArmorStandEntity _armorStand -> false;
 
 				// Regular Mobs

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
@@ -32,7 +32,7 @@ public class MobBoundingBoxes {
 
 			return switch (entity) {
 				case PlayerEntity _p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") -> SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes;
-				case PlayerEntity p when LividColor.LIVID_NAMES.contains(name) -> LividColor.shouldDrawBoundingBox(name);
+				case PlayerEntity p when entity.getId() == LividColor.getLividID() -> LividColor.shouldDrawBoundingBox(name);
 				case ArmorStandEntity _armorStand -> false;
 
 				// Regular Mobs

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.skyblock.entity;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.dungeon.LividColor;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.FrustumUtils;
 import de.hysky.skyblocker.utils.render.RenderHelper;
@@ -31,6 +32,7 @@ public class MobBoundingBoxes {
 
 			return switch (entity) {
 				case PlayerEntity _p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") -> SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes;
+				case PlayerEntity p when LividColor.LIVID_NAMES.contains(name) -> LividColor.shouldDrawBoundingBox(name);
 				case ArmorStandEntity _armorStand -> false;
 
 				// Regular Mobs

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -36,7 +36,7 @@ public class MobGlow {
 				return switch (entity) {
 					// Minibosses
 					case PlayerEntity p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") -> SkyblockerConfigManager.get().dungeons.starredMobGlow;
-					case PlayerEntity p when LividColor.LIVID_NAMES.contains(name) -> LividColor.shouldGlow(name);
+					case PlayerEntity p when entity.getId() == LividColor.getLividID() -> LividColor.shouldGlow(name);
 
 					// Bats
 					case BatEntity b -> SkyblockerConfigManager.get().dungeons.starredMobGlow || SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes;
@@ -48,7 +48,6 @@ public class MobGlow {
 					default -> SkyblockerConfigManager.get().dungeons.starredMobGlow && isStarred(entity);
 				};
 			}
-
 
 			return switch (entity) {
 				// Rift
@@ -111,11 +110,11 @@ public class MobGlow {
 			case PlayerEntity p when name.equals("Lost Adventurer") -> 0xfee15c;
 			case PlayerEntity p when name.equals("Shadow Assassin") -> 0x5b2cb2;
 			case PlayerEntity p when name.equals("Diamond Guy") -> 0x57c2f7;
-			case PlayerEntity p when LividColor.LIVID_NAMES.contains(name) -> LividColor.getGlowColor(name);
+			case PlayerEntity p when entity.getId() == LividColor.getLividID() -> LividColor.getGlowColor(name);
 			case PlayerEntity p when name.equals("Blobbercyst ") -> Formatting.GREEN.getColorValue();
 
 			case EndermanEntity enderman when TheEnd.isSpecialZealot(enderman) -> Formatting.RED.getColorValue();
-			case ArmorStandEntity armorStand when isNukekubiHead(armorStand) -> 0x990099;
+			case ArmorStandEntity armorStand when isNukekubiHead(armorStand) -> Formatting.GREEN.getColorValue();
 			case ZombieEntity zombie when Utils.isInCrimson() && DojoManager.inArena -> DojoManager.getColor();
 
 			default -> 0xf57738;

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -123,14 +123,15 @@ public class MobGlow {
 	}
 
 	private static boolean isNukekubiHead(ArmorStandEntity entity) {
+		boolean armorfound = false;
 		for (ItemStack armorItem : entity.getArmorItems()) {
 			// eb07594e2df273921a77c101d0bfdfa1115abed5b9b2029eb496ceba9bdbb4b3 is texture id for the nukekubi head,
 			// compare against it to exclusively find armorstands that are nukekubi heads
 			// get the texture of the nukekubi head item itself and compare it
 			String texture = ItemUtils.getHeadTexture(armorItem);
 
-			return texture.contains("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWIwNzU5NGUyZGYyNzM5MjFhNzdjMTAxZDBiZmRmYTExMTVhYmVkNWI5YjIwMjllYjQ5NmNlYmE5YmRiYjRiMyJ9fX0=");
+			armorfound |= texture.contains("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWIwNzU5NGUyZGYyNzM5MjFhNzdjMTAxZDBiZmRmYTExMTVhYmVkNWI5YjIwMjllYjQ5NmNlYmE5YmRiYjRiMyJ9fX0=");
 		}
-		return false;
+		return armorfound;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.entity;
 
+import com.google.common.collect.Streams;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
 import de.hysky.skyblocker.skyblock.dungeon.LividColor;
@@ -14,7 +15,6 @@ import net.minecraft.entity.mob.EndermanEntity;
 import net.minecraft.entity.mob.ZombieEntity;
 import net.minecraft.entity.passive.BatEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
 import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.Box;
@@ -23,6 +23,10 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class MobGlow {
+	/**
+	 * The Nukekubi head texture id is eb07594e2df273921a77c101d0bfdfa1115abed5b9b2029eb496ceba9bdbb4b3.
+	 */
+	public static final String NUKEKUBI_HEAD_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWIwNzU5NGUyZGYyNzM5MjFhNzdjMTAxZDBiZmRmYTExMTVhYmVkNWI5YjIwMjllYjQ5NmNlYmE5YmRiYjRiMyJ9fX0=";
 
 	public static boolean shouldMobGlow(Entity entity) {
 		Box box = entity.getBoundingBox();
@@ -36,7 +40,7 @@ public class MobGlow {
 				return switch (entity) {
 					// Minibosses
 					case PlayerEntity p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") -> SkyblockerConfigManager.get().dungeons.starredMobGlow;
-					case PlayerEntity p when entity.getId() == LividColor.getLividID() -> LividColor.shouldGlow(name);
+					case PlayerEntity p when entity.getId() == LividColor.getCorrectLividId() -> LividColor.shouldGlow(name);
 
 					// Bats
 					case BatEntity b -> SkyblockerConfigManager.get().dungeons.starredMobGlow || SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes;
@@ -110,7 +114,7 @@ public class MobGlow {
 			case PlayerEntity p when name.equals("Lost Adventurer") -> 0xfee15c;
 			case PlayerEntity p when name.equals("Shadow Assassin") -> 0x5b2cb2;
 			case PlayerEntity p when name.equals("Diamond Guy") -> 0x57c2f7;
-			case PlayerEntity p when entity.getId() == LividColor.getLividID() -> LividColor.getGlowColor(name);
+			case PlayerEntity p when entity.getId() == LividColor.getCorrectLividId() -> LividColor.getGlowColor(name);
 			case PlayerEntity p when name.equals("Blobbercyst ") -> Formatting.GREEN.getColorValue();
 
 			case EndermanEntity enderman when TheEnd.isSpecialZealot(enderman) -> Formatting.RED.getColorValue();
@@ -121,16 +125,10 @@ public class MobGlow {
 		};
 	}
 
+	/**
+	 * Compares the armor items of an armor stand to the Nukekubi head texture to determine if it is a Nukekubi head.
+	 */
 	private static boolean isNukekubiHead(ArmorStandEntity entity) {
-		boolean armorfound = false;
-		for (ItemStack armorItem : entity.getArmorItems()) {
-			// eb07594e2df273921a77c101d0bfdfa1115abed5b9b2029eb496ceba9bdbb4b3 is texture id for the nukekubi head,
-			// compare against it to exclusively find armorstands that are nukekubi heads
-			// get the texture of the nukekubi head item itself and compare it
-			String texture = ItemUtils.getHeadTexture(armorItem);
-
-			armorfound |= texture.contains("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWIwNzU5NGUyZGYyNzM5MjFhNzdjMTAxZDBiZmRmYTExMTVhYmVkNWI5YjIwMjllYjQ5NmNlYmE5YmRiYjRiMyJ9fX0=");
-		}
-		return armorfound;
+		return Streams.stream(entity.getArmorItems()).map(ItemUtils::getHeadTexture).anyMatch(headTexture -> headTexture.contains(NUKEKUBI_HEAD_TEXTURE));
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CollectionAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CollectionAdder.java
@@ -15,7 +15,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CollectionAdder extends SimpleSlotTextAdder {
-    private static final Pattern COLLECTION = Pattern.compile("^[\\w ]+ (?<level>[IVXLCDM]+)$");
+    private static final Pattern COLLECTION = Pattern.compile("^[\\w -]+ (?<level>[IVXLCDM]+)$");
 
     public CollectionAdder() {
         super("^\\w+ Collections");

--- a/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
@@ -18,9 +18,15 @@ import net.minecraft.util.Identifier;
 @Environment(value = EnvType.CLIENT)
 public class QuickNavButton extends ClickableWidget {
     private final int index;
-    private boolean toggled;
+    private final boolean toggled;
+    private boolean temporaryToggled = false;
     private final String command;
     private final ItemStack icon;
+
+    private static final long TOGGLE_DURATION = 250;
+    private long toggleTime;
+
+    private float alpha = 1.0f;
 
     /**
      * Checks if the current tab is a top tab based on its index.
@@ -32,7 +38,7 @@ public class QuickNavButton extends ClickableWidget {
     }
 
     public boolean toggled() {
-        return toggled;
+        return toggled || temporaryToggled;
     }
 
     /**
@@ -49,6 +55,7 @@ public class QuickNavButton extends ClickableWidget {
         this.toggled = toggled;
         this.command = command;
         this.icon = icon;
+        this.toggleTime = 0;
     }
 
     private void updateCoordinates() {
@@ -71,10 +78,12 @@ public class QuickNavButton extends ClickableWidget {
      */
     @Override
     public void onClick(double mouseX, double mouseY) {
-        if (!this.toggled) {
-            this.toggled = true;
+        if (!this.temporaryToggled) {
+            this.temporaryToggled = true;
+            this.toggleTime = System.currentTimeMillis();
             MessageScheduler.INSTANCE.sendMessageAfterCooldown(command);
             // TODO : add null check with log error
+            this.alpha = 0.5f;
         }
     }
 
@@ -93,17 +102,38 @@ public class QuickNavButton extends ClickableWidget {
         this.updateCoordinates();
         RenderSystem.disableDepthTest();
 
+        if (this.temporaryToggled && System.currentTimeMillis() - this.toggleTime >= TOGGLE_DURATION) {
+            this.temporaryToggled = false; // Reset toggled state
+        }
+        //"animation"
+        if (this.alpha < 1.0f) {
+            this.alpha += 0.05f;
+            if (this.alpha > 1.0f) {
+                this.alpha = 1.0f;
+            }
+        }
+
+        //"animation"
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, this.alpha);
+
         // Construct the texture identifier based on the index and toggled state
-        Identifier tabTexture = Identifier.ofVanilla("container/creative_inventory/tab_" + (isTopTab() ? "top" : "bottom") + "_" + (toggled ? "selected" : "unselected") + "_" + (index % 7 + 1));
+        Identifier tabTexture = Identifier.ofVanilla("container/creative_inventory/tab_" + (isTopTab() ? "top" : "bottom") + "_" + (toggled() ? "selected" : "unselected") + "_" + (index % 7 + 1));
 
         // Render the button texture
         context.drawGuiTexture(tabTexture, this.getX(), this.getY(), this.width, this.height);
         // Render the button icon
         int yOffset = this.index < 7 ? 1 : -1;
         context.drawItem(this.icon, this.getX() + 5, this.getY() + 8 + yOffset);
+        //prevent "fading animation" on not quicknav stuff
+        RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+        RenderSystem.disableBlend();
+
         RenderSystem.enableDepthTest();
     }
 
     @Override
-    protected void appendClickableNarrations(NarrationMessageBuilder builder) {}
+    protected void appendClickableNarrations(NarrationMessageBuilder builder) {
+    }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
@@ -23,7 +23,7 @@ public class QuickNavButton extends ClickableWidget {
     private final String command;
     private final ItemStack icon;
 
-    private static final long TOGGLE_DURATION = 250;
+    private static final long TOGGLE_DURATION = 1000;
     private long toggleTime;
 
     private float alpha = 1.0f;
@@ -134,6 +134,5 @@ public class QuickNavButton extends ClickableWidget {
     }
 
     @Override
-    protected void appendClickableNarrations(NarrationMessageBuilder builder) {
-    }
+    protected void appendClickableNarrations(NarrationMessageBuilder builder) {}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
@@ -51,10 +51,13 @@ public class NEURepoManager {
                         }))
                 )
         );
-        SkyblockEvents.JOIN.register(NEURepoManager::load);
+        SkyblockEvents.JOIN.register(NEURepoManager::handleRecipeSynchronization);
     }
 
-    private static void load() {
+    /**
+     * load the recipe manually because Hypixel doesn't send any vanilla recipes to the client
+     */
+    private static void handleRecipeSynchronization() {
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.world != null && client.getNetworkHandler() != null) {
             SynchronizeRecipesS2CPacket packet = new SynchronizeRecipesS2CPacket(List.of());

--- a/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.utils;
 
 import com.mojang.brigadier.Command;
 import de.hysky.skyblocker.SkyblockerMod;
+import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import io.github.moulberry.repo.NEURepository;
@@ -9,6 +10,7 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.packet.s2c.play.SynchronizeRecipesS2CPacket;
 import net.minecraft.text.Text;
 import org.apache.commons.lang3.function.Consumers;
 import org.eclipse.jgit.api.Git;
@@ -49,6 +51,20 @@ public class NEURepoManager {
                         }))
                 )
         );
+        SkyblockEvents.JOIN.register(NEURepoManager::load);
+    }
+
+    private static void load() {
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.world != null && client.getNetworkHandler() != null) {
+            SynchronizeRecipesS2CPacket packet = new SynchronizeRecipesS2CPacket(List.of());
+
+            try {
+                client.getNetworkHandler().onSynchronizeRecipes(packet);
+            } catch (Exception e) {
+                LOGGER.info("[Skyblocker] recipe sync error" , e);
+            }
+        }
     }
 
     public static boolean isLoading() {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -113,6 +113,8 @@
   "skyblocker.config.dungeons.livid": "Livid (F5/M5)",
   "skyblocker.config.dungeons.livid.enableLividColorGlow": "Enable Livid Color Glow",
   "skyblocker.config.dungeons.livid.enableLividColorGlow.@Tooltip": "Applies the glowing effect to the correct Livid in F5/M5.",
+  "skyblocker.config.dungeons.livid.enableLividColorBoundingBox": "Enable Livid Color Bounding Box",
+  "skyblocker.config.dungeons.livid.enableLividColorBoundingBox.@Tooltip": "Applies a bounding box to the correct Livid in F5/M5.",
   "skyblocker.config.dungeons.livid.enableLividColorText": "Enable Livid Color Text",
   "skyblocker.config.dungeons.livid.enableLividColorText.@Tooltip": "Send the livid color in the chat during the Livid boss fight.",
   "skyblocker.config.dungeons.livid.enableLividColorTitle": "Enable Livid Color Title",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -111,6 +111,8 @@
   "skyblocker.config.dungeons.hideSoulweaverSkulls.@Tooltip": "Hides the Haunted Skulls spawned that are spawned as a result of using Soulweaver Gloves.",
 
   "skyblocker.config.dungeons.livid": "Livid (F5/M5)",
+  "skyblocker.config.dungeons.livid.enableSolidColor": "Enable Glow and/or Bounding use same color",
+  "skyblocker.config.dungeons.livid.enableSolidColor.@Tooltip": "Instead of Livid color an Red color is Shown",
   "skyblocker.config.dungeons.livid.enableLividColorGlow": "Enable Livid Color Glow",
   "skyblocker.config.dungeons.livid.enableLividColorGlow.@Tooltip": "Applies the glowing effect to the correct Livid in F5/M5.",
   "skyblocker.config.dungeons.livid.enableLividColorBoundingBox": "Enable Livid Color Bounding Box",


### PR DESCRIPTION
fixes #378, fixes #539, fixes #538, fixes #860

# emi/rei fix
emi and rei are working again

# Quicknav
The click behavior of the Quicknavbutton has been changed so that it is more like a button click. The button is therefore pressed for 0.25 seconds. This has the advantage that the button can be pressed again if an error occurs. Otherwise, everything is the same, i.e. if the container name is recognized, it remains pressed and cannot be pressed again.
A fade animation has also been added.
![outs3](https://github.com/SkyblockerMod/Skyblocker/assets/19829407/9f75c7d0-e166-4fea-86eb-28fbdafcff5a)


# Livid
The logic of the livid code has been changed.
The system checks whether the current color is the same as the last found livid color. The initial color is detected after the first blindness effect + 2 seconds.
I also added the bounding box option for livid to make it easier to recognize the correct enemy. I changed default mob glow option to false by and bounding box option to true.
thanks to hysteria for testing stuff

# nukekubi head fix
the heads are now highlighted correctly again (to-do: only highlight your boss heads and not others)
changed the highlight color to green
thanks to hysteria for testing stuff

#  Slottext: Half-Eaten Carrot Collection
added support for Half-Eaten Carrot collection for slottext