### PR TITLE
Add raytracing to the egg finder to make it fairer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
 
 	// Apache Commons Math
 	include implementation("org.apache.commons:commons-math3:${project.commons_math_version}")
+
+	// Apache Commons Text
+	include implementation("org.apache.commons:commons-text:${project.commons_text_version}")
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,8 @@ repoparser_version = 1.5.0
 jgit_version = 6.9.0.202403050737-r
 ## Apache Commons Math (https://mvnrepository.com/artifact/org.apache.commons/commons-math3)
 commons_math_version = 3.6.1
+## Apache Commons Text (https://mvnrepository.com/artifact/org.apache.commons/commons-text)
+commons_text_version = 1.12.0
 
 # Mod Properties
 mod_version = 1.21.1

--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
@@ -25,7 +25,7 @@ import net.minecraft.text.ClickEvent;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,7 +212,6 @@ public class EggFinder {
 		}
 
 		@Override
-		@SuppressWarnings("deprecation") // It's either a new dependency or a deprecated method, and I'd rather use the deprecated method
 		public String toString() {
 			return WordUtils.capitalizeFully(this.name());
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
@@ -61,6 +61,7 @@ public class EggFinder {
 		WorldRenderEvents.AFTER_TRANSLUCENT.register(EggFinder::renderWaypoints);
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			if (!SkyblockerConfigManager.get().helpers.chocolateFactory.enableEggFinder || client.player == null) return;
+			if (!isLocationCorrect || SkyblockTime.skyblockSeason.get() != SkyblockTime.Season.SPRING) return;
 			for (EggType type : EggType.entries) {
 				Egg egg = type.egg;
 				if (egg != null && !egg.seen && client.player.canSee(egg.entity)) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
@@ -42,7 +42,14 @@ public class EggFinder {
 	private static final Logger logger = LoggerFactory.getLogger("Skyblocker Egg Finder");
 	//This is most likely unnecessary with the addition of the location change packet, but it works fine and might be doing something so might as well keep it
 	private static final LinkedList<ArmorStandEntity> armorStandQueue = new LinkedList<>();
+	/**
+	 * The locations that the egg finder should work while the player is in.
+	 */
 	private static final Location[] possibleLocations = {Location.CRIMSON_ISLE, Location.CRYSTAL_HOLLOWS, Location.DUNGEON_HUB, Location.DWARVEN_MINES, Location.HUB, Location.THE_END, Location.THE_PARK, Location.GOLD_MINE, Location.DEEP_CAVERNS, Location.SPIDERS_DEN, Location.THE_FARMING_ISLAND};
+	/**
+	 * Whether the player is in a location where the egg finder should work.
+	 * This is set to false upon world change and will be checked with the location change event afterward.
+	 */
 	private static boolean isLocationCorrect = false;
 
 	private EggFinder() {
@@ -182,10 +189,12 @@ public class EggFinder {
 		public final String texture;
 		/*
 			When a new egg spawns in the player's range, the order of packets/messages goes like this:
-			set_equipment -> new egg message -> set_entity_data
+			set_equipment → new egg message → set_entity_data
 			We have to set the egg to null to prevent the highlight from staying where it was before the new egg spawned,
-			and doing so causes the found message to get sent twice. This is the reason for the existence of this field, so that we can not send the 2nd message.
-			This doesn't fix the field being set twice, but that's not an issue anyway. It'd be much harder to fix the highlight issue mentioned above if it wasn't being set twice.
+			and doing so causes the found message to get sent twice.
+			This is the reason for the existence of this field, so that we don't send the 2nd message.
+			This doesn't fix the field being set twice, but that's not an issue anyway.
+			It'd be much harder to fix the highlight issue mentioned above if it wasn't being set twice.
 		 */
 		private long messageLastSent = 0;
 

--- a/src/main/java/de/hysky/skyblocker/utils/PosUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/PosUtils.java
@@ -25,4 +25,8 @@ public final class PosUtils {
     public static String getPosString(BlockPos blockPos) {
         return blockPos.getX() + "," + blockPos.getY() + "," + blockPos.getZ();
     }
+
+    public static String toSpaceSeparatedString(BlockPos blockPos) {
+        return blockPos.getX() + " " + blockPos.getY() + " " + blockPos.getZ();
+    }
 }

--- a/src/main/java/de/hysky/skyblocker/utils/SkyblockTime.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SkyblockTime.java
@@ -1,6 +1,8 @@
 package de.hysky.skyblocker.utils;
 
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,39 +15,77 @@ public class SkyblockTime {
 	public static final AtomicReference<Season> skyblockSeason = new AtomicReference<>(Season.SPRING);
 	public static final AtomicReference<Month> skyblockMonth = new AtomicReference<>(Month.EARLY_SPRING);
 	public static final AtomicInteger skyblockDay = new AtomicInteger(0);
+	public static final AtomicInteger skyblockHour = new AtomicInteger(0);
 	private static final Logger LOGGER = LoggerFactory.getLogger("Skyblocker Time");
+
+	//All time lengths are in milliseconds
+	public static final double HOUR_LENGTH = 50000;
+	public static final double DAY_LENGTH = HOUR_LENGTH * 24;
+	public static final double MONTH_LENGTH = DAY_LENGTH * 31;
+	public static final double SEASON_LENGTH = MONTH_LENGTH * 3;
+	public static final double YEAR_LENGTH = SEASON_LENGTH * 4;
 
 	private SkyblockTime() {
 	}
 
+	/**
+	 * Updates the time and schedules a cyclic scheduler which will update the time every hour, to be run on the next hour change.
+	 */
 	public static void init() {
 		updateTime();
-		//ScheduleCyclic already runs the task upon scheduling, so there's no need to call updateTime() here
-		Scheduler.INSTANCE.schedule(() -> Scheduler.INSTANCE.scheduleCyclic(SkyblockTime::updateTime, 1200 * 20), (int) (1200000 - (getSkyblockMillis() % 1200000)) / 50);
+		//scheduleCyclic already runs the task upon scheduling, so there's no need to call updateTime() in the lambda as well
+		//The division by 50 is to convert the time to ticks
+		Scheduler.INSTANCE.schedule(() -> Scheduler.INSTANCE.scheduleCyclic(SkyblockTime::updateTime, (int) (HOUR_LENGTH / 50)), (int) (HOUR_LENGTH - (getSkyblockMillis() % HOUR_LENGTH)) / 50);
 	}
 
 	public static long getSkyblockMillis() {
 		return System.currentTimeMillis() - SKYBLOCK_EPOCH;
 	}
 
-	private static int getSkyblockYear() {
-		return (int) (Math.floor(getSkyblockMillis() / 446400000.0) + 1);
+	private static int calculateSkyblockYear() {
+		return (int) (Math.floor(getSkyblockMillis() / YEAR_LENGTH) + 1);
 	}
 
-	private static int getSkyblockMonth() {
-		return (int) (Math.floor(getSkyblockMillis() / 37200000.0) % 12);
+	private static int calculateSkyblockMonth() {
+		return (int) (Math.floor(getSkyblockMillis() / MONTH_LENGTH) % 12);
 	}
 
-	private static int getSkyblockDay() {
-		return (int) (Math.floor(getSkyblockMillis() / 1200000.0) % 31 + 1);
+	private static int calculateSkyblockDay() {
+		return (int) (Math.floor(getSkyblockMillis() / DAY_LENGTH) % 31 + 1);
 	}
 
+	private static int calculateSkyblockHour() {
+		return (int) (Math.floor(getSkyblockMillis() / HOUR_LENGTH) % 24);
+	}
+
+	//This could probably be compacted by abstracting the logic into a method that takes a Supplier and a Consumer, etc. but there's really no need
 	private static void updateTime() {
-		skyblockYear.set(getSkyblockYear());
-		skyblockSeason.set(Season.values()[getSkyblockMonth() / 3]);
-		skyblockMonth.set(Month.values()[getSkyblockMonth()]);
-		skyblockDay.set(getSkyblockDay());
-		LOGGER.info("[Skyblocker Time] Skyblock time updated to Year {}, Season {}, Month {}, Day {}", skyblockYear.get(), skyblockSeason.get(), skyblockMonth.get(), skyblockDay.get());
+		int year = calculateSkyblockYear();
+		if (skyblockYear.get() != year) {
+			skyblockYear.set(year);
+			YEAR_CHANGE.invoker().onYearChange(year);
+		}
+		Season season = Season.values()[calculateSkyblockMonth() / 3];
+		if (skyblockSeason.get() != season) {
+			skyblockSeason.set(season);
+			SEASON_CHANGE.invoker().onSeasonChange(season);
+		}
+		Month month = Month.values()[calculateSkyblockMonth()];
+		if (skyblockMonth.get() != month) {
+			skyblockMonth.set(month);
+			MONTH_CHANGE.invoker().onMonthChange(month);
+		}
+		int day = calculateSkyblockDay();
+		if (skyblockDay.get() != day) {
+			skyblockDay.set(day);
+			DAY_CHANGE.invoker().onDayChange(day);
+		}
+		int hour = calculateSkyblockHour();
+		if (skyblockHour.get() != hour) {
+			skyblockHour.set(hour);
+			HOUR_CHANGE.invoker().onHourChange(hour);
+		}
+		LOGGER.info("[Skyblocker Time] Skyblock time updated to Year {}, Season {}, Month {}, Day {}, Hour {}", year, season, month, day, hour);
 	}
 
 	public enum Season {
@@ -58,4 +98,54 @@ public class SkyblockTime {
 		EARLY_FALL, FALL, LATE_FALL,
 		EARLY_WINTER, WINTER, LATE_WINTER
 	}
+
+	public interface OnHourChange {
+		void onHourChange(int hour);
+	}
+
+	public interface OnDayChange {
+		void onDayChange(int day);
+	}
+
+	public interface OnMonthChange {
+		void onMonthChange(Month month);
+	}
+
+	public interface OnSeasonChange {
+		void onSeasonChange(Season season);
+	}
+
+	public interface OnYearChange {
+		void onYearChange(int year);
+	}
+
+	public static final Event<OnHourChange> HOUR_CHANGE = EventFactory.createArrayBacked(OnHourChange.class, listeners -> hour -> {
+		for (OnHourChange listener : listeners) {
+			listener.onHourChange(hour);
+		}
+	});
+
+	public static final Event<OnDayChange> DAY_CHANGE = EventFactory.createArrayBacked(OnDayChange.class, listeners -> day -> {
+		for (OnDayChange listener : listeners) {
+			listener.onDayChange(day);
+		}
+	});
+
+	public static final Event<OnMonthChange> MONTH_CHANGE = EventFactory.createArrayBacked(OnMonthChange.class, listeners -> month -> {
+		for (OnMonthChange listener : listeners) {
+			listener.onMonthChange(month);
+		}
+	});
+
+	public static final Event<OnSeasonChange> SEASON_CHANGE = EventFactory.createArrayBacked(OnSeasonChange.class, listeners -> season -> {
+		for (OnSeasonChange listener : listeners) {
+			listener.onSeasonChange(season);
+		}
+	});
+
+	public static final Event<OnYearChange> YEAR_CHANGE = EventFactory.createArrayBacked(OnYearChange.class, listeners -> year -> {
+		for (OnYearChange listener : listeners) {
+			listener.onYearChange(year);
+		}
+	});
 }

--- a/src/main/java/de/hysky/skyblocker/utils/SkyblockTime.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SkyblockTime.java
@@ -85,6 +85,7 @@ public class SkyblockTime {
 			skyblockHour.set(hour);
 			HOUR_CHANGE.invoker().onHourChange(hour);
 		}
+		TIME_UPDATE.invoker().onTimeUpdate(year, season, month, day, hour);
 		LOGGER.info("[Skyblocker Time] Skyblock time updated to Year {}, Season {}, Month {}, Day {}, Hour {}", year, season, month, day, hour);
 	}
 
@@ -119,6 +120,10 @@ public class SkyblockTime {
 		void onYearChange(int year);
 	}
 
+	public interface OnTimeUpdate {
+		void onTimeUpdate(int year, Season season, Month month, int day, int hour);
+	}
+
 	public static final Event<OnHourChange> HOUR_CHANGE = EventFactory.createArrayBacked(OnHourChange.class, listeners -> hour -> {
 		for (OnHourChange listener : listeners) {
 			listener.onHourChange(hour);
@@ -146,6 +151,12 @@ public class SkyblockTime {
 	public static final Event<OnYearChange> YEAR_CHANGE = EventFactory.createArrayBacked(OnYearChange.class, listeners -> year -> {
 		for (OnYearChange listener : listeners) {
 			listener.onYearChange(year);
+		}
+	});
+
+	public static final Event<OnTimeUpdate> TIME_UPDATE = EventFactory.createArrayBacked(OnTimeUpdate.class, listeners -> (year, season, month, day, hour) -> {
+		for (OnTimeUpdate listener : listeners) {
+			listener.onTimeUpdate(year, season, month, day, hour);
 		}
 	});
 }

--- a/src/main/java/de/hysky/skyblocker/utils/SkyblockTime.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SkyblockTime.java
@@ -25,6 +25,37 @@ public class SkyblockTime {
 	public static final double SEASON_LENGTH = MONTH_LENGTH * 3;
 	public static final double YEAR_LENGTH = SEASON_LENGTH * 4;
 
+	public static final Event<OnHourChange> HOUR_CHANGE = EventFactory.createArrayBacked(OnHourChange.class, listeners -> hour -> {
+		for (OnHourChange listener : listeners) {
+			listener.onHourChange(hour);
+		}
+	});
+	public static final Event<OnDayChange> DAY_CHANGE = EventFactory.createArrayBacked(OnDayChange.class, listeners -> day -> {
+		for (OnDayChange listener : listeners) {
+			listener.onDayChange(day);
+		}
+	});
+	public static final Event<OnMonthChange> MONTH_CHANGE = EventFactory.createArrayBacked(OnMonthChange.class, listeners -> month -> {
+		for (OnMonthChange listener : listeners) {
+			listener.onMonthChange(month);
+		}
+	});
+	public static final Event<OnSeasonChange> SEASON_CHANGE = EventFactory.createArrayBacked(OnSeasonChange.class, listeners -> season -> {
+		for (OnSeasonChange listener : listeners) {
+			listener.onSeasonChange(season);
+		}
+	});
+	public static final Event<OnYearChange> YEAR_CHANGE = EventFactory.createArrayBacked(OnYearChange.class, listeners -> year -> {
+		for (OnYearChange listener : listeners) {
+			listener.onYearChange(year);
+		}
+	});
+	public static final Event<OnTimeUpdate> TIME_UPDATE = EventFactory.createArrayBacked(OnTimeUpdate.class, listeners -> (year, season, month, day, hour) -> {
+		for (OnTimeUpdate listener : listeners) {
+			listener.onTimeUpdate(year, season, month, day, hour);
+		}
+	});
+
 	private SkyblockTime() {
 	}
 
@@ -123,40 +154,4 @@ public class SkyblockTime {
 	public interface OnTimeUpdate {
 		void onTimeUpdate(int year, Season season, Month month, int day, int hour);
 	}
-
-	public static final Event<OnHourChange> HOUR_CHANGE = EventFactory.createArrayBacked(OnHourChange.class, listeners -> hour -> {
-		for (OnHourChange listener : listeners) {
-			listener.onHourChange(hour);
-		}
-	});
-
-	public static final Event<OnDayChange> DAY_CHANGE = EventFactory.createArrayBacked(OnDayChange.class, listeners -> day -> {
-		for (OnDayChange listener : listeners) {
-			listener.onDayChange(day);
-		}
-	});
-
-	public static final Event<OnMonthChange> MONTH_CHANGE = EventFactory.createArrayBacked(OnMonthChange.class, listeners -> month -> {
-		for (OnMonthChange listener : listeners) {
-			listener.onMonthChange(month);
-		}
-	});
-
-	public static final Event<OnSeasonChange> SEASON_CHANGE = EventFactory.createArrayBacked(OnSeasonChange.class, listeners -> season -> {
-		for (OnSeasonChange listener : listeners) {
-			listener.onSeasonChange(season);
-		}
-	});
-
-	public static final Event<OnYearChange> YEAR_CHANGE = EventFactory.createArrayBacked(OnYearChange.class, listeners -> year -> {
-		for (OnYearChange listener : listeners) {
-			listener.onYearChange(year);
-		}
-	});
-
-	public static final Event<OnTimeUpdate> TIME_UPDATE = EventFactory.createArrayBacked(OnTimeUpdate.class, listeners -> (year, season, month, day, hour) -> {
-		for (OnTimeUpdate listener : listeners) {
-			listener.onTimeUpdate(year, season, month, day, hour);
-		}
-	});
 }


### PR DESCRIPTION
I'm honestly not sure how to explain the changes. Might be better to read commits.
Fixes #832 by adding ray tracing every tick. Also has better logic for waypoints and chat messages, now it doesn't highlight eggs/send messages when the egg was already found in another island, and this state is reset when the egg's reset hour happens, which is at 7, 14, 21 (7am, 2pm, 9 pm)

Also cleans up and improves `SkyblockTime`. Now it includes hour and refreshes every 50 secs (a skyblock hour). There are also events for when the time unit changes value.