### PR TITLE
Workaround "fake" transparent pixels

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinTextureMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinTextureMixin.java
@@ -1,5 +1,8 @@
 package de.hysky.skyblocker.mixins;
 
+import java.awt.Color;
+import java.util.Set;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -9,32 +12,62 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.item.PlayerHeadHashCache;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.texture.PlayerSkinTexture;
+import net.minecraft.util.math.ColorHelper;
 
 @Mixin(PlayerSkinTexture.class)
 public class PlayerSkinTextureMixin {
+	@Unique
+	private static final Set<String> STRIP_DE_FACTO_TRANSPARENT_PIXELS = Set.of(
+			"4f3b91b6aa7124f30ed4ad1b2bb012a82985a33640555e18e792f96af8f58ec6", /*Titanium Necklace*/
+			"49821410631186c6f3fbbae5f0ef5b947f475eb32027a8aad0a456512547c209", /*Titanium Cloak*/
+			"4162303bcdd770aebe7fd19fa26371390a7515140358548084361b5056cdc4e6" /*Titanium Belt*/);
+	@Unique
+	private static final float BRIGHTNESS_THRESHOLD = 0.1f;
+
 	@Shadow
 	@Final
 	private String url;
 
-	@Unique
-	private boolean isSkyblockSkinTexture;
-
 	@Inject(method = "remapTexture", at = @At("HEAD"))
-	private void skyblocker$determineSkinSource(CallbackInfoReturnable<NativeImage> cir) {
-		if (Utils.isOnSkyblock()) {
-			int skinHash = PlayerHeadHashCache.getSkinHash(this.url).hashCode();
-			this.isSkyblockSkinTexture = PlayerHeadHashCache.contains(skinHash);
+	private void skyblocker$determineSkinSource(NativeImage image, CallbackInfoReturnable<NativeImage> cir, @Share("isSkyblockSkinTexture") LocalBooleanRef isSkyblockSkinTexture) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.dontStripSkinAlphaValues) {
+			String skinTextureHash = PlayerHeadHashCache.getSkinHash(this.url);
+			int skinHash = skinTextureHash.hashCode();
+			isSkyblockSkinTexture.set(PlayerHeadHashCache.contains(skinHash));
+
+			//Hypixel had the grand idea of using black pixels in place of actual transparent pixels on the titanium equipment so here we go!
+			if (STRIP_DE_FACTO_TRANSPARENT_PIXELS.contains(skinTextureHash)) {
+				stripDeFactoTransparentPixels(image);
+			}
 		}
 	}
 
 	@WrapWithCondition(method = "remapTexture", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/texture/PlayerSkinTexture;stripAlpha(Lnet/minecraft/client/texture/NativeImage;IIII)V"))
-	private boolean skyblocker$dontStripAlphaValues(NativeImage image, int x1, int y1, int x2, int y2) {
-		return !(SkyblockerConfigManager.get().uiAndVisuals.dontStripSkinAlphaValues && this.isSkyblockSkinTexture);
+	private boolean skyblocker$dontStripAlphaValues(NativeImage image, int x1, int y1, int x2, int y2, @Share("isSkyblockSkinTexture") LocalBooleanRef isSkyblockSkinTexture) {
+		return !isSkyblockSkinTexture.get();
+	}
+
+	@Unique
+	private static void stripDeFactoTransparentPixels(NativeImage image) {
+		int height = image.getHeight();
+		int width = image.getWidth();
+
+		for (int x = 0; x < width; x++) {
+			for (int y = 0; y < height; y++) {
+				int color = image.getColor(x, y);
+				float[] hsb = Color.RGBtoHSB(ColorHelper.Abgr.getRed(color), ColorHelper.Abgr.getGreen(color), ColorHelper.Abgr.getBlue(color), null);
+
+				//Work around "fake" transparent pixels - Thanks Hypixel I totally appreciate this!
+				if (hsb[2] <= BRIGHTNESS_THRESHOLD) image.setColor(x, y, ColorHelper.Abgr.withAlpha(0x00, color & 0x00FFFFFF));
+			}
+		}
 	}
 }


### PR DESCRIPTION
As seen in the new titanium equipment for mining Hypixel has used different shades of black pixels in place of real transparent pixels. Why? I don't know, they sure do love consistency especially given that the other new mining equipment textures use real transparent pixels.