### PR TITLE
Add the `run` directory as an excluded directory for intellij upon gradle load

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,12 @@ base {
 	archivesName = project.archives_base_name
 }
 
+idea {
+	module {
+		excludeDirs.add(file("run"))
+	}
+}
+
 processResources {
 	inputs.property "version", project.version
 


### PR DESCRIPTION
IntelliJ was somehow picking up the `item-repo` repository inside of the config folder as a valid repository, and I'm hoping this fixes that.

I don't know if this actually works, I had removed the `item-repo` from `.idea/vcs.xml` manually before I thought of this. But even if it doesn't, I don't think it'd hurt anybody either.