### PR TITLE
Skyblock XP Messages

### DIFF
--- a/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
+++ b/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
@@ -9,6 +9,7 @@ import de.hysky.skyblocker.skyblock.*;
 import de.hysky.skyblocker.skyblock.calculators.CalculatorCommand;
 import de.hysky.skyblocker.skyblock.chat.ChatRuleAnnouncementScreen;
 import de.hysky.skyblocker.skyblock.chat.ChatRulesHandler;
+import de.hysky.skyblocker.skyblock.chat.SkyblockXpMessages;
 import de.hysky.skyblocker.skyblock.chocolatefactory.EggFinder;
 import de.hysky.skyblocker.skyblock.chocolatefactory.TimeTowerReminder;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
@@ -138,6 +139,7 @@ public class SkyblockerMod implements ClientModInitializer {
         Shortcuts.init();
         ChatRulesHandler.init();
         ChatRuleAnnouncementScreen.init();
+        SkyblockXpMessages.init();
         CalculatorCommand.init();
         DiscordRPCManager.init();
         LividColor.init();

--- a/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
@@ -14,6 +14,14 @@ public class ChatCategory {
     public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
         return ConfigCategory.createBuilder()
                 .name(Text.translatable("skyblocker.config.chat"))
+                .option(Option.<Boolean>createBuilder()
+                        .name(Text.translatable("skyblocker.config.chat.skyblockXpMessages"))
+                        .description(OptionDescription.of(Text.translatable("skyblocker.config.chat.skyblockXpMessages.@Tooltip")))
+                        .binding(defaults.chat.skyblockXpMessages,
+                                () -> config.chat.skyblockXpMessages,
+                                newValue -> config.chat.skyblockXpMessages = newValue)
+                        .controller(ConfigUtils::createBooleanController)
+                        .build())
 
                 //Uncategorized Options
                 .group(OptionGroup.createBuilder()

--- a/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
@@ -5,6 +5,9 @@ import dev.isxander.yacl3.config.v2.api.SerialEntry;
 
 public class ChatConfig {
     @SerialEntry
+    public boolean skyblockXpMessages = true;
+
+    @SerialEntry
     public ChatFilterResult hideAbility = ChatFilterResult.PASS;
 
     @SerialEntry
@@ -48,9 +51,6 @@ public class ChatConfig {
 
     @SerialEntry
     public ChatFilterResult hideDicer = ChatFilterResult.PASS;
-
-    @SerialEntry
-    public boolean skyblockXpMessages = true;
 
     @SerialEntry
     public ChatRuleConfig chatRuleConfig = new ChatRuleConfig();

--- a/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
@@ -50,6 +50,9 @@ public class ChatConfig {
     public ChatFilterResult hideDicer = ChatFilterResult.PASS;
 
     @SerialEntry
+    public boolean skyblockXpMessages = true;
+
+    @SerialEntry
     public ChatRuleConfig chatRuleConfig = new ChatRuleConfig();
 
     public static class ChatRuleConfig {

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/SkyblockXpMessages.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/SkyblockXpMessages.java
@@ -19,7 +19,6 @@ public class SkyblockXpMessages {
 
 	public static void init() {
 		ClientReceiveMessageEvents.GAME.register(SkyblockXpMessages::onMessage);
-		Scheduler.INSTANCE.scheduleCyclic(RECENT_MESSAGES::clear, 20 * 60);
 	}
 
 	private static void onMessage(Text text, boolean overlay) {
@@ -31,6 +30,7 @@ public class SkyblockXpMessages {
 			if (matcher.find() && !RECENT_MESSAGES.contains(hash)) {
 				CLIENT.player.sendMessage(Constants.PREFIX.get().append(matcher.group()));
 				RECENT_MESSAGES.add(hash);
+				Scheduler.INSTANCE.schedule(() -> RECENT_MESSAGES.remove(hash), 20 * 10);
 			}
 		}
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/SkyblockXpMessages.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/SkyblockXpMessages.java
@@ -1,0 +1,37 @@
+package de.hysky.skyblocker.skyblock.chat;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.Constants;
+import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.scheduler.Scheduler;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.Text;
+
+public class SkyblockXpMessages {
+	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
+	private static final Pattern SKYBLOCK_XP_PATTERN = Pattern.compile("§b\\+\\d+ SkyBlock XP §7\\([^()]+§7\\)§b \\(\\d+\\/\\d+\\)");
+	private static final IntOpenHashSet RECENT_MESSAGES = new IntOpenHashSet();
+
+	public static void init() {
+		ClientReceiveMessageEvents.GAME.register(SkyblockXpMessages::onMessage);
+		Scheduler.INSTANCE.scheduleCyclic(RECENT_MESSAGES::clear, 20 * 60);
+	}
+
+	private static void onMessage(Text text, boolean overlay) {
+		if (Utils.isOnSkyblock() && overlay && SkyblockerConfigManager.get().chat.skyblockXpMessages) {
+			String message = text.getString();
+			Matcher matcher = SKYBLOCK_XP_PATTERN.matcher(message);
+			int hash = message.hashCode();
+
+			if (matcher.find() && !RECENT_MESSAGES.contains(hash)) {
+				CLIENT.player.sendMessage(Constants.PREFIX.get().append(matcher.group()));
+				RECENT_MESSAGES.add(hash);
+			}
+		}
+	}
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -435,6 +435,9 @@
   "skyblocker.config.chat.filter.hideToggleSkyMall": "Hide Toggle Sky Mall Messages",
   "skyblocker.config.chat.filter.hideToggleSkyMall.@Tooltip": "Hides those pesky messages telling you to disable the Sky Mall HOTM perk when you want it enabled!",
 
+  "skyblocker.config.chat.skyblockXpMessages": "SkyBlock XP Messages",
+  "skyblocker.config.chat.skyblockXpMessages.@Tooltip": "Notifies you in the chat when you gain SkyBlock XP.",
+
   "skyblocker.config.eventNotifications": "Event Notifications",
 
   "skyblocker.config.eventNotifications.criterion": "Notification Criterion",


### PR DESCRIPTION
When you get Skyblock XP the message in the action bar is also put into the chat, pretty useful since the action bar text goes away quickly and people might not see it.

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/df12fe9e-7bf8-4180-b4de-6912243eda8e">
