### PR TITLE
Make Warp Autocomplete adapt to the player's rank

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,13 +9,13 @@ loader_version=0.15.11
 
 #Fabric api
 ## 1.21.1
-fabric_api_version=0.102.0+1.21.1
+fabric_api_version=0.102.1+1.21.1
 
 # Minecraft Mods
 ## YACL (https://github.com/isXander/YetAnotherConfigLib)
 yacl_version=3.5.0+1.21
 ## HM API (https://github.com/AzureAaron/hm-api)
-hm_api_version=1.0.0+1.21
+hm_api_version=1.0.1+1.21.1
 ## Mod Menu (https://modrinth.com/mod/modmenu/versions)
 mod_menu_version = 11.0.0-beta.1
 ## REI (https://modrinth.com/mod/rei/versions?l=fabric)

--- a/src/main/java/de/hysky/skyblocker/skyblock/WarpAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/WarpAutocomplete.java
@@ -1,20 +1,26 @@
 package de.hysky.skyblocker.skyblock;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-import de.hysky.skyblocker.SkyblockerMod;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
+
+import de.hysky.skyblocker.utils.CodecUtils;
 import de.hysky.skyblocker.utils.Http;
 import de.hysky.skyblocker.utils.Utils;
+import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
+import it.unimi.dsi.fastutil.objects.Object2BooleanMaps;
+import net.azureaaron.hmapi.data.rank.PackageRank;
+import net.azureaaron.hmapi.data.rank.RankType;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.CommandSource;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
@@ -24,23 +30,36 @@ import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.lit
  */
 public class WarpAutocomplete {
     private static final Logger LOGGER = LoggerFactory.getLogger(WarpAutocomplete.class);
+    private static final Codec<Object2BooleanMap<String>> MAP_CODEC = CodecUtils.object2BooleanMapCodec(Codec.STRING);
+
     @Nullable
     public static LiteralCommandNode<FabricClientCommandSource> commandNode;
 
     public static void init() {
         CompletableFuture.supplyAsync(() -> {
             try {
-                JsonArray jsonElements = SkyblockerMod.GSON.fromJson(Http.sendGetRequest("https://hysky.de/api/locations"), JsonArray.class);
-                return jsonElements.asList().stream().map(JsonElement::getAsString).toList();
+                String warps = Http.sendGetRequest("https://hysky.de/api/locations");
+
+                return MAP_CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(warps)).getOrThrow();
             } catch (Exception e) {
                 LOGGER.error("[Skyblocker] Failed to download warps list", e);
             }
-            return List.<String>of();
+            return Object2BooleanMaps.<String>emptyMap();
         }).thenAccept(warps -> commandNode = literal("warp")
                 .requires(fabricClientCommandSource -> Utils.isOnSkyblock())
                 .then(argument("destination", StringArgumentType.string())
-                        .suggests((context, builder) -> CommandSource.suggestMatching(warps, builder))
+                        .suggests((context, builder) -> CommandSource.suggestMatching(getEligibleWarps(warps), builder))
                 ).build()
         );
+    }
+
+    private static Stream<String> getEligibleWarps(Object2BooleanMap<String> warps) {
+        return warps.object2BooleanEntrySet().stream()
+    	        .filter(WarpAutocomplete::shouldShowWarp)
+    	        .map(Object2BooleanMap.Entry::getKey);
+    }
+
+    private static boolean shouldShowWarp(Object2BooleanMap.Entry<String> entry) {
+        return entry.getBooleanValue() ? RankType.compare(Utils.getRank(), PackageRank.MVP_PLUS) >= 0 : true;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/utils/CodecUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/CodecUtils.java
@@ -1,6 +1,10 @@
 package de.hysky.skyblocker.utils;
 
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
+
+import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -18,5 +22,9 @@ public final class CodecUtils {
 
 	public static MapCodec<OptionalDouble> optionalDouble(MapCodec<Optional<Double>> codec) {
 		return codec.xmap(opt -> opt.map(OptionalDouble::of).orElseGet(OptionalDouble::empty), optDouble -> optDouble.isPresent() ? Optional.of(optDouble.getAsDouble()) : Optional.empty());
+	}
+
+	public static <K> Codec<Object2BooleanMap<K>> object2BooleanMapCodec(Codec<K> keyCodec) {
+	    return Codec.unboundedMap(keyCodec, Codec.BOOL).xmap(Object2BooleanOpenHashMap::new, Object2BooleanOpenHashMap::new);
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,9 +34,9 @@
   "accessWidener": "skyblocker.accesswidener",
   "depends": {
     "fabricloader": ">=0.15.11",
-    "fabric-api": ">=0.102.0+1.21.1",
+    "fabric-api": ">=0.102.1+1.21.1",
     "yet_another_config_lib_v3": ">=3.5.0+1.21",
-    "hm-api": ">=1.0.0+1.21",
+    "hm-api": ">=1.0.1+1.21.1",
     "minecraft": "~1.21",
     "java": ">=21"
   },


### PR DESCRIPTION
Makes the warp autocomplete feature adapt to the player's rank (only shows MVP+ warps if you are MVP+ or higher). In order to make this fancy stuff possible it required new API additions to my Mod API library so that's been updated, full change log is available at that repository if you want to read it.

Also updated and requires Fabric API 0.102.1 to avoid class path conflicts with HM API as it now compiles against that FAPI version.