### PR TITLE
Fix Croesus profit estimator on master mode chests

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/CroesusProfit.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/CroesusProfit.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 public class CroesusProfit extends SimpleContainerSolver {
     private static final Pattern ESSENCE_PATTERN = Pattern.compile("(?<type>[A-Za-z]+) Essence x(?<amount>\\d+)");
     public CroesusProfit() {
-        super(".*Catacombs - Floor.*");
+        super(".*The Catacombs - Flo.*");
     }
 
     @Override


### PR DESCRIPTION
Very epic fix.

```
[23:13:30] [Render thread/INFO] (Minecraft) [STDOUT]: Screen: Croesus
[23:13:34] [Render thread/INFO] (Minecraft) [STDOUT]: Screen: The Catacombs - Floor III
[23:13:35] [Render thread/INFO] (Minecraft) [STDOUT]: Screen: Croesus
[23:13:36] [Render thread/INFO] (Minecraft) [STDOUT]: Screen: Master Mode The Catacombs - Flo
```

Turns out yesterday's update made the Croesus UI's titles get truncated for master mode, and as a result, the regex doesn't match anything.
I'm guessing hypixel will revert their changes eventually, so this regex also works on the previous titles (pre-update).

I don't think this conflicts with any other UI's title, from what I checked.

![image](https://github.com/user-attachments/assets/dcf55cd8-e504-4e01-ac61-b8eeb9cf68aa)
