### PR TITLE
Make ChocolateFactorySolver a singleton to fix tooltip not working

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/ChocolateFactorySolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/ChocolateFactorySolver.java
@@ -73,7 +73,9 @@ public class ChocolateFactorySolver extends SimpleContainerSolver implements Too
 		DECIMAL_FORMAT.setMaximumFractionDigits(1);
 	}
 
-	public ChocolateFactorySolver() {
+	public static final ChocolateFactorySolver INSTANCE = new ChocolateFactorySolver();
+
+	private ChocolateFactorySolver() {
 		super("^Chocolate Factory$"); //There are multiple screens that fit the pattern `^Chocolate Factory`, so the $ is required
 		ClientTickEvents.START_CLIENT_TICK.register(ChocolateFactorySolver::onTick);
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
@@ -24,7 +24,7 @@ public class TooltipManager {
 	private static final TooltipAdder[] adders = new TooltipAdder[]{
 			new LineSmoothener(), // Applies before anything else
 			new SupercraftReminder(),
-			new ChocolateFactorySolver(),
+			ChocolateFactorySolver.INSTANCE,
 			new ReorderHelper(),
 			new NpcPriceTooltip(1),
 			new BazaarPriceTooltip(2),

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
@@ -56,7 +56,7 @@ public class ContainerSolverManager {
 				UltrasequencerSolver.INSTANCE,
 				new NewYearCakeBagHelper(),
 				NewYearCakesHelper.INSTANCE,
-				new ChocolateFactorySolver(),
+				ChocolateFactorySolver.INSTANCE,
 				new ReorderHelper()
 		};
 	}


### PR DESCRIPTION
There were 2 different instances of the class being created for different managers, which broke cf tooltips since the variables from one container matcher implementation are needed on the other one. This PR makes CF a singleton and passes the same instance to both managers, therefore fixing the issue.