### PR TITLE
Remove duplicate translation key

### DIFF
--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -228,7 +228,6 @@
   "skyblocker.config.general.itemTooltip.avg.BOTH": "Both",
   "skyblocker.config.general.itemTooltip.avg.ONE_DAY": "1 day price",
   "skyblocker.config.general.itemTooltip.avg.THREE_DAY": "3 day price",
-  "skyblocker.config.general.itemTooltip.avg": "Average Type",
   "skyblocker.config.general.itemTooltip.dungeonQuality": "Dungeon Quality",
   "skyblocker.config.general.itemTooltip.dungeonQuality.@Tooltip": "Displays quality and tier of dungeon drops from mobs.\n\n\nReminder:\nTier 1-3 dropped from F1-F3\nTier 4-7 dropped from F4-F7 or M1-M4\nTier 8-10 are dropped only from M5-M7",
   "skyblocker.config.general.itemTooltip.enableAccessoriesHelper": "Enable Accessories Helper",


### PR DESCRIPTION
`skyblocker.config.general.itemTooltip.avg` had 2 entries with the same value of `Average Type`, so I removed one.