### PR TITLE
Fix inconsistency with Hypixel's inconsistencies

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/hud/HudPowderWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/hud/HudPowderWidget.java
@@ -125,7 +125,7 @@ public class HudPowderWidget extends Widget {
         String glacitePowderString = formatPowderString(glacitePowder, glacitePowderDiff);
 
         this.addSimpleIcoText(Ico.MITHRIL, "Mithril: ", Formatting.DARK_GREEN, mithrilPowderString);
-        this.addSimpleIcoText(Ico.AMETHYST_SHARD, "Gemstone: ", Formatting.DARK_PURPLE, gemstonePowderString);
+        this.addSimpleIcoText(Ico.AMETHYST_SHARD, "Gemstone: ", Formatting.LIGHT_PURPLE, gemstonePowderString);
         this.addSimpleIcoText(Ico.BLUE_ICE, "Glacite: ", Formatting.AQUA, glacitePowderString);
     }
 


### PR DESCRIPTION
Dwarven Mines are colored dark green.
Mithril powder is colored dark green.

Glacite tunnels is colored aqua.
Glacite powder is colored aqua.

Crystal hollows are colored dark purple.
Gemstone powder is colored light purple.

This pull request fixes the color of the gemstone powder being inconsistent with the color used in-game, light purple, despite that color in itself being inconsistent. But it is consistently inconsistent in the fact that the powder always uses that color, even though the location doesn't. _Whew_, that was a tongue twister.

**TLDR; This pull request makes gemstone powder color on powder widget match the in-game color.**