### PR TITLE
Added description to hideEmptyTooltips option.

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -49,6 +49,7 @@ public class UIAndVisualsCategory {
                         .build())
                 .option(Option.<Boolean>createBuilder()
                         .name(Text.translatable("skyblocker.config.uiAndVisuals.hideEmptyTooltips"))
+                        .description(OptionDescription.of(Text.translatable("skyblocker.config.uiAndVisuals.hideEmptyTooltips.@Tooltip")))
                         .binding(defaults.uiAndVisuals.hideEmptyTooltips,
                                 () -> config.uiAndVisuals.hideEmptyTooltips,
                                 newValue -> config.uiAndVisuals.hideEmptyTooltips = newValue)

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -228,6 +228,7 @@
   "skyblocker.config.general.acceptReparty": "Auto accept Reparty",
 
   "skyblocker.config.uiAndVisuals.hideEmptyTooltips": "Hide empty item tooltips in menus",
+  "skyblocker.config.uiAndVisuals.hideEmptyTooltips.@Tooltip": "Hides the tooltip of an item if it doesn't have any information to display. Also blocks clicks on filler items like glass panes.",
 
   "skyblocker.config.general.hitbox": "Hitboxes",
   "skyblocker.config.general.hitbox.oldFarmlandHitbox": "Enable 1.8 farmland hitbox",


### PR DESCRIPTION
Adds the description "Hides the tooltip of an item if it doesn't have any information to display. Also blocks clicks on filler items like glass panes." in attempt to solve https://github.com/SkyblockerMod/Skyblocker/issues/891