### PR TITLE
Option to increase fog radius when in the Crimson Isles

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/CrimsonIsleCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/CrimsonIsleCategory.java
@@ -143,6 +143,16 @@ public class CrimsonIsleCategory {
 								.build())
 						.build())
 
+				// Extend nether fog
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.crimsonIsle.extendNetherFog"))
+						.description(OptionDescription.of(Text.translatable("skyblocker.config.crimsonIsle.extendNetherFog.@Tooltip")))
+						.binding(config.crimsonIsle.extendNetherFog,
+								() -> config.crimsonIsle.extendNetherFog,
+								newValue -> config.crimsonIsle.extendNetherFog = newValue)
+						.controller(ConfigUtils::createBooleanController)
+						.build())
+
 				.build();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/config/configs/CrimsonIsleConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/CrimsonIsleConfig.java
@@ -10,6 +10,9 @@ public class CrimsonIsleConfig {
     @SerialEntry
     public Dojo dojo = new Dojo();
 
+    @SerialEntry
+    public boolean extendNetherFog = true;
+
 
     public static class Kuudra {
         @SerialEntry

--- a/src/main/java/de/hysky/skyblocker/mixins/BackgroundRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/BackgroundRendererMixin.java
@@ -1,0 +1,45 @@
+package de.hysky.skyblocker.mixins;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.CrimsonIsleConfig;
+import de.hysky.skyblocker.utils.Utils;
+import net.minecraft.block.enums.CameraSubmersionType;
+import net.minecraft.client.render.BackgroundRenderer;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.FogShape;
+import net.minecraft.util.math.MathHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BackgroundRenderer.class)
+public abstract class BackgroundRendererMixin {
+
+    /**
+     * Moves fog farther away from the player when in the crimson isles.
+     * This sets it to be the same distance as what you would see in the overworld (every other skyblock island)
+     */
+    @Inject(method = "applyFog", at = @At("RETURN"))
+    private static void applyFogModifyDistance(Camera camera, BackgroundRenderer.FogType fogType, float viewDistance, boolean thickFog, float tickDelta, CallbackInfo info) {
+        final CameraSubmersionType cameraSubmersionType = camera.getSubmersionType();
+        CrimsonIsleConfig config = SkyblockerConfigManager.get().crimsonIsle;
+
+        if (Utils.isOnSkyblock()
+                && config.extendNetherFog
+                && cameraSubmersionType == CameraSubmersionType.NONE && thickFog) {
+
+            float start;
+            if (fogType == BackgroundRenderer.FogType.FOG_SKY) {
+                start = 0.0f;
+            } else {
+                start = viewDistance - MathHelper.clamp(viewDistance / 10.0f, 4.0f, 64.0f);
+            }
+
+            RenderSystem.setShaderFogStart(start);
+            RenderSystem.setShaderFogEnd(viewDistance);
+            RenderSystem.setShaderFogShape(FogShape.CYLINDER);
+        }
+    }
+}

--- a/src/main/java/de/hysky/skyblocker/mixins/BackgroundRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/BackgroundRendererMixin.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.mixins;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.CrimsonIsleConfig;
@@ -8,7 +9,6 @@ import net.minecraft.block.enums.CameraSubmersionType;
 import net.minecraft.client.render.BackgroundRenderer;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.FogShape;
-import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,19 +22,16 @@ public abstract class BackgroundRendererMixin {
      * This sets it to be the same distance as what you would see in the overworld (every other skyblock island)
      */
     @Inject(method = "applyFog", at = @At("RETURN"))
-    private static void applyFogModifyDistance(Camera camera, BackgroundRenderer.FogType fogType, float viewDistance, boolean thickFog, float tickDelta, CallbackInfo info) {
+    private static void applyFogModifyDistance(CallbackInfo ci, @Local(argsOnly = true) Camera camera, @Local(argsOnly = true) BackgroundRenderer.FogType fogType, @Local(argsOnly = true, ordinal = 0) float viewDistance, @Local(argsOnly = true) boolean thickFog) {
         final CameraSubmersionType cameraSubmersionType = camera.getSubmersionType();
         CrimsonIsleConfig config = SkyblockerConfigManager.get().crimsonIsle;
 
-        if (Utils.isOnSkyblock()
-                && config.extendNetherFog
-                && cameraSubmersionType == CameraSubmersionType.NONE && thickFog) {
-
+        if (Utils.isOnSkyblock() && config.extendNetherFog && cameraSubmersionType == CameraSubmersionType.NONE && thickFog) {
             float start;
             if (fogType == BackgroundRenderer.FogType.FOG_SKY) {
                 start = 0.0f;
             } else {
-                start = viewDistance - MathHelper.clamp(viewDistance / 10.0f, 4.0f, 64.0f);
+                start = viewDistance - Math.clamp(viewDistance / 10.0f, 4.0f, 64.0f);
             }
 
             RenderSystem.setShaderFogStart(start);

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -29,6 +29,9 @@
 
   "skyblocker.config.crimsonIsle": "Crimson Isle",
 
+  "skyblocker.config.crimsonIsle.extendNetherFog": "Extend Nether Fog",
+  "skyblocker.config.crimsonIsle.extendNetherFog.@Tooltip": "When in the Crimson Isles, prevents fog from appearing closer to the player as it does in vanilla nether biomes",
+
   "skyblocker.config.crimsonIsle.kuudra": "Kuudra",
 
   "skyblocker.config.crimsonIsle.kuudra.arrowPoisonThreshold": "Arrow Poison Warning Threshold",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -30,7 +30,7 @@
   "skyblocker.config.crimsonIsle": "Crimson Isle",
 
   "skyblocker.config.crimsonIsle.extendNetherFog": "Extend Nether Fog",
-  "skyblocker.config.crimsonIsle.extendNetherFog.@Tooltip": "When in the Crimson Isles, prevents fog from appearing closer to the player as it does in vanilla nether biomes",
+  "skyblocker.config.crimsonIsle.extendNetherFog.@Tooltip": "When in the Crimson Isle, prevents fog from appearing closer to the player as it does in vanilla nether biomes.",
 
   "skyblocker.config.crimsonIsle.kuudra": "Kuudra",
 

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_21",
   "client": [
     "AbstractInventoryScreenMixin",
+    "BackgroundRendererMixin",
     "BatEntityMixin",
     "ClientPlayerEntityMixin",
     "ClientPlayNetworkHandlerMixin",


### PR DESCRIPTION
## Nether Fog Decrease when in Crimson Isles

This is something that has bothered me in the past, so it would be cool to be able to change this in Skyblocker

When on the crimson isles island on Skyblock, the fog will be pushed outward to appear at the same distance as it would in the overworld (every other island).

### Screenshots (8 chunk render distance on both images)
Without Fog Extension
![2024-07-20_12 34 59](https://github.com/user-attachments/assets/d5e05f48-309c-43de-bdb3-02cba0cb426e)

With Fog Extension
![2024-07-20_12 36 25](https://github.com/user-attachments/assets/189d6265-43c8-4fc5-b507-ea4eef943579)
