### PR TITLE
Fix discord announcement not including minecraft version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ publishMods {
 	discord {
 		webhookUrl = System.getenv("DISCORD_WEBHOOK")
 		username = "Changelog"
-		content = changelog.map { "<@&1134565945482948638>\n## Skyblocker v${mod_version}\n" + it}
+		content = changelog.map { "<@&1134565945482948638>\n## ${displayName}\n" + it}
 	}
 }
 


### PR DESCRIPTION
The announcement in discord doesn't include the mc version. This adds that.

Not tested because I don't know how to test this.