### PR TITLE
Fix dungeon secret widget spamming logs

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/DungeonSecretWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/DungeonSecretWidget.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.tabhud.widget;
 
+import de.hysky.skyblocker.skyblock.dungeon.DungeonScore;
 import de.hysky.skyblocker.skyblock.tabhud.util.Ico;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListMgr;
 import net.minecraft.text.MutableText;
@@ -11,7 +12,6 @@ import java.util.regex.Pattern;
 // this widget shows info about the secrets of the dungeon
 
 public class DungeonSecretWidget extends Widget {
-
     private static final MutableText TITLE = Text.literal("Discoveries").formatted(Formatting.DARK_PURPLE, Formatting.BOLD);
     private static final Pattern DISCOVERIES = Pattern.compile("Discoveries: (\\d+)");
 
@@ -21,7 +21,10 @@ public class DungeonSecretWidget extends Widget {
 
     @Override
     public void updateContent() {
-        if (PlayerListMgr.regexAt(31, DISCOVERIES) != null) {
+        if (!DungeonScore.isDungeonStarted()) {
+            this.addSimpleIcoText(Ico.CHEST, "Secrets:", Formatting.YELLOW, 30);
+            this.addSimpleIcoText(Ico.SKULL, "Crypts:", Formatting.YELLOW, 31);
+        } else if (PlayerListMgr.regexAt(31, DISCOVERIES) != null) {
             this.addSimpleIcoText(Ico.CHEST, "Secrets:", Formatting.YELLOW, 32);
             this.addSimpleIcoText(Ico.SKULL, "Crypts:", Formatting.YELLOW, 33);
         } else {


### PR DESCRIPTION
It couldn't match because the Discoveries row moves down by 1 when the dungeon starts and the indexes are set according to that. This PR adds indexes for when the dungeon hasn't started yet, therefore shutting up the error messages that are logged 20 times per second while tab is held.