### PR TITLE
Proper Item DFU for PV

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,9 @@ dependencies {
 	// Networth Calculator (https://github.com/AzureAaron/networth-calculator)
 	include implementation("net.azureaaron:networth-calculator:${project.networth_calculator_version}")
 
+	// Legacy Item DFU
+	include implementation("net.azureaaron:legacy-item-dfu:${project.legacy_item_dfu_version}")
+
 	// JGit used pull data from the NEU item repo
 	include implementation("org.eclipse.jgit:org.eclipse.jgit:${project.jgit_version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,8 @@ occlusionculling_version = 0.0.8-SNAPSHOT
 repoparser_version = 1.5.0
 ## Networth Calculator (https://github.com/AzureAaron/networth-calculator)
 networth_calculator_version = 1.0.1
+## Legacy Item DFU (https://github.com/AzureAaron/legacy-item-dfu)
+legacy_item_dfu_version = 1.0.0-alpha.1
 
 # Other Libraries
 ## JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ repoparser_version = 1.5.0
 ## Networth Calculator (https://github.com/AzureAaron/networth-calculator)
 networth_calculator_version = 1.0.1
 ## Legacy Item DFU (https://github.com/AzureAaron/legacy-item-dfu)
-legacy_item_dfu_version = 1.0.0-alpha.1
+legacy_item_dfu_version = 1.0.0+1.21.1
 
 # Other Libraries
 ## JGit (https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit)

--- a/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/itemLoaders/ItemLoader.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/itemLoaders/ItemLoader.java
@@ -5,31 +5,19 @@ import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
 
 import de.hysky.skyblocker.skyblock.PetCache;
-import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.skyblock.profileviewer.ProfileViewerScreen;
 import de.hysky.skyblocker.skyblock.profileviewer.inventory.Pet;
 import de.hysky.skyblocker.skyblock.tabhud.util.Ico;
 import de.hysky.skyblocker.utils.ItemUtils;
-import de.hysky.skyblocker.utils.NEURepoManager;
-import de.hysky.skyblocker.utils.TextTransformer;
-import io.github.moulberry.repo.data.NEUItem;
+import de.hysky.skyblocker.utils.datafixer.LegacyItemStackFixer;
 import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.*;
-import net.minecraft.datafixer.fix.ItemIdFix;
-import net.minecraft.datafixer.fix.ItemInstanceTheFlatteningFix;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.*;
-import net.minecraft.registry.Registries;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 
 import java.io.ByteArrayInputStream;
 import java.util.*;
-import java.util.stream.Collectors;
-
-import static de.hysky.skyblocker.skyblock.itemlist.ItemRepository.getItemStack;
 
 public class ItemLoader {
 
@@ -38,107 +26,42 @@ public class ItemLoader {
         List<ItemStack> itemList = new ArrayList<>();
 
         for (int i = 0; i < containerContent.size(); i++) {
-            if (containerContent.getCompound(i).getInt("id") == 0) {
+            NbtCompound nbt = containerContent.getCompound(i);
+            if (nbt.getInt("id") == 0) {
                 itemList.add(ItemStack.EMPTY);
                 continue;
             }
 
-            NbtCompound nbttag = containerContent.getCompound(i).getCompound("tag");
-            NbtCompound extraAttributes = nbttag.getCompound("ExtraAttributes");
-            String internalName = extraAttributes.getString("id");
-            if (internalName.equals("PET")) {
-                PetCache.PetInfo petInfo = PetCache.PetInfo.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(extraAttributes.getString("petInfo"))).getOrThrow();
+            ItemStack stack = LegacyItemStackFixer.fixLegacyStack(nbt);
+
+            if (stack.isEmpty()) {
+            	ItemStack fallback = Ico.BARRIER.copy();
+
+            	fallback.set(DataComponentTypes.CUSTOM_NAME, Text.literal("Error: " + nbt.getCompound("tag").getCompound("ExtraAttributes").getString("id")));
+                itemList.add(fallback);
+
+                continue;
+            }
+
+            String itemId = stack.getSkyblockId();
+            NbtCompound customData = ItemUtils.getCustomData(stack);
+
+            if (itemId.equals("PET")) {
+                PetCache.PetInfo petInfo = PetCache.PetInfo.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(customData.getString("petInfo"))).getOrThrow();
                 Pet pet = new Pet(petInfo);
                 itemList.add(pet.getIcon());
                 continue;
             }
 
-            Identifier itemId = identifierFromOldId(containerContent.getCompound(i).getInt("id"), containerContent.getCompound(i).getInt("Damage"));
-
-            ItemStack stack;
-            if (itemId.toString().equals("minecraft:air")) {
-                ItemStack itemStack = getItemStack(internalName);
-                stack = itemStack != null ? itemStack.copy() : ItemStack.EMPTY;
-            } else {
-                stack = new ItemStack(Registries.ITEM.get(itemId));
-            }
-
-            if (stack.isEmpty() || stack.getItem().equals(Ico.BARRIER.getItem())) {
-                // Last ditch effort to find item in NEU REPO
-                Map<String, NEUItem> items = NEURepoManager.NEU_REPO.getItems().getItems();
-                stack = items.values().stream()
-                        .filter(j -> Formatting.strip(j.getSkyblockItemId()).equals(Formatting.strip(internalName).replace(":", "-")))
-                        .findFirst()
-                        .map(NEUItem::getSkyblockItemId)
-                        .map(ItemRepository::getItemStack)
-                        .map(ItemStack::copy)
-                        .orElse(Ico.BARRIER.copy());
-
-
-                if (stack.getName().getString().contains("barrier")) {
-                    stack.set(DataComponentTypes.CUSTOM_NAME, Text.literal("Err: " + internalName));
-                    itemList.add(stack);
-                    continue;
-                }
-            }
-
-            // Custom Data
-            NbtCompound customData = new NbtCompound();
-
-            // Add Skyblock Item Id
-            customData.put(ItemUtils.ID, NbtString.of(internalName));
-
-
-            // Item Name
-            stack.set(DataComponentTypes.CUSTOM_NAME, TextTransformer.fromLegacy(nbttag.getCompound("display").getString("Name")));
-
-            // Lore
-            NbtList loreList = nbttag.getCompound("display").getList("Lore", 8);
-            stack.set(DataComponentTypes.LORE, new LoreComponent(loreList.stream()
-                    .map(NbtElement::asString)
-                    .map(TextTransformer::fromLegacy)
-                    .collect(Collectors.toList())));
-
-            // add skull texture
-            NbtList texture = nbttag.getCompound("SkullOwner").getCompound("Properties").getList("textures", 10);
-            if (!texture.isEmpty()) {
-                stack.set(DataComponentTypes.PROFILE, new ProfileComponent(Optional.of(internalName), Optional.of(UUID.fromString(nbttag.getCompound("SkullOwner").get("Id").asString())), ItemUtils.propertyMapWithTexture(texture.getCompound(0).getString("Value"))));
-            }
-
-            // Colour
-            if (nbttag.getCompound("display").contains("color")) {
-                int color = nbttag.getCompound("display").getInt("color");
-                stack.set(DataComponentTypes.DYED_COLOR, new DyedColorComponent(color, false));
-            }
-
-            // add enchantment glint
-            if (nbttag.getKeys().contains("ench")) {
-                stack.set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true);
-            }
-
-            // Hide weapon damage and other useless info
-            stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, new AttributeModifiersComponent(List.of(), false));
-
-            // Set Count
-            stack.setCount(containerContent.getCompound(i).getInt("Count"));
-
             // Attach an override for Aaron's Mod so that these ItemStacks will work with the mod's features even when not in Skyblock
-            extraAttributes.put("aaron-mod", Util.make(new NbtCompound(), comp -> comp.putBoolean("alwaysDisplaySkyblockInfo", true)));
-
-            stack.set(DataComponentTypes.CUSTOM_DATA, NbtComponent.of(extraAttributes));
+            if (stack.contains(DataComponentTypes.CUSTOM_DATA)) {
+                customData.put("aaron-mod", Util.make(new NbtCompound(), comp -> comp.putBoolean("alwaysDisplaySkyblockInfo", true)));
+            }
 
             itemList.add(stack);
         }
 
         return itemList;
-    }
-
-    private static Identifier identifierFromOldId(int id, int damage) {
-        try {
-            return damage != 0 ? Identifier.of(ItemInstanceTheFlatteningFix.getItem(ItemIdFix.fromId(id), damage)) : Identifier.of(ItemIdFix.fromId(id));
-        } catch (Exception e) {
-            return Identifier.of("air");
-        }
     }
 
     private static NbtList decompress(JsonObject data) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/special/DyeSpecialEffects.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/special/DyeSpecialEffects.java
@@ -22,7 +22,7 @@ public class DyeSpecialEffects {
 	private static final Logger LOGGER = LogUtils.getLogger();
 	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
 	@VisibleForTesting
-	protected static final Pattern DROP_PATTERN = Pattern.compile("WOW! (?:\\[[A-Z+]+\\] )?(?<player>[A-Za-z0-9_]+) found (?<dye>[A-Za-z ]+ Dye) #[\\d,]+!");
+	protected static final Pattern DROP_PATTERN = Pattern.compile("WOW! (?:\\[[A-Z+]+\\] )?(?<player>[A-Za-z0-9_]+) found (?<dye>[A-Za-z ]+ Dye)(?: #[\\d,]+)?!");
 
 	static void init() {
 		ClientReceiveMessageEvents.GAME.register(DyeSpecialEffects::displayDyeDropEffect);

--- a/src/main/java/de/hysky/skyblocker/utils/datafixer/LegacyItemStackFixer.java
+++ b/src/main/java/de/hysky/skyblocker/utils/datafixer/LegacyItemStackFixer.java
@@ -65,7 +65,7 @@ public class LegacyItemStackFixer {
 		stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT.withShowInTooltip(false));
 
 		//Hide Vanilla Enchantments
-		stack.set(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT.withShowInTooltip(false));
+		stack.set(DataComponentTypes.ENCHANTMENTS, stack.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT).withShowInTooltip(false));
 
 		return stack;
 	}

--- a/src/main/java/de/hysky/skyblocker/utils/datafixer/LegacyItemStackFixer.java
+++ b/src/main/java/de/hysky/skyblocker/utils/datafixer/LegacyItemStackFixer.java
@@ -1,0 +1,76 @@
+package de.hysky.skyblocker.utils.datafixer;
+
+import static net.azureaaron.legacyitemdfu.LegacyItemStackFixer.getFixer;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+
+import static net.azureaaron.legacyitemdfu.LegacyItemStackFixer.FIRST_VERSION;
+import static net.azureaaron.legacyitemdfu.LegacyItemStackFixer.LATEST_VERSION;
+
+import com.mojang.logging.LogUtils;
+import com.mojang.serialization.Dynamic;
+
+import de.hysky.skyblocker.utils.TextTransformer;
+import net.azureaaron.legacyitemdfu.TypeReferences;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.component.type.LoreComponent;
+import net.minecraft.component.type.NbtComponent;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.registry.RegistryOps;
+import net.minecraft.text.Text;
+
+public class LegacyItemStackFixer {
+	private static final Logger LOGGER = LogUtils.getLogger();
+
+	//Static import things to avoid class name conflicts
+	@SuppressWarnings("deprecation")
+	public static ItemStack fixLegacyStack(NbtCompound nbt) {
+		RegistryOps<NbtElement> ops = ItemStackComponentizationFixer.getRegistryLookup().getOps(NbtOps.INSTANCE);
+		Dynamic<NbtElement> fixed = getFixer().update(TypeReferences.LEGACY_ITEM_STACK, new Dynamic<>(ops, nbt), FIRST_VERSION, LATEST_VERSION);
+		ItemStack stack = ItemStack.CODEC.parse(fixed)
+				.setPartial(ItemStack.EMPTY)
+				.resultOrPartial(LegacyItemStackFixer::log)
+				.get();
+
+		//Don't continue fixing up if it failed
+		if (stack.isEmpty()) return stack;
+
+		if (stack.contains(DataComponentTypes.CUSTOM_NAME)) {
+			stack.set(DataComponentTypes.CUSTOM_NAME, TextTransformer.fromLegacy(stack.get(DataComponentTypes.CUSTOM_NAME).getString()));
+		}
+
+		if (stack.contains(DataComponentTypes.LORE)) {
+			List<Text> fixedLore = stack.get(DataComponentTypes.LORE).lines().stream()
+					.map(Text::getString)
+					.map(TextTransformer::fromLegacy)
+					.map(Text.class::cast)
+					.toList();
+
+			stack.set(DataComponentTypes.LORE, new LoreComponent(fixedLore));
+		}
+
+		//Remap Custom Data
+		if (stack.contains(DataComponentTypes.CUSTOM_DATA)) {
+			stack.set(DataComponentTypes.CUSTOM_DATA, NbtComponent.of(stack.get(DataComponentTypes.CUSTOM_DATA).getNbt().getCompound("ExtraAttributes")));
+		}
+
+		//Hide Vanilla Attributes
+		stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT.withShowInTooltip(false));
+
+		//Hide Vanilla Enchantments
+		stack.set(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT.withShowInTooltip(false));
+
+		return stack;
+	}
+
+	private static void log(String error) {
+		LOGGER.error("[Skyblocker Legacy Item Fixer] Failed to fix up item! Error: {}", error);
+	}
+}

--- a/src/test/java/de/hysky/skyblocker/skyblock/special/DyeSpecialEffectsTest.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/special/DyeSpecialEffectsTest.java
@@ -17,6 +17,11 @@ public class DyeSpecialEffectsTest {
 
 	@Test
 	void testDye3() {
-		Assertions.assertTrue(DyeSpecialEffects.DROP_PATTERN.matcher("WOW! [MVP+] Viciscat found Cat Dye #1!").matches(), "Dye Test #3 didn't match!");
+		Assertions.assertTrue(DyeSpecialEffects.DROP_PATTERN.matcher("WOW! [MVP+] AzureAaron found Necron Dye!").matches(), "Dye Test #3 didn't match!");
+	}
+
+	@Test
+	void testDye4() {
+		Assertions.assertTrue(DyeSpecialEffects.DROP_PATTERN.matcher("WOW! [MVP+] Viciscat found Cat Dye #1!").matches(), "Dye Test #4 didn't match!");
 	}
 }


### PR DESCRIPTION
This is the result of wayy too much functional programming with DFU (or not enough!).

Basically replaces the current data fixing with a custom dfu solution from yours truly, from some testing it catches all items (and more than before since Mojang's maps are missing a few items, also compare the totem of corruption! finally not a blank white banner) and its way faster in terms of performance at fixing up item's than the game's DFU with patches.

Since this is also useful to me in Aaron Mod and maybe other people its also in a library found here: https://github.com/AzureAaron/legacy-item-dfu

Supersedes #862 