### PR TITLE
Tooltips for Item List

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -63,20 +63,9 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
         entryRegistry.addEntries(stacks);
     }
 
-    private final TooltipAdder[] adders = new TooltipAdder[]{
-        new LineSmoothener(), // Applies before anything else
-        new TrueHexDisplay(),
-        new NpcPriceTooltip(0),
-        new BazaarPriceTooltip(1),
-        new LBinTooltip(2),
-        new AvgBinTooltip(3),
-        new CraftPriceTooltip(4),
-        new DungeonQualityTooltip(5),
-        new MotesTooltip(6),
-        new MuseumTooltip(7),
-        new ColorTooltip(8),
-        new AccessoryTooltip(9),
-    };
+    private final List<TooltipAdder> adders = Arrays.stream(TooltipManager.adders)
+        .filter(adder -> adder instanceof SimpleTooltipAdder && ((SimpleTooltipAdder) adder).titlePattern != null)
+        .toList();
     private final Slot EMPTY_SLOT = new Slot(null, 0, 0, 0);
 
     public Tooltip modifyTooltip(

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -1,7 +1,8 @@
 package de.hysky.skyblocker.compatibility.rei;
 
 import de.hysky.skyblocker.SkyblockerMod;
-import de.hysky.skyblocker.skyblock.item.tooltip.adders.*;
+import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
+import de.hysky.skyblocker.skyblock.item.tooltip.TooltipManager;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.container.TooltipAdder;
 import me.shedaniel.rei.api.client.gui.widgets.Tooltip;
@@ -18,14 +19,14 @@ import net.minecraft.item.Items;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
  * REI integration
  */
 public class SkyblockerREIClientPlugin implements REIClientPlugin {
-    public static final CategoryIdentifier<SkyblockCraftingDisplay> SKYBLOCK = CategoryIdentifier.of(
-        SkyblockerMod.NAMESPACE,
+    public static final CategoryIdentifier<SkyblockCraftingDisplay> SKYBLOCK = CategoryIdentifier.of(SkyblockerMod.NAMESPACE,
         "skyblock"
     );
 
@@ -45,16 +46,12 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
         List<EntryStack<ItemStack>> stacks = ItemRepository.getItemsStream()
             .map(item -> {
                 EntryStack<ItemStack> entry = EntryStacks.of(item);
-                ClientEntryStacks.setTooltipProcessor(
-                    entry,
-                    (_entry, tooltip) -> modifyTooltip(
-                        entry.getValue(),
-                        tooltip.entries()
-                            .stream()
-                            .map(Tooltip.Entry::getAsText)
-                            .toList()
-                    )
-                );
+                ClientEntryStacks.setTooltipProcessor(entry, (_entry, tooltip) -> modifyTooltip(entry.getValue(),
+                    tooltip.entries()
+                        .stream()
+                        .map(Tooltip.Entry::getAsText)
+                        .toList()
+                ));
                 return entry;
             })
             .toList();

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -68,7 +68,7 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
         .toList();
     private final Slot EMPTY_SLOT = new Slot(null, 0, 0, 0);
 
-    public Tooltip modifyTooltip(ItemStack stack,List<Text> lines) {
+    public Tooltip modifyTooltip(ItemStack stack, List<Text> lines) {
         for (TooltipAdder adder : adders) {
             if (adder.isEnabled()) adder.addToTooltip(EMPTY_SLOT, stack, lines);
         }

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -68,10 +68,7 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
         .toList();
     private final Slot EMPTY_SLOT = new Slot(null, 0, 0, 0);
 
-    public Tooltip modifyTooltip(
-        ItemStack stack,
-        List<Text> lines
-    ) {
+    public Tooltip modifyTooltip(ItemStack stack,List<Text> lines) {
         for (TooltipAdder adder : adders) {
             if (adder.isEnabled()) adder.addToTooltip(EMPTY_SLOT, stack, lines);
         }

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -73,7 +73,7 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
         List<Text> lines
     ) {
         for (TooltipAdder adder : adders) {
-            adder.addToTooltip(EMPTY_SLOT, stack, lines);
+            if (adder.isEnabled()) adder.addToTooltip(EMPTY_SLOT, stack, lines);
         }
 
         return Tooltip.create(lines);

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -1,20 +1,33 @@
 package de.hysky.skyblocker.compatibility.rei;
 
 import de.hysky.skyblocker.SkyblockerMod;
+import de.hysky.skyblocker.skyblock.item.tooltip.adders.*;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
+import de.hysky.skyblocker.utils.container.TooltipAdder;
+import me.shedaniel.rei.api.client.gui.widgets.Tooltip;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
 import me.shedaniel.rei.api.client.registry.entry.EntryRegistry;
+import me.shedaniel.rei.api.client.util.ClientEntryStacks;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.entry.EntryStack;
 import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.text.Text;
+
+import java.util.List;
 
 /**
  * REI integration
  */
 public class SkyblockerREIClientPlugin implements REIClientPlugin {
-    public static final CategoryIdentifier<SkyblockCraftingDisplay> SKYBLOCK = CategoryIdentifier.of(SkyblockerMod.NAMESPACE, "skyblock");
+    public static final CategoryIdentifier<SkyblockCraftingDisplay> SKYBLOCK = CategoryIdentifier.of(
+        SkyblockerMod.NAMESPACE,
+        "skyblock"
+    );
 
     @Override
     public void registerCategories(CategoryRegistry categoryRegistry) {
@@ -29,6 +42,51 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
 
     @Override
     public void registerEntries(EntryRegistry entryRegistry) {
-        entryRegistry.addEntries(ItemRepository.getItemsStream().map(EntryStacks::of).toList());
+        List<EntryStack<ItemStack>> stacks = ItemRepository.getItemsStream()
+            .map(item -> {
+                EntryStack<ItemStack> entry = EntryStacks.of(item);
+                ClientEntryStacks.setTooltipProcessor(
+                    entry,
+                    (_entry, tooltip) -> modifyTooltip(
+                        entry.getValue(),
+                        tooltip.entries()
+                            .stream()
+                            .map(Tooltip.Entry::getAsText)
+                            .toList()
+                    )
+                );
+                return entry;
+            })
+            .toList();
+
+
+        entryRegistry.addEntries(stacks);
+    }
+
+    private final TooltipAdder[] adders = new TooltipAdder[]{
+        new LineSmoothener(), // Applies before anything else
+        new TrueHexDisplay(),
+        new NpcPriceTooltip(0),
+        new BazaarPriceTooltip(1),
+        new LBinTooltip(2),
+        new AvgBinTooltip(3),
+        new CraftPriceTooltip(4),
+        new DungeonQualityTooltip(5),
+        new MotesTooltip(6),
+        new MuseumTooltip(7),
+        new ColorTooltip(8),
+        new AccessoryTooltip(9),
+    };
+    private final Slot EMPTY_SLOT = new Slot(null, 0, 0, 0);
+
+    public Tooltip modifyTooltip(
+        ItemStack stack,
+        List<Text> lines
+    ) {
+        for (TooltipAdder adder : adders) {
+            adder.addToTooltip(EMPTY_SLOT, stack, lines);
+        }
+
+        return Tooltip.create(lines);
     }
 }

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -61,7 +61,10 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
     }
 
     private final List<TooltipAdder> adders = Arrays.stream(TooltipManager.adders)
-        .filter(adder -> adder instanceof SimpleTooltipAdder && ((SimpleTooltipAdder) adder).titlePattern != null)
+        .filter(adder -> {
+            if (!(adder instanceof SimpleTooltipAdder simpleTooltipAdder)) return false;
+            return simpleTooltipAdder.titlePattern == null;
+        })
         .toList();
     private final Slot EMPTY_SLOT = new Slot(null, 0, 0, 0);
 

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -26,9 +26,7 @@ import java.util.List;
  * REI integration
  */
 public class SkyblockerREIClientPlugin implements REIClientPlugin {
-    public static final CategoryIdentifier<SkyblockCraftingDisplay> SKYBLOCK = CategoryIdentifier.of(SkyblockerMod.NAMESPACE,
-        "skyblock"
-    );
+    public static final CategoryIdentifier<SkyblockCraftingDisplay> SKYBLOCK = CategoryIdentifier.of(SkyblockerMod.NAMESPACE, "skyblock");
 
     @Override
     public void registerCategories(CategoryRegistry categoryRegistry) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
@@ -21,7 +21,7 @@ import java.util.Comparator;
 import java.util.List;
 
 public class TooltipManager {
-	private static final TooltipAdder[] adders = new TooltipAdder[]{
+	public static final TooltipAdder[] adders = new TooltipAdder[]{
 			new LineSmoothener(), // Applies before anything else
 			new TrueHexDisplay(),
 			new SupercraftReminder(),

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
@@ -33,7 +33,6 @@ public class CraftPriceTooltip extends SimpleTooltipAdder {
 
     @Override
     public void addToTooltip(@Nullable Slot focusedSloFt, ItemStack stack, List<Text> lines) {
-        if (SkyblockerConfigManager.get().general.itemTooltip.enableCraftingCost == GeneralConfig.Craft.OFF) return;
         if (TooltipInfoType.LOWEST_BINS.getData() == null || TooltipInfoType.BAZAAR.getData() == null) {
             ItemTooltip.nullWarning();
             return;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
@@ -33,6 +33,7 @@ public class CraftPriceTooltip extends SimpleTooltipAdder {
 
     @Override
     public void addToTooltip(@Nullable Slot focusedSloFt, ItemStack stack, List<Text> lines) {
+        if (SkyblockerConfigManager.get().general.itemTooltip.enableCraftingCost == GeneralConfig.Craft.OFF) return;
         if (TooltipInfoType.LOWEST_BINS.getData() == null || TooltipInfoType.BAZAAR.getData() == null) {
             ItemTooltip.nullWarning();
             return;


### PR DESCRIPTION
This PR adds the following tooltips to the items in the item list. Currently this only works for the REI plugin because EMI doesn't provide the ability to add tooltip providers, without overwriting EMI's rendering part.

~~I also fixed a bug, where the Crafting Cost tooltip tried being rendered when disabled, resulting in a null error.~~
![image](https://github.com/user-attachments/assets/4378242d-4f6c-46a6-96a3-b6999d69d8ce)

EDIT: I also tried using the transformTooltip function for EntryTypes in the EntryRendererRegistry. This method is experimental and resulted somehow in the skyblock items not being rendered at all.