### PR TITLE
[Slayer Helpers] Slayer Highlights, Blaze Helpers and Glow Caching

### DIFF
--- a/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
+++ b/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
@@ -28,6 +28,7 @@ import de.hysky.skyblocker.skyblock.end.BeaconHighlighter;
 import de.hysky.skyblocker.skyblock.end.EnderNodes;
 import de.hysky.skyblocker.skyblock.end.TheEnd;
 import de.hysky.skyblocker.skyblock.entity.MobBoundingBoxes;
+import de.hysky.skyblocker.skyblock.entity.MobGlow;
 import de.hysky.skyblocker.skyblock.events.EventNotifications;
 import de.hysky.skyblocker.skyblock.fancybars.FancyStatusBars;
 import de.hysky.skyblocker.skyblock.garden.FarmingHud;
@@ -45,6 +46,7 @@ import de.hysky.skyblocker.skyblock.profileviewer.ProfileViewerScreen;
 import de.hysky.skyblocker.skyblock.rift.TheRift;
 import de.hysky.skyblocker.skyblock.searchoverlay.SearchOverManager;
 import de.hysky.skyblocker.skyblock.shortcut.Shortcuts;
+import de.hysky.skyblocker.skyblock.slayers.SlayerEntitiesGlow;
 import de.hysky.skyblocker.skyblock.special.SpecialEffects;
 import de.hysky.skyblocker.skyblock.tabhud.TabHud;
 import de.hysky.skyblocker.skyblock.tabhud.screenbuilder.ScreenMaster;
@@ -202,6 +204,8 @@ public class SkyblockerMod implements ClientModInitializer {
         TooltipManager.init();
         SlotTextManager.init();
         BazaarHelper.init();
+        MobGlow.init();
+        SlayerEntitiesGlow.init();
 
         Scheduler.INSTANCE.scheduleCyclic(Utils::update, 20);
         Scheduler.INSTANCE.scheduleCyclic(DiscordRPCManager::updateDataAndPresence, 200);

--- a/src/main/java/de/hysky/skyblocker/config/categories/SlayersCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/SlayersCategory.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.config.categories;
 
 import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
+import de.hysky.skyblocker.config.configs.SlayersConfig;
 import dev.isxander.yacl3.api.ConfigCategory;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.OptionDescription;
@@ -16,6 +17,30 @@ public class SlayersCategory {
     public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
         return ConfigCategory.createBuilder()
                 .name(Text.translatable("skyblocker.config.slayer"))
+
+                .option(Option.<SlayersConfig.HighlightSlayerEntities>createBuilder()
+                        .name(Text.translatable("skyblocker.config.slayer.highlightMinis"))
+                        .description(OptionDescription.of(
+                                Text.translatable("skyblocker.config.slayer.highlightMinis.@Tooltip[0]"),
+                                Text.translatable("skyblocker.config.slayer.highlightMinis.@Tooltip[1]"),
+                                Text.translatable("skyblocker.config.slayer.highlightMinis.@Tooltip[2]")))
+                        .binding(defaults.slayers.highlightMinis,
+                                () -> config.slayers.highlightMinis,
+                                newValue -> config.slayers.highlightMinis = newValue)
+                        .controller(ConfigUtils::createEnumCyclingListController)
+                        .build())
+                .option(Option.<SlayersConfig.HighlightSlayerEntities>createBuilder()
+                        .name(Text.translatable("skyblocker.config.slayer.highlightBosses"))
+                        .description(OptionDescription.of(
+                                Text.translatable("skyblocker.config.slayer.highlightBosses.@Tooltip[0]"),
+                                Text.translatable("skyblocker.config.slayer.highlightBosses.@Tooltip[1]"),
+                                Text.translatable("skyblocker.config.slayer.highlightBosses.@Tooltip[2]"),
+                                Text.translatable("skyblocker.config.slayer.highlightBosses.@Tooltip[3]")))
+                        .binding(defaults.slayers.highlightBosses,
+                                () -> config.slayers.highlightBosses,
+                                newValue -> config.slayers.highlightBosses = newValue)
+                        .controller(ConfigUtils::createEnumCyclingListController)
+                        .build())
 
                 //Enderman Slayer
                 .group(OptionGroup.createBuilder()
@@ -135,6 +160,27 @@ public class SlayersCategory {
                                         () -> config.slayers.vampireSlayer.maniaUpdateFrequency,
                                         newValue -> config.slayers.vampireSlayer.maniaUpdateFrequency = newValue)
                                 .controller(opt -> IntegerSliderControllerBuilder.create(opt).range(1, 10).step(1))
+                                .build())
+                        .build())
+
+                .group(OptionGroup.createBuilder()
+                        .name(Text.translatable("skyblocker.config.slayer.blazeSlayer"))
+                        .collapsed(true)
+                        .option(Option.<SlayersConfig.BlazeSlayer.FirePillar>createBuilder()
+                                .name(Text.translatable("skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer"))
+                                .description(OptionDescription.of(Text.translatable("skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer.@Tooltip")))
+                                .binding(defaults.slayers.blazeSlayer.firePillarCountdown,
+                                        () -> config.slayers.blazeSlayer.firePillarCountdown,
+                                        newValue -> config.slayers.blazeSlayer.firePillarCountdown = newValue)
+                                .controller(ConfigUtils::createEnumCyclingListController)
+                                .build())
+                        .option(Option.<Boolean>createBuilder()
+                                .name(Text.translatable("skyblocker.config.slayer.blazeSlayer.attunementHighlights"))
+                                .description(OptionDescription.of(Text.translatable("skyblocker.config.slayer.blazeSlayer.attunementHighlights.@Tooltip")))
+                                .binding(defaults.slayers.blazeSlayer.attunementHighlights,
+                                        () -> config.slayers.blazeSlayer.attunementHighlights,
+                                        newValue -> config.slayers.blazeSlayer.attunementHighlights = newValue)
+                                .controller(ConfigUtils::createBooleanController)
                                 .build())
                         .build())
 

--- a/src/main/java/de/hysky/skyblocker/config/categories/SlayersCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/SlayersCategory.java
@@ -18,6 +18,7 @@ public class SlayersCategory {
         return ConfigCategory.createBuilder()
                 .name(Text.translatable("skyblocker.config.slayer"))
 
+                //General Slayers Options
                 .option(Option.<SlayersConfig.HighlightSlayerEntities>createBuilder()
                         .name(Text.translatable("skyblocker.config.slayer.highlightMinis"))
                         .description(OptionDescription.of(
@@ -163,6 +164,7 @@ public class SlayersCategory {
                                 .build())
                         .build())
 
+                //Blaze Slayer
                 .group(OptionGroup.createBuilder()
                         .name(Text.translatable("skyblocker.config.slayer.blazeSlayer"))
                         .collapsed(true)

--- a/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
@@ -17,10 +17,10 @@ public class SlayersConfig {
     public EndermanSlayer endermanSlayer = new EndermanSlayer();
 
     @SerialEntry
-    public BlazeSlayer blazeSlayer = new BlazeSlayer();
+    public VampireSlayer vampireSlayer = new VampireSlayer();
 
     @SerialEntry
-    public VampireSlayer vampireSlayer = new VampireSlayer();
+    public BlazeSlayer blazeSlayer = new BlazeSlayer();
 
     public static class EndermanSlayer {
         @SerialEntry

--- a/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
@@ -4,7 +4,20 @@ import dev.isxander.yacl3.config.v2.api.SerialEntry;
 
 public class SlayersConfig {
     @SerialEntry
+    public HighlightSlayerEntities highlightMinis = HighlightSlayerEntities.OFF;
+
+    @SerialEntry
+    public HighlightSlayerEntities highlightBosses = HighlightSlayerEntities.OFF;
+
+    public enum HighlightSlayerEntities {
+        OFF, GLOW, HITBOX
+    }
+
+    @SerialEntry
     public EndermanSlayer endermanSlayer = new EndermanSlayer();
+
+    @SerialEntry
+    public BlazeSlayer blazeSlayer = new BlazeSlayer();
 
     @SerialEntry
     public VampireSlayer vampireSlayer = new VampireSlayer();
@@ -18,6 +31,32 @@ public class SlayersConfig {
 
         @SerialEntry
         public boolean highlightNukekubiHeads = true;
+    }
+
+    public static class BlazeSlayer {
+        @SerialEntry
+        public FirePillar firePillarCountdown = FirePillar.SOUND_AND_VISUAL;
+
+        @SerialEntry
+        public Boolean attunementHighlights = true;
+
+        public enum FirePillar {
+            OFF("Off"),
+            VISUAL("Visual Indicator"),
+            SOUND_AND_VISUAL("Sound and Visual Indicator");
+
+            private final String description;
+
+            FirePillar(String description) {
+                this.description = description;
+            }
+
+            @Override
+            public String toString() {
+                return description;
+            }
+        }
+
     }
 
     public static class VampireSlayer {

--- a/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
@@ -33,32 +33,6 @@ public class SlayersConfig {
         public boolean highlightNukekubiHeads = true;
     }
 
-    public static class BlazeSlayer {
-        @SerialEntry
-        public FirePillar firePillarCountdown = FirePillar.SOUND_AND_VISUAL;
-
-        @SerialEntry
-        public Boolean attunementHighlights = true;
-
-        public enum FirePillar {
-            OFF("Off"),
-            VISUAL("Visual Indicator"),
-            SOUND_AND_VISUAL("Sound and Visual Indicator");
-
-            private final String description;
-
-            FirePillar(String description) {
-                this.description = description;
-            }
-
-            @Override
-            public String toString() {
-                return description;
-            }
-        }
-
-    }
-
     public static class VampireSlayer {
         @SerialEntry
         public boolean enableEffigyWaypoints = true;
@@ -95,5 +69,30 @@ public class SlayersConfig {
 
         @SerialEntry
         public int maniaUpdateFrequency = 5;
+    }
+
+    public static class BlazeSlayer {
+        @SerialEntry
+        public FirePillar firePillarCountdown = FirePillar.SOUND_AND_VISUAL;
+
+        @SerialEntry
+        public Boolean attunementHighlights = true;
+
+        public enum FirePillar {
+            OFF("Off"),
+            VISUAL("Visual Indicator"),
+            SOUND_AND_VISUAL("Sound and Visual Indicator");
+
+            private final String description;
+
+            FirePillar(String description) {
+                this.description = description;
+            }
+
+            @Override
+            public String toString() {
+                return description;
+            }
+        }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
@@ -3,16 +3,20 @@ package de.hysky.skyblocker.mixins;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.sugar.Local;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.SlayersConfig;
 import de.hysky.skyblocker.skyblock.CompactDamage;
 import de.hysky.skyblocker.skyblock.FishingHelper;
 import de.hysky.skyblocker.skyblock.chocolatefactory.EggFinder;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
+import de.hysky.skyblocker.skyblock.crimson.slayer.FirePillarAnnouncer;
 import de.hysky.skyblocker.skyblock.dungeon.DungeonScore;
 import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
 import de.hysky.skyblocker.skyblock.dwarven.WishingCompassSolver;
 import de.hysky.skyblocker.skyblock.end.BeaconHighlighter;
 import de.hysky.skyblocker.skyblock.end.EnderNodes;
 import de.hysky.skyblocker.skyblock.end.TheEnd;
+import de.hysky.skyblocker.skyblock.slayers.SlayerEntitiesGlow;
 import de.hysky.skyblocker.skyblock.waypoint.MythologicalRitual;
 import de.hysky.skyblocker.utils.SlayerUtils;
 import de.hysky.skyblocker.utils.Utils;
@@ -109,6 +113,7 @@ public abstract class ClientPlayNetworkHandlerMixin {
         if (packet.getStatus() == EntityStatuses.PLAY_DEATH_SOUND_OR_ADD_PROJECTILE_HIT_PARTICLES) {
             DungeonScore.handleEntityDeath(entity);
             TheEnd.onEntityDeath(entity);
+            SlayerEntitiesGlow.onEntityDeath(entity);
         }
         return entity;
     }
@@ -116,6 +121,13 @@ public abstract class ClientPlayNetworkHandlerMixin {
     @Inject(method = "onEntityTrackerUpdate", at = @At("TAIL"))
     private void skyblocker$onEntityTrackerUpdate(EntityTrackerUpdateS2CPacket packet, CallbackInfo ci, @Local Entity entity) {
         if (!(entity instanceof ArmorStandEntity armorStandEntity)) return;
+
+        if (SkyblockerConfigManager.get().slayers.highlightMinis == SlayersConfig.HighlightSlayerEntities.GLOW && SlayerEntitiesGlow.isSlayerMiniMob(armorStandEntity)
+                || SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW && SlayerEntitiesGlow.isSlayer(armorStandEntity)) {
+            SlayerEntitiesGlow.setSlayerMobGlow(armorStandEntity);
+        }
+
+        if (SkyblockerConfigManager.get().slayers.blazeSlayer.firePillarCountdown != SlayersConfig.BlazeSlayer.FirePillar.OFF) FirePillarAnnouncer.checkFirePillar(entity);
 
         EggFinder.checkIfEgg(armorStandEntity);
         try { //Prevent packet handling fails if something goes wrong so that entity trackers still update, just without compact damage numbers

--- a/src/main/java/de/hysky/skyblocker/mixins/WorldRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/WorldRendererMixin.java
@@ -1,6 +1,8 @@
 package de.hysky.skyblocker.mixins;
 
 import de.hysky.skyblocker.skyblock.dungeon.LividColor;
+import de.hysky.skyblocker.skyblock.slayers.SlayerEntitiesGlow;
+import net.minecraft.entity.decoration.ArmorStandEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -42,7 +44,10 @@ public class WorldRendererMixin {
 		boolean shouldShowBoundingBox = MobBoundingBoxes.shouldDrawMobBoundingBox(entity);
 
 		if (shouldShowBoundingBox) {
-			MobBoundingBoxes.submitBox2BeRendered(entity.getBoundingBox(), MobBoundingBoxes.getBoxColor(entity));
+			MobBoundingBoxes.submitBox2BeRendered(
+					entity instanceof ArmorStandEntity e ? SlayerEntitiesGlow.getSlayerMobBoundingBox(e) : entity.getBoundingBox(),
+					MobBoundingBoxes.getBoxColor(entity)
+			);
 		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/AttunementColors.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/AttunementColors.java
@@ -9,16 +9,16 @@ import java.awt.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class AttunementColours {
-    private static final Pattern COLOUR_PATTERN = Pattern.compile("ASHEN|SPIRIT|CRYSTAL|AURIC");
+public class AttunementColors {
+    private static final Pattern COLOR_PATTERN = Pattern.compile("ASHEN|SPIRIT|CRYSTAL|AURIC");
 
     /**
      * Fetches highlight colour based on the Inferno Demonlord, or its demons', Hellion Shield Attunement
      */
-    public static int getColour(LivingEntity e) {
+    public static int getColor(LivingEntity e) {
         if (!SkyblockerConfigManager.get().slayers.blazeSlayer.attunementHighlights) return 0xf57738;
         for (Entity entity : SlayerUtils.getEntityArmorStands(e)) {
-            Matcher matcher = COLOUR_PATTERN.matcher(entity.getDisplayName().getString());
+            Matcher matcher = COLOR_PATTERN.matcher(entity.getDisplayName().getString());
             if (matcher.find()) {
                 String matchedColour = matcher.group();
                 return switch (matchedColour) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/AttunementColours.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/AttunementColours.java
@@ -1,0 +1,35 @@
+package de.hysky.skyblocker.skyblock.crimson.slayer;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.SlayerUtils;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+
+import java.awt.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AttunementColours {
+    private static final Pattern COLOUR_PATTERN = Pattern.compile("ASHEN|SPIRIT|CRYSTAL|AURIC");
+
+    /**
+     * Fetches highlight colour based on the Inferno Demonlord, or its demons', Hellion Shield Attunement
+     */
+    public static int getColour(LivingEntity e) {
+        if (!SkyblockerConfigManager.get().slayers.blazeSlayer.attunementHighlights) return 0xf57738;
+        for (Entity entity : SlayerUtils.getEntityArmorStands(e)) {
+            Matcher matcher = COLOUR_PATTERN.matcher(entity.getDisplayName().getString());
+            if (matcher.find()) {
+                String matchedColour = matcher.group();
+                return switch (matchedColour) {
+                    case "ASHEN" -> Color.DARK_GRAY.getRGB();
+                    case "SPIRIT" -> Color.WHITE.getRGB();
+                    case "CRYSTAL" -> Color.CYAN.getRGB();
+                    case "AURIC" -> Color.YELLOW.getRGB();
+                    default -> Color.RED.getRGB();
+                };
+            }
+        }
+        return Color.RED.getRGB();
+    }
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/FirePillarAnnouncer.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/FirePillarAnnouncer.java
@@ -1,0 +1,60 @@
+package de.hysky.skyblocker.skyblock.crimson.slayer;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.SlayersConfig;
+import de.hysky.skyblocker.utils.SlayerUtils;
+import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.render.RenderHelper;
+import de.hysky.skyblocker.utils.render.title.Title;
+import de.hysky.skyblocker.utils.render.title.TitleContainer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.PlainTextContent;
+import net.minecraft.util.Formatting;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FirePillarAnnouncer {
+
+    private static final Pattern FIRE_PILLAR_PATTERN = Pattern.compile("(\\d+)s \\d+ hits");
+
+    /**
+     *  Checks if an entity is the fire pillar when it has been updated (i.e. name change). This triggers twice on
+     *  seven seconds remaining, so it's been reduced down to only announce the last 5 seconds until explosion.
+     * <p>
+     *  There's also not a great way to detect ownership of the fire pillar, so a crude range calculation is used to try and
+     *  prevent another player's FirePillar appearing on the HUD.
+     *
+     * @param entity The updated entity that is checked to be a fire pillar
+     */
+    public static void checkFirePillar(Entity entity) {
+        if (Utils.isInCrimson() && SlayerUtils.isInSlayer() && entity instanceof ArmorStandEntity) {
+
+            String entityName = entity.getName().getString();
+            Matcher matcher = FIRE_PILLAR_PATTERN.matcher(entityName);
+
+            if (matcher.matches()) {
+                int seconds = Integer.parseInt(matcher.group(1));
+                if (seconds > 5) return;
+
+                // There is an edge case where the slayer has entered demon phase and temporarily despawned with
+                //  an active fire pillar in play, So fallback to the player
+                Entity referenceEntity = SlayerUtils.getSlayerEntity();
+                if (!(referenceEntity != null ? referenceEntity : MinecraftClient.getInstance().player).getBlockPos().isWithinDistance(entity.getPos(), 24)) return;
+                announceFirePillarDetails(entityName);
+            }
+        }
+    }
+
+    private static void announceFirePillarDetails(String entityName) {
+        Title title = new Title(MutableText.of(new PlainTextContent.Literal(entityName)).formatted(Formatting.BOLD, Formatting.DARK_PURPLE));
+
+        if (SkyblockerConfigManager.get().slayers.blazeSlayer.firePillarCountdown == SlayersConfig.BlazeSlayer.FirePillar.SOUND_AND_VISUAL) {
+            RenderHelper.displayInTitleContainerAndPlaySound(title, 15);
+        } else {
+            TitleContainer.addTitle(title, 15);
+        }
+    }
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/FirePillarAnnouncer.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/FirePillarAnnouncer.java
@@ -42,7 +42,7 @@ public class FirePillarAnnouncer {
                 // There is an edge case where the slayer has entered demon phase and temporarily despawned with
                 //  an active fire pillar in play, So fallback to the player
                 Entity referenceEntity = SlayerUtils.getSlayerEntity();
-                if (!(referenceEntity != null ? referenceEntity : MinecraftClient.getInstance().player).getBlockPos().isWithinDistance(entity.getPos(), 24)) return;
+                if (!(referenceEntity != null ? referenceEntity : MinecraftClient.getInstance().player).getBlockPos().isWithinDistance(entity.getPos(), 22)) return;
                 announceFirePillarDetails(entityName);
             }
         }

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/FirePillarAnnouncer.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/slayer/FirePillarAnnouncer.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.PlainTextContent;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -49,7 +50,7 @@ public class FirePillarAnnouncer {
     }
 
     private static void announceFirePillarDetails(String entityName) {
-        Title title = new Title(MutableText.of(new PlainTextContent.Literal(entityName)).formatted(Formatting.BOLD, Formatting.DARK_PURPLE));
+        Title title = new Title(Text.literal(entityName).formatted(Formatting.BOLD, Formatting.DARK_PURPLE));
 
         if (SkyblockerConfigManager.get().slayers.blazeSlayer.firePillarCountdown == SlayersConfig.BlazeSlayer.FirePillar.SOUND_AND_VISUAL) {
             RenderHelper.displayInTitleContainerAndPlaySound(title, 15);

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobBoundingBoxes.java
@@ -1,7 +1,9 @@
 package de.hysky.skyblocker.skyblock.entity;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.SlayersConfig;
 import de.hysky.skyblocker.skyblock.dungeon.LividColor;
+import de.hysky.skyblocker.skyblock.slayers.SlayerEntitiesGlow;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.FrustumUtils;
 import de.hysky.skyblocker.utils.render.RenderHelper;
@@ -9,6 +11,7 @@ import de.hysky.skyblocker.utils.render.Renderable;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -38,6 +41,17 @@ public class MobBoundingBoxes {
 				// Regular Mobs
 				default -> SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes && MobGlow.isStarred(entity);
 			};
+		}
+
+		if (SkyblockerConfigManager.get().slayers.highlightMinis == SlayersConfig.HighlightSlayerEntities.HITBOX
+				&& entity instanceof ArmorStandEntity le && SlayerEntitiesGlow.isSlayerMiniMob(le)) {
+			return true;
+		}
+
+		if (SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.HITBOX
+				&& entity instanceof ArmorStandEntity le) {
+			return le.getDisplayName().getString().contains(MinecraftClient.getInstance().getSession().getUsername()) ||
+					entity.getDisplayName().getString().contains("Ⓣ") || entity.getDisplayName().getString().contains("Ⓐ");
 		}
 
 		return false;

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -5,7 +5,7 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.SlayersConfig;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
 import de.hysky.skyblocker.skyblock.crimson.kuudra.Kuudra;
-import de.hysky.skyblocker.skyblock.crimson.slayer.AttunementColours;
+import de.hysky.skyblocker.skyblock.crimson.slayer.AttunementColors;
 import de.hysky.skyblocker.skyblock.dungeon.LividColor;
 import de.hysky.skyblocker.skyblock.end.TheEnd;
 import de.hysky.skyblocker.skyblock.slayers.SlayerEntitiesGlow;
@@ -40,11 +40,10 @@ public class MobGlow {
 	private static final ConcurrentHashMap<Entity, CacheEntry> canSeeCache = new ConcurrentHashMap<>();
 
 	public static void init() {
-		Scheduler.INSTANCE.scheduleCyclic(MobGlow::clearCache, 100*20);
+		Scheduler.INSTANCE.scheduleCyclic(MobGlow::clearCache, 300*20);
 	}
 
 	public static boolean shouldMobGlow(Entity entity) {
-		if (entity.isInvisible()) return false;
 
 		long currentTime = System.currentTimeMillis();
 
@@ -76,19 +75,27 @@ public class MobGlow {
 	}
 
 	private static boolean computeShouldMobGlow(Entity entity) {
+
+		if (entity.isInvisible()) {
+			return switch (entity) {
+				case ArmorStandEntity armorStand when Utils.isInTheEnd() && SlayerUtils.isInSlayer() && isNukekubiHead(armorStand) ->
+						SkyblockerConfigManager.get().slayers.endermanSlayer.highlightNukekubiHeads;
+				default -> false;
+			};
+		}
+
 		String name = entity.getName().getString();
 
 		// Dungeons
 		if (Utils.isInDungeons()) {
 			return switch (entity) {
+
 				// Minibosses
-				case PlayerEntity p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") ->
-						SkyblockerConfigManager.get().dungeons.starredMobGlow;
-				case PlayerEntity p when entity.getId() == LividColor.getCorrectLividId() ->
-						LividColor.shouldGlow(name);
+				case PlayerEntity p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") -> SkyblockerConfigManager.get().dungeons.starredMobGlow;
+				case PlayerEntity p when entity.getId() == LividColor.getCorrectLividId() -> LividColor.shouldGlow(name);
+
 				// Bats
-				case BatEntity b ->
-						SkyblockerConfigManager.get().dungeons.starredMobGlow || SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes;
+				case BatEntity b -> SkyblockerConfigManager.get().dungeons.starredMobGlow || SkyblockerConfigManager.get().dungeons.starredMobBoundingBoxes;
 
 				// Armor Stands
 				case ArmorStandEntity _armorStand -> false;
@@ -101,38 +108,24 @@ public class MobGlow {
 		return switch (entity) {
 
 			// Rift Blobbercyst
-			case PlayerEntity p when Utils.isInTheRift() && name.equals("Blobbercyst ") ->
-					SkyblockerConfigManager.get().otherLocations.rift.blobbercystGlow;
+			case PlayerEntity p when Utils.isInTheRift() && name.equals("Blobbercyst ") -> SkyblockerConfigManager.get().otherLocations.rift.blobbercystGlow;
 
 			// Dojo Helpers
-			case ZombieEntity zombie when Utils.isInCrimson() && DojoManager.inArena ->
-					DojoManager.shouldGlow(getArmorStandName(zombie));
+			case ZombieEntity zombie when Utils.isInCrimson() && DojoManager.inArena -> DojoManager.shouldGlow(getArmorStandName(zombie));
 
 			//Kuudra
-			case MagmaCubeEntity magmaCube when Utils.isInKuudra() ->
-					SkyblockerConfigManager.get().crimsonIsle.kuudra.kuudraGlow && magmaCube.getSize() == Kuudra.KUUDRA_MAGMA_CUBE_SIZE;
+			case MagmaCubeEntity magmaCube when Utils.isInKuudra() -> SkyblockerConfigManager.get().crimsonIsle.kuudra.kuudraGlow && magmaCube.getSize() == Kuudra.KUUDRA_MAGMA_CUBE_SIZE;
 
 			// Special Zealot && Slayer (Mini)Boss
-			case EndermanEntity enderman when Utils.isInTheEnd() ->
-					TheEnd.isSpecialZealot(enderman) || SlayerEntitiesGlow.shouldGlow(enderman.getUuid());
-			case ZombieEntity zombie when !(zombie instanceof ZombifiedPiglinEntity) && SlayerUtils.isInSlayerQuestType(SlayerUtils.REVENANT) ->
-					SlayerEntitiesGlow.shouldGlow(zombie.getUuid());
-			case SpiderEntity spider when SlayerUtils.isInSlayerQuestType(SlayerUtils.TARA) ->
-					SlayerEntitiesGlow.shouldGlow(spider.getUuid());
-			case WolfEntity wolf when SlayerUtils.isInSlayerQuestType(SlayerUtils.SVEN) ->
-					SlayerEntitiesGlow.shouldGlow(wolf.getUuid());
-			case BlazeEntity blaze when SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) ->
-					SlayerEntitiesGlow.shouldGlow(blaze.getUuid());
-
-			// Enderman Slayer's Nukekubi Skulls
-			case ArmorStandEntity armorStand when Utils.isInTheEnd() && SlayerUtils.isInSlayer() && isNukekubiHead(armorStand) ->
-					SkyblockerConfigManager.get().slayers.endermanSlayer.highlightNukekubiHeads;
+			case EndermanEntity enderman when Utils.isInTheEnd() -> TheEnd.isSpecialZealot(enderman) || SlayerEntitiesGlow.shouldGlow(enderman.getUuid());
+			case ZombieEntity zombie when !(zombie instanceof ZombifiedPiglinEntity) && SlayerUtils.isInSlayerQuestType(SlayerUtils.REVENANT) -> SlayerEntitiesGlow.shouldGlow(zombie.getUuid());
+			case SpiderEntity spider when SlayerUtils.isInSlayerQuestType(SlayerUtils.TARA) -> SlayerEntitiesGlow.shouldGlow(spider.getUuid());
+			case WolfEntity wolf when SlayerUtils.isInSlayerQuestType(SlayerUtils.SVEN) -> SlayerEntitiesGlow.shouldGlow(wolf.getUuid());
+			case BlazeEntity blaze when SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) -> SlayerEntitiesGlow.shouldGlow(blaze.getUuid());
 
 			// Blaze Slayer's Demonic minions
-			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW ->
-					SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
-			case ZombifiedPiglinEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW ->
-					SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
+			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW -> SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
+			case ZombifiedPiglinEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW -> SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
 
 			default -> false;
 		};
@@ -187,10 +180,10 @@ public class MobGlow {
 			case MagmaCubeEntity magmaCube when Utils.isInKuudra() -> 0xf7510f;
 
 			// Blaze Slayer Attunement Colours
-			case ArmorStandEntity armorStand when SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) -> AttunementColours.getColour(armorStand);
-			case BlazeEntity blaze when SlayerUtils.isInSlayer() -> AttunementColours.getColour(blaze);
-			case ZombifiedPiglinEntity piglin when SlayerUtils.isInSlayer() -> AttunementColours.getColour(piglin);
-			case WitherSkeletonEntity wSkelly when SlayerUtils.isInSlayer() -> AttunementColours.getColour(wSkelly);
+			case ArmorStandEntity armorStand when SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) -> AttunementColors.getColor(armorStand);
+			case BlazeEntity blaze when SlayerUtils.isInSlayer() -> AttunementColors.getColor(blaze);
+			case ZombifiedPiglinEntity piglin when SlayerUtils.isInSlayer() -> AttunementColors.getColor(piglin);
+			case WitherSkeletonEntity wSkelly when SlayerUtils.isInSlayer() -> AttunementColors.getColor(wSkelly);
 
 			default -> 0xf57738;
 		};

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -203,7 +203,7 @@ public class MobGlow {
 		return Streams.stream(entity.getArmorItems()).map(ItemUtils::getHeadTexture).anyMatch(headTexture -> headTexture.contains(NUKEKUBI_HEAD_TEXTURE));
 	}
 
-	private record CacheEntry(boolean value, long timestamp){};
+	private record CacheEntry(boolean value, long timestamp){}
 
 	private static void clearCache() {
 		canSeeCache.clear();

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.skyblock.entity;
 
 import com.google.common.collect.Streams;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.SlayersConfig;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
 import de.hysky.skyblocker.skyblock.crimson.kuudra.Kuudra;
 import de.hysky.skyblocker.skyblock.crimson.slayer.AttunementColours;
@@ -60,13 +61,13 @@ public class MobGlow {
 
 	/**
 	 * Checks if the player can see the entity.
-	 * Has "True sight" within an small aura, but since name tags exist I think this is fine...
+	 * Has "True sight" within a certain aura, but since name tags exist I think this is fine...
 	 */
 	private static boolean playerCanSee(Entity entity, long currentTime) {
 
 		CacheEntry canSee = canSeeCache.get(entity);
 		if (canSee == null || (currentTime - canSee.timestamp) > PLAYER_CAN_SEE_CACHE_DURATION) {
-			boolean playerCanSee = entity.distanceTo(MinecraftClient.getInstance().player) <= 15 || MinecraftClient.getInstance().player.canSee(entity);
+			boolean playerCanSee = entity.distanceTo(MinecraftClient.getInstance().player) <= 20 || MinecraftClient.getInstance().player.canSee(entity);
 			canSeeCache.put(entity, new CacheEntry(playerCanSee, currentTime));
 			return playerCanSee;
 		}
@@ -128,10 +129,10 @@ public class MobGlow {
 					SkyblockerConfigManager.get().slayers.endermanSlayer.highlightNukekubiHeads;
 
 			// Blaze Slayer's Demonic minions
-			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses.toString().equals("GLOW") ->
-					SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 10;
-			case ZombifiedPiglinEntity e when SkyblockerConfigManager.get().slayers.highlightBosses.toString().equals("GLOW") ->
-					SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 10;
+			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW ->
+					SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
+			case ZombifiedPiglinEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW ->
+					SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
 
 			default -> false;
 		};

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -40,7 +40,7 @@ public class MobGlow {
 	private static final ConcurrentHashMap<Entity, CacheEntry> canSeeCache = new ConcurrentHashMap<>();
 
 	public static void init() {
-		Scheduler.INSTANCE.scheduleCyclic(MobGlow::clearCache, 300*20);
+		Scheduler.INSTANCE.scheduleCyclic(MobGlow::clearCache, 300 * 20);
 	}
 
 	public static boolean shouldMobGlow(Entity entity) {
@@ -75,15 +75,6 @@ public class MobGlow {
 	}
 
 	private static boolean computeShouldMobGlow(Entity entity) {
-
-		if (entity.isInvisible()) {
-			return switch (entity) {
-				case ArmorStandEntity armorStand when Utils.isInTheEnd() && SlayerUtils.isInSlayer() && isNukekubiHead(armorStand) ->
-						SkyblockerConfigManager.get().slayers.endermanSlayer.highlightNukekubiHeads;
-				default -> false;
-			};
-		}
-
 		String name = entity.getName().getString();
 
 		// Dungeons
@@ -122,6 +113,9 @@ public class MobGlow {
 			case SpiderEntity spider when SlayerUtils.isInSlayerQuestType(SlayerUtils.TARA) -> SlayerEntitiesGlow.shouldGlow(spider.getUuid());
 			case WolfEntity wolf when SlayerUtils.isInSlayerQuestType(SlayerUtils.SVEN) -> SlayerEntitiesGlow.shouldGlow(wolf.getUuid());
 			case BlazeEntity blaze when SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) -> SlayerEntitiesGlow.shouldGlow(blaze.getUuid());
+
+			// Enderman Slayer's Nukekubi Skulls
+			case ArmorStandEntity armorStand when Utils.isInTheEnd() && SlayerUtils.isInSlayer() && isNukekubiHead(armorStand) -> SkyblockerConfigManager.get().slayers.endermanSlayer.highlightNukekubiHeads;
 
 			// Blaze Slayer's Demonic minions
 			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW -> SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 15;
@@ -196,7 +190,7 @@ public class MobGlow {
 		return Streams.stream(entity.getArmorItems()).map(ItemUtils::getHeadTexture).anyMatch(headTexture -> headTexture.contains(NUKEKUBI_HEAD_TEXTURE));
 	}
 
-	private record CacheEntry(boolean value, long timestamp){}
+	private record CacheEntry(boolean value, long timestamp) {}
 
 	private static void clearCache() {
 		canSeeCache.clear();

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -47,21 +47,16 @@ public class MobGlow {
 
 		long currentTime = System.currentTimeMillis();
 
-		boolean shouldGlow;
 		CacheEntry cachedGlow = glowCache.get(entity);
 		if (cachedGlow == null || (currentTime - cachedGlow.timestamp) > GLOW_CACHE_DURATION) {
-			shouldGlow = computeShouldMobGlow(entity);
+			boolean shouldGlow = computeShouldMobGlow(entity);
 			glowCache.put(entity, new CacheEntry(shouldGlow, currentTime));
-		} else {
-			shouldGlow = cachedGlow.value;
+			cachedGlow = glowCache.get(entity);
 		}
 
-		if (shouldGlow) {
-			return playerCanSee(entity, currentTime);
-		}
-
-		return false;
+		return cachedGlow.value && playerCanSee(entity, currentTime);
 	}
+
 
 	/**
 	 * Checks if the player can see the entity.
@@ -83,7 +78,7 @@ public class MobGlow {
 		String name = entity.getName().getString();
 
 		// Dungeons
-		if (Utils.isInDungeons() && !entity.isInvisible()) {
+		if (Utils.isInDungeons()) {
 			return switch (entity) {
 				// Minibosses
 				case PlayerEntity p when name.equals("Lost Adventurer") || name.equals("Shadow Assassin") || name.equals("Diamond Guy") ->
@@ -105,7 +100,7 @@ public class MobGlow {
 		return switch (entity) {
 
 			// Rift Blobbercyst
-			case PlayerEntity p when Utils.isInTheRift() && !entity.isInvisible() && name.equals("Blobbercyst ") ->
+			case PlayerEntity p when Utils.isInTheRift() && name.equals("Blobbercyst ") ->
 					SkyblockerConfigManager.get().otherLocations.rift.blobbercystGlow;
 
 			// Dojo Helpers
@@ -117,7 +112,7 @@ public class MobGlow {
 					SkyblockerConfigManager.get().crimsonIsle.kuudra.kuudraGlow && magmaCube.getSize() == Kuudra.KUUDRA_MAGMA_CUBE_SIZE;
 
 			// Special Zealot && Slayer (Mini)Boss
-			case EndermanEntity enderman when Utils.isInTheEnd() && !entity.isInvisible() ->
+			case EndermanEntity enderman when Utils.isInTheEnd() ->
 					TheEnd.isSpecialZealot(enderman) || SlayerEntitiesGlow.shouldGlow(enderman.getUuid());
 			case ZombieEntity zombie when !(zombie instanceof ZombifiedPiglinEntity) && SlayerUtils.isInSlayerQuestType(SlayerUtils.REVENANT) ->
 					SlayerEntitiesGlow.shouldGlow(zombie.getUuid());

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -124,8 +124,8 @@ public class MobGlow {
 			case BlazeEntity blaze when SlayerUtils.isInSlayerQuestType(SlayerUtils.DEMONLORD) -> SlayerEntitiesGlow.shouldGlow(blaze.getUuid());
 
 			// Blaze Slayer's Demonic minions
-			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW -> SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
-			case ZombifiedPiglinEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW -> SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 14;
+			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW -> SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 15;
+			case ZombifiedPiglinEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW -> SlayerUtils.isInSlayerType(SlayerUtils.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 15;
 
 			default -> false;
 		};

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
@@ -1,7 +1,5 @@
 package de.hysky.skyblocker.skyblock.slayers;
 
-import de.hysky.skyblocker.events.SkyblockEvents;
-import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.SlayerUtils;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
@@ -35,6 +35,9 @@ public class SlayerEntitiesGlow {
             Map.entry("Burningsoul Demon", SlayerUtils.DEMONLORD)
     );
 
+    public static void init() {
+        SkyblockEvents.LOCATION_CHANGE.register(SlayerEntitiesGlow::clearGlow);
+    }
     private static final Map<String, Class<? extends MobEntity>> SLAYER_MOB_TYPE = Map.of(
             SlayerUtils.REVENANT, ZombieEntity.class,
             SlayerUtils.TARA, SpiderEntity.class,
@@ -50,13 +53,15 @@ public class SlayerEntitiesGlow {
     }
 
     public static boolean isSlayer(LivingEntity e) {
-        return SlayerUtils.isInSlayer() && SlayerUtils.getEntityArmorStands(e).stream().anyMatch(entity -> entity.getDisplayName().getString().contains(MinecraftClient.getInstance().getSession().getUsername()));
+        return SlayerUtils.isInSlayer() && SlayerUtils.getEntityArmorStands(e).stream().anyMatch(entity ->
+                entity.getDisplayName().getString().contains(MinecraftClient.getInstance().getSession().getUsername()));
     }
 
     public static boolean isSlayerMiniMob(LivingEntity entity) {
         if (entity.getCustomName() == null) return false;
         String entityName = entity.getCustomName().getString();
-        return SLAYER_MINI_NAMES.keySet().stream().anyMatch(slayerMobName -> entityName.contains(slayerMobName) && SlayerUtils.isInSlayerQuestType(SLAYER_MINI_NAMES.get(slayerMobName)));
+        return SLAYER_MINI_NAMES.keySet().stream().anyMatch(slayerMobName ->
+                entityName.contains(slayerMobName) && SlayerUtils.isInSlayerQuestType(SLAYER_MINI_NAMES.get(slayerMobName)));
     }
 
     public static Box getSlayerMobBoundingBox(LivingEntity entity) {
@@ -86,9 +91,18 @@ public class SlayerEntitiesGlow {
                         .getBoxAt(armorStand.getPos()).expand(1.5), entity ->
                         !entity.isDead() && entity.age > armorStand.age - 4 && entity.age < armorStand.age + 4)
                 .stream()
-                .filter(entity -> !(entity instanceof CaveSpiderEntity)) // CaveSpider extends Spider so filter out mob for BroodFather highlight
+                .filter(entity -> !(entity instanceof CaveSpiderEntity))
+                .filter(SlayerEntitiesGlow::isValidSlayerMob)
                 .min(Comparator.comparingDouble((MobEntity e) -> e.distanceTo(armorStand)))
                 .orElse(null);
+    }
+
+    /**
+     * Use this func to add checks to prevent accidental highlights
+     * i.e. Cavespider extends spider and thus will highlight the broodfather's head pet instead and
+     */
+    private static boolean isValidSlayerMob(MobEntity entity) {
+        return !(entity instanceof CaveSpiderEntity) && !(entity.isBaby());
     }
 
     /**
@@ -113,7 +127,4 @@ public class SlayerEntitiesGlow {
         MOBS_TO_GLOW.clear();
     }
 
-    public static void init() {
-        SkyblockEvents.LOCATION_CHANGE.register(SlayerEntitiesGlow::clearGlow);
-    }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
@@ -1,0 +1,119 @@
+package de.hysky.skyblocker.skyblock.slayers;
+
+import de.hysky.skyblocker.events.SkyblockEvents;
+import de.hysky.skyblocker.utils.Location;
+import de.hysky.skyblocker.utils.SlayerUtils;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.entity.mob.*;
+import net.minecraft.entity.passive.WolfEntity;
+import net.minecraft.util.math.Box;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class SlayerEntitiesGlow {
+    private static final Map<String, String> SLAYER_MINI_NAMES = Map.ofEntries(
+            Map.entry("Revenant Sycophant", SlayerUtils.REVENANT),
+            Map.entry("Revenant Champion", SlayerUtils.REVENANT),
+            Map.entry("Deformed Revenant", SlayerUtils.REVENANT),
+            Map.entry("Atoned Champion", SlayerUtils.REVENANT),
+            Map.entry("Atoned Revenant", SlayerUtils.REVENANT),
+            Map.entry("Tarantula Vermin", SlayerUtils.TARA),
+            Map.entry("Tarantula Beast", SlayerUtils.TARA),
+            Map.entry("Mutant Tarantula", SlayerUtils.TARA),
+            Map.entry("Pack Enforcer", SlayerUtils.SVEN),
+            Map.entry("Sven Follower", SlayerUtils.SVEN),
+            Map.entry("Sven Alpha", SlayerUtils.SVEN),
+            Map.entry("Voidling Devotee", SlayerUtils.VOIDGLOOM),
+            Map.entry("Voidling Radical", SlayerUtils.VOIDGLOOM),
+            Map.entry("Voidcrazed Maniac", SlayerUtils.VOIDGLOOM),
+            Map.entry("Flare Demon", SlayerUtils.DEMONLORD),
+            Map.entry("Kindleheart Demon", SlayerUtils.DEMONLORD),
+            Map.entry("Burningsoul Demon", SlayerUtils.DEMONLORD)
+    );
+
+    private static final Map<String, Class<? extends MobEntity>> SLAYER_MOB_TYPE = Map.of(
+            SlayerUtils.REVENANT, ZombieEntity.class,
+            SlayerUtils.TARA, SpiderEntity.class,
+            SlayerUtils.SVEN, WolfEntity.class,
+            SlayerUtils.VOIDGLOOM, EndermanEntity.class,
+            SlayerUtils.DEMONLORD, BlazeEntity.class
+    );
+
+    private static final Set<UUID> MOBS_TO_GLOW = new HashSet<>();
+
+    public static boolean shouldGlow(UUID entityUUID) {
+        return MOBS_TO_GLOW.contains(entityUUID);
+    }
+
+    public static boolean isSlayer(LivingEntity e) {
+        return SlayerUtils.isInSlayer() && SlayerUtils.getEntityArmorStands(e).stream().anyMatch(entity -> entity.getDisplayName().getString().contains(MinecraftClient.getInstance().getSession().getUsername()));
+    }
+
+    public static boolean isSlayerMiniMob(LivingEntity entity) {
+        if (entity.getCustomName() == null) return false;
+        String entityName = entity.getCustomName().getString();
+        return SLAYER_MINI_NAMES.keySet().stream().anyMatch(slayerMobName -> entityName.contains(slayerMobName) && SlayerUtils.isInSlayerQuestType(SLAYER_MINI_NAMES.get(slayerMobName)));
+    }
+
+    public static Box getSlayerMobBoundingBox(LivingEntity entity) {
+        return switch (SlayerUtils.getSlayerType()) {
+            case SlayerUtils.REVENANT ->
+                    new Box(entity.getX() - 0.4, entity.getY() - 0.1, entity.getZ() - 0.4, entity.getX() + 0.4, entity.getY() - 2.2, entity.getZ() + 0.4);
+            case SlayerUtils.TARA ->
+                    new Box(entity.getX() - 0.9, entity.getY() - 0.2, entity.getZ() - 0.9, entity.getX() + 0.9, entity.getY() - 1.2, entity.getZ() + 0.9);
+            case SlayerUtils.VOIDGLOOM ->
+                    new Box(entity.getX() - 0.4, entity.getY() - 0.2, entity.getZ() - 0.4, entity.getX() + 0.4, entity.getY() - 3, entity.getZ() + 0.4);
+            case SlayerUtils.SVEN ->
+                    new Box(entity.getX() - 0.5, entity.getY() - 0.1, entity.getZ() - 0.5, entity.getX() + 0.5, entity.getY() - 1, entity.getZ() + 0.5);
+            default ->
+                    new Box(entity.getX() - 0.5, entity.getY() + 0.1, entity.getZ() - 0.5, entity.getX() + 0.5, entity.getY() - 2.2, entity.getZ() + 0.5);
+        };
+    }
+
+    /**
+     * <p> Finds the closest matching MobEntity for the armorStand using entityClass and armorStand age difference to filter
+     * out impossible candidates, returning the closest mob of those remaining in the search box by block distance </p>
+     *
+     * @param entityClass the mob type of the Slayer (i.e. ZombieEntity.class)
+     * @param armorStand  the entity that contains the display name of the Slayer (mini)boss
+     */
+    private static MobEntity findClosestMobEntity(Class<? extends MobEntity> entityClass, ArmorStandEntity armorStand) {
+        return armorStand.getWorld().getEntitiesByClass(entityClass, armorStand.getDimensions(null)
+                        .getBoxAt(armorStand.getPos()).expand(1.5), entity ->
+                        !entity.isDead() && entity.age > armorStand.age - 4 && entity.age < armorStand.age + 4)
+                .stream()
+                .filter(entity -> !(entity instanceof CaveSpiderEntity)) // CaveSpider extends Spider so filter out mob for BroodFather highlight
+                .min(Comparator.comparingDouble((MobEntity e) -> e.distanceTo(armorStand)))
+                .orElse(null);
+    }
+
+    /**
+     * <p> Adds the Entity UUID to the Hashset of Slayer Mobs to glow </p>
+     *
+     * @param armorStand the entity that contains the display name of the Slayer (mini)boss
+     */
+    public static void setSlayerMobGlow(ArmorStandEntity armorStand) {
+        String slayerType = SlayerUtils.getSlayerType();
+        Class<? extends MobEntity> entityClass = SLAYER_MOB_TYPE.get(slayerType);
+        if (entityClass != null) {
+            MobEntity closestEntity = findClosestMobEntity(entityClass, armorStand);
+            if (closestEntity != null) MOBS_TO_GLOW.add(closestEntity.getUuid());
+        }
+    }
+
+    public static void onEntityDeath(@Nullable Entity entity) {
+        if (entity != null && entity.getUuid() != null) MOBS_TO_GLOW.remove(entity.getUuid());
+    }
+
+    private static void clearGlow(Location location) {
+        MOBS_TO_GLOW.clear();
+    }
+
+    public static void init() {
+        SkyblockEvents.LOCATION_CHANGE.register(SlayerEntitiesGlow::clearGlow);
+    }
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerEntitiesGlow.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.skyblock.slayers;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.SlayerUtils;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -36,7 +37,7 @@ public class SlayerEntitiesGlow {
     );
 
     public static void init() {
-        SkyblockEvents.LOCATION_CHANGE.register(SlayerEntitiesGlow::clearGlow);
+        ClientPlayConnectionEvents.JOIN.register((ignore, ignore2, ignore3) -> clearGlow());
     }
     private static final Map<String, Class<? extends MobEntity>> SLAYER_MOB_TYPE = Map.of(
             SlayerUtils.REVENANT, ZombieEntity.class,
@@ -60,22 +61,16 @@ public class SlayerEntitiesGlow {
     public static boolean isSlayerMiniMob(LivingEntity entity) {
         if (entity.getCustomName() == null) return false;
         String entityName = entity.getCustomName().getString();
-        return SLAYER_MINI_NAMES.keySet().stream().anyMatch(slayerMobName ->
-                entityName.contains(slayerMobName) && SlayerUtils.isInSlayerQuestType(SLAYER_MINI_NAMES.get(slayerMobName)));
+        return SLAYER_MINI_NAMES.keySet().stream().anyMatch(slayerMobName -> entityName.contains(slayerMobName) && SlayerUtils.isInSlayerQuestType(SLAYER_MINI_NAMES.get(slayerMobName)));
     }
 
     public static Box getSlayerMobBoundingBox(LivingEntity entity) {
         return switch (SlayerUtils.getSlayerType()) {
-            case SlayerUtils.REVENANT ->
-                    new Box(entity.getX() - 0.4, entity.getY() - 0.1, entity.getZ() - 0.4, entity.getX() + 0.4, entity.getY() - 2.2, entity.getZ() + 0.4);
-            case SlayerUtils.TARA ->
-                    new Box(entity.getX() - 0.9, entity.getY() - 0.2, entity.getZ() - 0.9, entity.getX() + 0.9, entity.getY() - 1.2, entity.getZ() + 0.9);
-            case SlayerUtils.VOIDGLOOM ->
-                    new Box(entity.getX() - 0.4, entity.getY() - 0.2, entity.getZ() - 0.4, entity.getX() + 0.4, entity.getY() - 3, entity.getZ() + 0.4);
-            case SlayerUtils.SVEN ->
-                    new Box(entity.getX() - 0.5, entity.getY() - 0.1, entity.getZ() - 0.5, entity.getX() + 0.5, entity.getY() - 1, entity.getZ() + 0.5);
-            default ->
-                    new Box(entity.getX() - 0.5, entity.getY() + 0.1, entity.getZ() - 0.5, entity.getX() + 0.5, entity.getY() - 2.2, entity.getZ() + 0.5);
+            case SlayerUtils.REVENANT -> new Box(entity.getX() - 0.4, entity.getY() - 0.1, entity.getZ() - 0.4, entity.getX() + 0.4, entity.getY() - 2.2, entity.getZ() + 0.4);
+            case SlayerUtils.TARA -> new Box(entity.getX() - 0.9, entity.getY() - 0.2, entity.getZ() - 0.9, entity.getX() + 0.9, entity.getY() - 1.2, entity.getZ() + 0.9);
+            case SlayerUtils.VOIDGLOOM -> new Box(entity.getX() - 0.4, entity.getY() - 0.2, entity.getZ() - 0.4, entity.getX() + 0.4, entity.getY() - 3, entity.getZ() + 0.4);
+            case SlayerUtils.SVEN -> new Box(entity.getX() - 0.5, entity.getY() - 0.1, entity.getZ() - 0.5, entity.getX() + 0.5, entity.getY() - 1, entity.getZ() + 0.5);
+            default -> entity.getBoundingBox();
         };
     }
 
@@ -91,7 +86,6 @@ public class SlayerEntitiesGlow {
                         .getBoxAt(armorStand.getPos()).expand(1.5), entity ->
                         !entity.isDead() && entity.age > armorStand.age - 4 && entity.age < armorStand.age + 4)
                 .stream()
-                .filter(entity -> !(entity instanceof CaveSpiderEntity))
                 .filter(SlayerEntitiesGlow::isValidSlayerMob)
                 .min(Comparator.comparingDouble((MobEntity e) -> e.distanceTo(armorStand)))
                 .orElse(null);
@@ -123,7 +117,7 @@ public class SlayerEntitiesGlow {
         if (entity != null && entity.getUuid() != null) MOBS_TO_GLOW.remove(entity.getUuid());
     }
 
-    private static void clearGlow(Location location) {
+    private static void clearGlow() {
         MOBS_TO_GLOW.clear();
     }
 

--- a/src/main/java/de/hysky/skyblocker/utils/SlayerUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SlayerUtils.java
@@ -58,6 +58,25 @@ public class SlayerUtils {
         return false;
     }
 
+    public static boolean isInSlayerType(String slayer) {
+        try {
+            boolean inFight = false;
+            boolean type = false;
+            for (String line : Utils.STRING_SCOREBOARD) {
+                switch (line) {
+                    case String a when a.contains("Slayer Quest") -> { return false; }
+                    case String b when b.contains("Slay the boss!") -> inFight = true;
+                    case String c when c.contains(slayer) -> type = true;
+                    default -> { continue; }
+                }
+                if (inFight && type) return true;
+            }
+        } catch (NullPointerException e) {
+            LOGGER.error("[Skyblocker] Error while checking if player is in slayer", e);
+        }
+        return false;
+    }
+
     public static boolean isInSlayerQuestType(String slayer) {
         try {
             boolean quest = false;

--- a/src/main/java/de/hysky/skyblocker/utils/SlayerUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SlayerUtils.java
@@ -7,10 +7,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 //TODO Slayer Packet system that can provide information about the current slayer boss, abstract so that different bosses can have different info
 public class SlayerUtils {
+    public static final String REVENANT = "Revenant Horror";
+    public static final String TARA = "Tarantula Broodfather";
+    public static final String SVEN = "Sven Packmaster";
+    public static final String VOIDGLOOM = "Voidgloom Seraph";
+    public static final String VAMPIRE = "Riftstalker Bloodfiend";
+    public static final String DEMONLORD = "Inferno Demonlord";
     private static final Logger LOGGER = LoggerFactory.getLogger(SlayerUtils.class);
+    private static final Pattern SLAYER_PATTERN = Pattern.compile("Revenant Horror|Tarantula Broodfather|Sven Packmaster|Voidgloom Seraph|Inferno Demonlord|Riftstalker Bloodfiend");
 
     //TODO: Cache this, probably included in Packet system
     public static List<Entity> getEntityArmorStands(Entity entity) {
@@ -21,15 +30,15 @@ public class SlayerUtils {
     public static Entity getSlayerEntity() {
         if (MinecraftClient.getInstance().world != null) {
             for (Entity entity : MinecraftClient.getInstance().world.getEntities()) {
-                //Check if entity is Bloodfiend
-                if (entity.hasCustomName() && entity.getCustomName().getString().contains("Bloodfiend")) {
-                    //Grab the players username
-                    String username = MinecraftClient.getInstance().getSession().getUsername();
-                    //Check all armor stands around the boss
-                    for (Entity armorStand : getEntityArmorStands(entity)) {
-                        //Check if the display name contains the players username
-                        if (armorStand.getDisplayName().getString().contains(username)) {
-                            return entity;
+                if (entity.hasCustomName()) {
+                    String entityName = entity.getCustomName().getString();
+                    Matcher matcher = SLAYER_PATTERN.matcher(entityName);
+                    if (matcher.find()) {
+                        String username = MinecraftClient.getInstance().getSession().getUsername();
+                        for (Entity armorStand : getEntityArmorStands(entity)) {
+                            if (armorStand.getDisplayName().getString().contains(username)) {
+                                return entity;
+                            }
                         }
                     }
                 }
@@ -40,15 +49,39 @@ public class SlayerUtils {
 
     public static boolean isInSlayer() {
         try {
-            for (int i = 0; i < Utils.STRING_SCOREBOARD.size(); i++) {
-                String line = Utils.STRING_SCOREBOARD.get(i);
-
+            for (String line : Utils.STRING_SCOREBOARD) {
                 if (line.contains("Slay the boss!")) return true;
             }
         } catch (NullPointerException e) {
             LOGGER.error("[Skyblocker] Error while checking if player is in slayer", e);
         }
-
         return false;
+    }
+
+    public static boolean isInSlayerQuestType(String slayer) {
+        try {
+            boolean quest = false;
+            boolean type = false;
+            for (String line : Utils.STRING_SCOREBOARD) {
+                if (line.contains("Slayer Quest")) quest = true;
+                if (line.contains(slayer)) type = true;
+                if (quest && type) return true;
+            }
+        } catch (NullPointerException e) {
+            LOGGER.error("[Skyblocker] Error while checking if player is in slayer quest type", e);
+        }
+        return false;
+    }
+
+    public static String getSlayerType() {
+        try {
+            for (String line : Utils.STRING_SCOREBOARD) {
+                Matcher matcher = SLAYER_PATTERN.matcher(line);
+                if (matcher.find()) return matcher.group();
+            }
+        } catch (NullPointerException | IndexOutOfBoundsException e) {
+            LOGGER.error("[Skyblocker] Error while checking slayer type", e);
+        }
+        return "";
     }
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -197,7 +197,7 @@
   "skyblocker.config.dungeons.starredMobBoundingBoxes.@Tooltip": "Draws the bounding boxes of starred mobs.",
 
   "skyblocker.config.dungeons.starredMobGlow": "Starred Mob Glow",
-  "skyblocker.config.dungeons.starredMobGlow.@Tooltip": "Applies the glowing effect to starred mobs that are visible.\n\nWARNING: This feature is experimental and you may encounter issues with it.",
+  "skyblocker.config.dungeons.starredMobGlow.@Tooltip": "Applies the glowing effect to starred mobs that are visible.\n\nWARNING: This feature utilises ray casting on a lot of entities which may have an impact on performance.",
 
   "skyblocker.config.dungeons.terminals": "Terminal Solvers (F7/M7)",
   "skyblocker.config.dungeons.terminals.blockIncorrectClicks": "Block Incorrect Clicks",
@@ -600,10 +600,27 @@
 
   "skyblocker.config.slayer": "Slayers",
 
+  "skyblocker.config.slayer.blazeSlayer": "Blaze Slayer",
+  "skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer" : "Fire Pillar Countdown Notifications",
+  "skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer.@Tooltip": "Countdowns the last five seconds before the Fire Pillar explodes. Configure 'Title Container' to customise the location on the HUD (Note: This only uses a rudimentary distance check, so the Pillar may be spawned by another player's slayer)",
+  "skyblocker.config.slayer.blazeSlayer.attunementHighlights" : "Attunement Highlights",
+  "skyblocker.config.slayer.blazeSlayer.attunementHighlights.@Tooltip": "If Boss Highlighting is on, applies a color matching the current attunement to the selected effect.",
+
   "skyblocker.config.slayer.endermanSlayer": "Enderman Slayer",
   "skyblocker.config.slayer.endermanSlayer.enableYangGlyphsNotification": "Enable Yang Glyphs notification",
   "skyblocker.config.slayer.endermanSlayer.highlightBeacons": "Beacon Highlighting",
   "skyblocker.config.slayer.endermanSlayer.highlightNukekubiHeads": "Nukekubi Head Highlighting",
+
+  "skyblocker.config.slayer.highlightMinis": "Highlight Minibosses",
+  "skyblocker.config.slayer.highlightMinis.@Tooltip[0]": "\nOFF: Do not highlight Slayer Minibosses.",
+  "skyblocker.config.slayer.highlightMinis.@Tooltip[1]": "\nGLOW: Creates a glow effect on Slayer Minibosses. Due to technical limitations, there is a small chance of this option making mistakes in mob detection",
+  "skyblocker.config.slayer.highlightMinis.@Tooltip[2]": "\nHITBOX: Display a Hitbox around Slayer Minibosses",
+
+  "skyblocker.config.slayer.highlightBosses": "Highlight Bosses",
+  "skyblocker.config.slayer.highlightBosses.@Tooltip[0]": "\nOFF: Do not highlight Slayer Bosses.",
+  "skyblocker.config.slayer.highlightBosses.@Tooltip[1]": "\nGLOW: Creates a glow effect on Slayer Bosses. Due to technical limitations, there is a small chance of this option making mistakes in mob detection",
+  "skyblocker.config.slayer.highlightBosses.@Tooltip[2]": "\nHITBOX: Display a Hitbox around the Slayer Boss",
+  "skyblocker.config.slayer.highlightBosses.@Tooltip[3]": "This option is required for Blazeslayer Attunement Highlighting",
 
   "skyblocker.config.slayer.vampireSlayer": "Vampire Slayer",
   "skyblocker.config.slayer.vampireSlayer.compactEffigyWaypoints": "Compact Effigy Waypoints",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -197,8 +197,7 @@
   "skyblocker.config.dungeons.starredMobBoundingBoxes.@Tooltip": "Draws the bounding boxes of starred mobs.",
 
   "skyblocker.config.dungeons.starredMobGlow": "Starred Mob Glow",
-  "skyblocker.config.dungeons.starredMobGlow.@Tooltip": "Applies the glowing effect to starred mobs that are visible.\n\nWARNING: This feature utilises ray casting on a lot of entities which may have an impact on performance.",
-
+  "skyblocker.config.dungeons.starredMobGlow.@Tooltip": "Applies the glowing effect to starred mobs that are visible.\n\nWARNING: This feature utilises ray casting on entities which may have an impact on performance.",
   "skyblocker.config.dungeons.terminals": "Terminal Solvers (F7/M7)",
   "skyblocker.config.dungeons.terminals.blockIncorrectClicks": "Block Incorrect Clicks",
   "skyblocker.config.dungeons.terminals.solveColor": "Solve Select Colored",
@@ -620,7 +619,7 @@
   "skyblocker.config.slayer.highlightBosses.@Tooltip[0]": "\nOFF: Do not highlight Slayer Bosses.",
   "skyblocker.config.slayer.highlightBosses.@Tooltip[1]": "\nGLOW: Creates a glow effect on Slayer Bosses. Due to technical limitations, there is a small chance of this option making mistakes in mob detection",
   "skyblocker.config.slayer.highlightBosses.@Tooltip[2]": "\nHITBOX: Display a Hitbox around the Slayer Boss",
-  "skyblocker.config.slayer.highlightBosses.@Tooltip[3]": "This option is required for Blazeslayer Attunement Highlighting",
+  "skyblocker.config.slayer.highlightBosses.@Tooltip[3]": "\nThis option is required for Blazeslayer Attunement Highlighting",
 
   "skyblocker.config.slayer.vampireSlayer": "Vampire Slayer",
   "skyblocker.config.slayer.vampireSlayer.compactEffigyWaypoints": "Compact Effigy Waypoints",


### PR DESCRIPTION
Remade this PR cause The merge conflicts were horrible

- Hitbox Slayer Mob Highlighting
- Glow Effect Slayer Mob Highlighting
- Blazeslayer Attunement highlighting
- Fire Pillar Countdown Notifiications

This PR Also reworks "ShouldGlow" Detection

- There's a "truesight" aura of 20 blocks - I think this is fine because this is just about in range of where nametags begin to shrink to the point of being undreadable, and thus could be reasonably argued you could tell this is where a mob is.
- Anything beyond this distance is raycast to ensure it can be seen
- caches "shouldGlow" for 50ms/1 ticks duration
- caches "canSee" for 100ms/2 ticks duration