### PR TITLE
Make enums translatable and fix line break issue

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.config.configs;
 
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.util.Formatting;
 
 public class DungeonsConfig {
@@ -224,11 +225,7 @@ public class DungeonsConfig {
 
             @Override
             public String toString() {
-                return switch (this) {
-                    case HIGHLIGHT -> "Highlight";
-                    case OUTLINED_HIGHLIGHT -> "Outlined Highlight";
-                    case OUTLINE -> "Outline";
-                };
+                return I18n.translate("skyblocker.config.dungeons.doorHighlight.doorHighlightType.type." + name());
             }
         }
     }

--- a/src/main/java/de/hysky/skyblocker/config/configs/EventNotificationsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/EventNotificationsConfig.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.config.configs;
 
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
 
@@ -22,7 +23,12 @@ public class EventNotificationsConfig {
         NONE,
         SKYBLOCK,
         HYPIXEL,
-        EVERYWHERE
+        EVERYWHERE;
+
+        @Override
+        public String toString() {
+            return I18n.translate("skyblocker.config.eventNotifications.criterion." + name());
+        }
     }
 
     public enum Sound {
@@ -32,13 +38,19 @@ public class EventNotificationsConfig {
         PLING(SoundEvents.BLOCK_NOTE_BLOCK_PLING.value()),
         GOAT(SoundEvents.GOAT_HORN_SOUNDS.getFirst().value());
 
+        private final SoundEvent soundEvent;
+
+        Sound(SoundEvent soundEvent) {
+            this.soundEvent = soundEvent;
+        }
+
         public SoundEvent getSoundEvent() {
             return soundEvent;
         }
 
-        final SoundEvent soundEvent;
-        Sound(SoundEvent soundEvent) {
-            this.soundEvent = soundEvent;
+        @Override
+        public String toString() {
+            return I18n.translate("skyblocker.config.eventNotifications.notificationSound.sound." + name());
         }
     }
 }

--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -202,10 +202,7 @@ public class GeneralConfig {
 
         @Override
         public String toString() {
-            return switch (this) {
-                case CIRCULAR -> "Circular";
-                case SQUARE -> "Square";
-            };
+            return I18n.translate("skyblocker.config.general.itemInfoDisplay.itemRarityBackgroundStyle.style." + name());
         }
     }
 
@@ -226,10 +223,7 @@ public class GeneralConfig {
 
         @Override
         public String toString() {
-            return switch (this) {
-                case CLASSIC -> "Classic";
-                case FANCY -> "FANCY";
-            };
+            return I18n.translate("skyblocker.config.general.itemProtection.slotLockStyle.style." + name());
         }
     }
 

--- a/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.config.configs;
 
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
+import net.minecraft.client.resource.language.I18n;
 
 import java.awt.*;
 
@@ -133,12 +134,7 @@ public class MiningConfig {
 
         @Override
         public String toString() {
-            return switch (this) {
-                case OFF -> "Off";
-                case DWARVEN -> "Dwarven";
-                case GLACITE -> "Glacite";
-                case BOTH -> "Both";
-            };
+            return I18n.translate("skyblocker.config.mining.commissionWaypoints.mode." + name());
         }
     }
 

--- a/src/main/java/de/hysky/skyblocker/config/configs/QuickNavigationConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/QuickNavigationConfig.java
@@ -68,7 +68,8 @@ public class QuickNavigationConfig {
         /**
          * Default constructor or else gson skips initialization.
          */
-        private QuickNavItem() {}
+        @SuppressWarnings("unused")
+		private QuickNavItem() {}
 
         public QuickNavItem(ItemData itemData, String clickEvent, String tooltip) {
             this(itemData, "none", clickEvent, tooltip);

--- a/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.config.configs;
 
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
+import net.minecraft.client.resource.language.I18n;
 
 public class SlayersConfig {
     @SerialEntry
@@ -10,7 +11,12 @@ public class SlayersConfig {
     public HighlightSlayerEntities highlightBosses = HighlightSlayerEntities.OFF;
 
     public enum HighlightSlayerEntities {
-        OFF, GLOW, HITBOX
+        OFF, GLOW, HITBOX;
+
+        @Override
+        public String toString() {
+            return I18n.translate("skyblocker.config.slayer.highlightBosses." + name());
+        }
     }
 
     @SerialEntry
@@ -79,19 +85,13 @@ public class SlayersConfig {
         public Boolean attunementHighlights = true;
 
         public enum FirePillar {
-            OFF("Off"),
-            VISUAL("Visual Indicator"),
-            SOUND_AND_VISUAL("Sound and Visual Indicator");
-
-            private final String description;
-
-            FirePillar(String description) {
-                this.description = description;
-            }
+            OFF,
+            VISUAL,
+            SOUND_AND_VISUAL;
 
             @Override
             public String toString() {
-                return description;
+                return I18n.translate("skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer.mode." + name());
             }
         }
     }

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.config.configs;
 
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.util.Formatting;
 
 import java.awt.*;
@@ -104,10 +105,7 @@ public class UIAndVisualsConfig {
 
         @Override
         public String toString() {
-            return switch (this) {
-                case HORIZONTAL -> "Horizontal";
-                case VERTICAL -> "Vertical";
-            };
+            return I18n.translate("skyblocker.config.uiAndVisuals.titleContainer.direction." + name());
         }
     }
 
@@ -116,11 +114,7 @@ public class UIAndVisualsConfig {
 
         @Override
         public String toString() {
-            return switch (this) {
-                case LEFT -> "Left";
-                case RIGHT -> "Right";
-                case MIDDLE -> "Middle";
-            };
+            return I18n.translate("skyblocker.config.uiAndVisuals.titleContainer.alignment." + name());
         }
     }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/bazaar/ReorderHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/bazaar/ReorderHelper.java
@@ -60,7 +60,6 @@ public class ReorderHelper extends SimpleContainerSolver implements TooltipAdder
 			case 11, 13 -> {
 				lines.add(Text.empty());
 				lines.add(Text.empty().append(Text.translatable("skyblocker.reorderHelper.tooltip.line1")).formatted(Formatting.DARK_GRAY, Formatting.ITALIC));
-				lines.add(Text.empty().append(Text.translatable("skyblocker.reorderHelper.tooltip.line2")).formatted(Formatting.DARK_GRAY, Formatting.ITALIC));
 			}
 		}
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/bazaar/ReorderHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/bazaar/ReorderHelper.java
@@ -59,7 +59,7 @@ public class ReorderHelper extends SimpleContainerSolver implements TooltipAdder
 		switch (focusedSlot.id) {
 			case 11, 13 -> {
 				lines.add(Text.empty());
-				lines.add(Text.empty().append(Text.translatable("skyblocker.reorderHelper.tooltip.line1")).formatted(Formatting.DARK_GRAY, Formatting.ITALIC));
+				lines.add(Text.empty().append(Text.translatable("skyblocker.reorderHelper.tooltip")).formatted(Formatting.DARK_GRAY, Formatting.ITALIC));
 			}
 		}
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextMode.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextMode.java
@@ -1,5 +1,7 @@
 package de.hysky.skyblocker.skyblock.item.slottext;
 
+import net.minecraft.client.resource.language.I18n;
+
 /**
  * Used in {@link SlotTextManager#isEnabled()} to determine whether the slot text should be shown or not.
  */
@@ -12,12 +14,6 @@ public enum SlotTextMode {
 
 	@Override
 	public String toString() {
-		return switch (this) {
-			case ENABLED         -> "Enabled";
-			case HOLD_TO_SHOW    -> "Hold to Show";
-			case PRESS_TO_TOGGLE -> "Press to Toggle";
-			case HOLD_TO_HIDE    -> "Hold to Hide";
-			case DISABLED        -> "Disabled";
-		};
+		return I18n.translate("skyblocker.config.general.itemInfoDisplay.slotText.mode." + name());
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
+++ b/src/main/java/de/hysky/skyblocker/utils/waypoint/Waypoint.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.utils.waypoint;
 import de.hysky.skyblocker.utils.render.RenderHelper;
 import de.hysky.skyblocker.utils.render.Renderable;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.util.StringIdentifiable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
@@ -141,13 +142,7 @@ public class Waypoint implements Renderable {
 
         @Override
         public String toString() {
-            return switch (this) {
-                case WAYPOINT -> "Waypoint";
-                case OUTLINED_WAYPOINT -> "Outlined Waypoint";
-                case HIGHLIGHT -> "Highlight";
-                case OUTLINED_HIGHLIGHT -> "Outlined Highlight";
-                case OUTLINE -> "Outline";
-            };
+            return I18n.translate("skyblocker.waypoints.type." + name());
         }
     }
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -931,7 +931,7 @@
   "skyblocker.customItemNames.removed": "§fRemoved this item's custom name.",
   "skyblocker.customItemNames.neverHad": "§fThis item doesn't have a custom name set, but why not add one? ;)",
   "skyblocker.customItemNames.added": "§fSet a custom name for your currently held item!",
-  "skyblocker.customItemNames.noItemUuid": "§cYou must be holding an item that has an uuid to set a custom name!",
+  "skyblocker.customItemNames.noItemUuid": "§cYou must be holding an item that has a uuid to set a custom name!",
   "skyblocker.customItemNames.unableToSetName": "§cUnable to set a custom item name :( (Are you in skyblock?, are you holding an item?)",
 
   "skyblocker.customDyeColors.invalidHex": "§cInvalid HEX color code!",
@@ -939,7 +939,7 @@
   "skyblocker.customDyeColors.removed": "§fRemoved this item's custom dye color.",
   "skyblocker.customDyeColors.neverHad": "§fThis item doesn't have a custom dye color set, but why not add one? ;)",
   "skyblocker.customDyeColors.added": "§fSet a custom dye color for your currently held item!",
-  "skyblocker.customDyeColors.noItemUuid": "§cYou must be holding an item that has an uuid to set a custom dye color!",
+  "skyblocker.customDyeColors.noItemUuid": "§cYou must be holding an item that has a uuid to set a custom dye color!",
   "skyblocker.customDyeColors.unableToSetColor": "§cUnable to set a custom dye color :( (Are you in skyblock?, are you holding an item?)",
 
   "skyblocker.customArmorTrims.invalidMaterialOrPattern": "§cYou supplied either an invalid material or an invalid trim pattern!",
@@ -947,7 +947,7 @@
   "skyblocker.customArmorTrims.removed": "§fRemoved this item's custom armor trim.",
   "skyblocker.customArmorTrims.neverHad": "§fThis item doesn't have an armor trim set, but why not add one? ;)",
   "skyblocker.customArmorTrims.added": "§fSet a custom armor trim for your currently held item!",
-  "skyblocker.customArmorTrims.noItemUuid": "§cYou must be holding an item that has an uuid to set a custom armor trim!",
+  "skyblocker.customArmorTrims.noItemUuid": "§cYou must be holding an item that has a uuid to set a custom armor trim!",
   "skyblocker.customArmorTrims.unableToSetTrim": "§cUnable to set a custom armor trim :( (Are you in skyblock?, are you holding an item?)",
 
   "skyblocker.customAnimatedDyes.invalidHex": "§cAn invalid HEX color code was supplied!",
@@ -955,7 +955,7 @@
   "skyblocker.customAnimatedDyes.removed": "Removed this item's custom animated dye.",
   "skyblocker.customAnimatedDyes.neverHad": "This item doesn't have a custom animated dye set, but why not add one? ;)",
   "skyblocker.customAnimatedDyes.added": "Set a custom animated dye for your currently held item!",
-  "skyblocker.customAnimatedDyes.noItemUuid": "§cYou must be holding an item that has an uuid to set a custom animated dye.",
+  "skyblocker.customAnimatedDyes.noItemUuid": "§cYou must be holding an item that has a uuid to set a custom animated dye.",
   "skyblocker.customAnimatedDyes.unableToSetDye": "§cUnable to set a custom animated dye :( (Are you in skyblock?, are you holding an item?)",
 
   "skyblocker.quiverWarning.50Left": "You only have 50 Arrows left in your Quiver!",
@@ -964,7 +964,7 @@
 
   "skyblocker.itemProtection.added": "§fYour %s will now be protected! §o*your item now feels a little safer :')*",
   "skyblocker.itemProtection.removed": "§fYour %s will §nno longer be protected§f :( - §lBeware of the dangers in doing this!",
-  "skyblocker.itemProtection.noItemUuid": "§cYou must be holding an item that has an uuid to protect it!",
+  "skyblocker.itemProtection.noItemUuid": "§cYou must be holding an item that has a uuid to protect it!",
   "skyblocker.itemProtection.unableToProtect": "§cUnable to protect this item :( (Are you in skyblock?, are you holding an item?)",
 
   "skyblocker.tips.enabled": "§aEnabled Tips.",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1029,7 +1029,7 @@
   "skyblocker.partyFinder.deList": "Click to de-list",
   "skyblocker.partyFinder.join": "Click to join",
 
-  "skyblocker.reorderHelper.tooltip.line1": "[Skyblocker] You can copy the amount of items\nby holding CTRL while clicking on the item!",
+  "skyblocker.reorderHelper.tooltip": "[Skyblocker] You can copy the amount of items\nby holding CTRL while clicking on the item!",
 
   "skyblocker.fancyAuctionHouse.editBid": "Click to edit bid!",
   "skyblocker.fancyAuctionHouse.price": "Price:",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -72,6 +72,9 @@
 
   "skyblocker.config.dungeons.doorHighlight": "Door Highlight",
   "skyblocker.config.dungeons.doorHighlight.doorHighlightType": "Door Highlight Type",
+  "skyblocker.config.dungeons.doorHighlight.doorHighlightType.type.HIGHLIGHT": "Highlight",
+  "skyblocker.config.dungeons.doorHighlight.doorHighlightType.type.OUTLINED_HIGHLIGHT": "Outlined Highlight",
+  "skyblocker.config.dungeons.doorHighlight.doorHighlightType.type.OUTLINE": "Outline",
   "skyblocker.config.dungeons.doorHighlight.doorHighlightType.@Tooltip": "Highlight: Only displays a highlight.\n\nOutlined Highlight: Displays both a highlight and an outline.\n\nOutline: Only displays an outline.",
   "skyblocker.config.dungeons.doorHighlight.doorHighlightType.secretWaypointsNote": "\n\n\nNote: Dungeon Secret Waypoints must be enabled for this to work.",
   "skyblocker.config.dungeons.doorHighlight.enableDoorHighlight": "Enable Door Highlight",
@@ -226,9 +229,6 @@
 
   "skyblocker.config.general.acceptReparty": "Auto accept Reparty",
 
-  "skyblocker.config.uiAndVisuals.hideEmptyTooltips": "Hide empty item tooltips in menus",
-  "skyblocker.config.uiAndVisuals.hideEmptyTooltips.@Tooltip": "Hides the tooltip of an item if it doesn't have any information to display. Also blocks clicks on filler items like glass panes.",
-
   "skyblocker.config.general.hitbox": "Hitboxes",
   "skyblocker.config.general.hitbox.oldFarmlandHitbox": "Enable 1.8 farmland hitbox",
   "skyblocker.config.general.hitbox.oldLeverHitbox": "Enable 1.8 lever hitbox",
@@ -238,11 +238,18 @@
   "skyblocker.config.general.itemInfoDisplay.attributeShardInfo.@Tooltip": "Displays the attribute's level and the initials of the attribute's name on the slot containing the item.",
   "skyblocker.config.general.itemInfoDisplay.itemRarityBackgroundStyle": "Item Rarity Background Style",
   "skyblocker.config.general.itemInfoDisplay.itemRarityBackgroundStyle.@Tooltip": "Choose between a circular or a square background style!",
+  "skyblocker.config.general.itemInfoDisplay.itemRarityBackgroundStyle.style.CIRCULAR": "Circular",
+  "skyblocker.config.general.itemInfoDisplay.itemRarityBackgroundStyle.style.SQUARE": "Square",
   "skyblocker.config.general.itemInfoDisplay.itemRarityBackgrounds": "Item Rarity Backgrounds",
   "skyblocker.config.general.itemInfoDisplay.itemRarityBackgrounds.@Tooltip": "Displays a colored background behind an item, the color represents the item's rarity.",
   "skyblocker.config.general.itemInfoDisplay.itemRarityBackgroundsOpacity": "Item Rarity Backgrounds Opacity",
   "skyblocker.config.general.itemInfoDisplay.slotText": "Slot Text",
   "skyblocker.config.general.itemInfoDisplay.slotText.@Tooltip": "Displays information such as enchantment book level, minion level, pet level, potion level, prehistoric egg blocks walked, rancher's boots speed cap, and skill level",
+  "skyblocker.config.general.itemInfoDisplay.slotText.mode.ENABLED": "Enabled",
+  "skyblocker.config.general.itemInfoDisplay.slotText.mode.HOLD_TO_SHOW": "Hold to Show",
+  "skyblocker.config.general.itemInfoDisplay.slotText.mode.PRESS_TO_TOGGLE": "Press to Toggle",
+  "skyblocker.config.general.itemInfoDisplay.slotText.mode.HOLD_TO_HIDE": "Hold to Hide",
+  "skyblocker.config.general.itemInfoDisplay.slotText.mode.DISABLED": "Disabled",
 
   "skyblocker.config.general.itemList": "Item List",
   "skyblocker.config.general.itemList.enableItemList": "Enable Item List",
@@ -250,6 +257,8 @@
   "skyblocker.config.general.itemProtection": "Item Protection",
   "skyblocker.config.general.itemProtection.slotLockStyle": "Slot Lock Icon Style",
   "skyblocker.config.general.itemProtection.slotLockStyle.@Tooltip": "Choose between the fancy or the classic slot lock icon.",
+  "skyblocker.config.general.itemProtection.slotLockStyle.style.CLASSIC": "Classic",
+  "skyblocker.config.general.itemProtection.slotLockStyle.style.FANCY": "Fancy",
 
   "skyblocker.config.general.itemTooltip": "Item Tooltip",
   "skyblocker.config.general.itemTooltip.avg": "Average Type",
@@ -464,8 +473,17 @@
   "skyblocker.config.eventNotifications": "Event Notifications",
 
   "skyblocker.config.eventNotifications.criterion": "Notification Criterion",
+  "skyblocker.config.eventNotifications.criterion.NONE": "None",
+  "skyblocker.config.eventNotifications.criterion.SKYBLOCK": "SkyBlock",
+  "skyblocker.config.eventNotifications.criterion.HYPIXEL": "Hypixel",
+  "skyblocker.config.eventNotifications.criterion.EVERYWHERE": "Everywhere",
   "skyblocker.config.eventNotifications.monologue": "can you pls log onto skyblock rq pls? that would be cool cuz like if you are seeing dis then it means that ur config either got cleared or that this is ur first time using the mod if so then thanks for choosing it and hopefully you enjoy it! so yea this is where you will be able to set reminders for all events in skyblock they will be added as you encounter so you first need to log onto skyblock so yea hope you enjoy the mod and all that",
   "skyblocker.config.eventNotifications.notificationSound": "Notification Sound",
+  "skyblocker.config.eventNotifications.notificationSound.sound.NONE": "None",
+  "skyblocker.config.eventNotifications.notificationSound.sound.BELL": "Bell",
+  "skyblocker.config.eventNotifications.notificationSound.sound.DING": "Ding",
+  "skyblocker.config.eventNotifications.notificationSound.sound.PLING": "Pling",
+  "skyblocker.config.eventNotifications.notificationSound.sound.GOAT": "Goat",
   "skyblocker.config.eventNotifications.@Tooltip[0]": "Configure how much time before an event you will be reminded with a notification toast! For example if you set '5m' and '30s' in the list, you will receive a notification 5 minutes before and another 30 seconds before an event starts.",
   "skyblocker.config.eventNotifications.@Tooltip[1]": "The order doesn't matter. If you want to disable notifications, just empty the list.",
   "skyblocker.config.eventNotifications.@Tooltip[2]": "This list will modify the '%s' event",
@@ -479,6 +497,10 @@
   "skyblocker.config.mining.commissionWaypoints.mode.@Tooltip[2]": "\nGlacite: Show waypoints only in glacite tunnels.",
   "skyblocker.config.mining.commissionWaypoints.mode.@Tooltip[3]": "\nBoth: Show waypoints in dwarven mines and glacite tunnels.",
   "skyblocker.config.mining.commissionWaypoints.mode.@Tooltip[4]": "\n(takes effect when commissions updated)",
+  "skyblocker.config.mining.commissionWaypoints.mode.OFF": "Off",
+  "skyblocker.config.mining.commissionWaypoints.mode.DWARVEN": "Dwarven",
+  "skyblocker.config.mining.commissionWaypoints.mode.GLACITE": "Glacite",
+  "skyblocker.config.mining.commissionWaypoints.mode.BOTH": "Both",
   "skyblocker.config.mining.commissionWaypoints.useColor": "Colored Waypoints",
   "skyblocker.config.mining.commissionWaypoints.useColor.@Tooltip": "Color the waypoint text to match the block it's for.",
   "skyblocker.config.mining.commissionWaypoints.textScale": "Text Scale",
@@ -616,6 +638,9 @@
   "skyblocker.config.slayer.blazeSlayer": "Blaze Slayer",
   "skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer" : "Fire Pillar Countdown Notifications",
   "skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer.@Tooltip": "Countdowns the last five seconds before the Fire Pillar explodes. Configure 'Title Container' to customise the location on the HUD (Note: This only uses a rudimentary distance check, so the Pillar may be spawned by another player's slayer)",
+  "skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer.mode.OFF": "Off",
+  "skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer.mode.VISUAL": "Visual Indicator",
+  "skyblocker.config.slayer.blazeSlayer.enableFirePillarAnnouncer.mode.SOUND_AND_VISUAL": "Sound and Visual Indicator",
   "skyblocker.config.slayer.blazeSlayer.attunementHighlights" : "Attunement Highlights",
   "skyblocker.config.slayer.blazeSlayer.attunementHighlights.@Tooltip": "If Boss Highlighting is on, applies a color matching the current attunement to the selected effect.",
 
@@ -634,6 +659,9 @@
   "skyblocker.config.slayer.highlightBosses.@Tooltip[1]": "\nGLOW: Creates a glow effect on Slayer Bosses. Due to technical limitations, there is a small chance of this option making mistakes in mob detection",
   "skyblocker.config.slayer.highlightBosses.@Tooltip[2]": "\nHITBOX: Display a Hitbox around the Slayer Boss",
   "skyblocker.config.slayer.highlightBosses.@Tooltip[3]": "\nThis option is required for Blazeslayer Attunement Highlighting",
+  "skyblocker.config.slayer.highlightBosses.OFF": "Off",
+  "skyblocker.config.slayer.highlightBosses.GLOW": "Glow",
+  "skyblocker.config.slayer.highlightBosses.HITBOX": "Hitbox",
 
   "skyblocker.config.slayer.vampireSlayer": "Vampire Slayer",
   "skyblocker.config.slayer.vampireSlayer.compactEffigyWaypoints": "Compact Effigy Waypoints",
@@ -693,6 +721,9 @@
   "skyblocker.config.uiAndVisuals.flameOverlay.flameOpacity": "Flame Opacity",
   "skyblocker.config.uiAndVisuals.flameOverlay.flameOpacity.@Tooltip": "100%  default opacity\n0%     off",
 
+  "skyblocker.config.uiAndVisuals.hideEmptyTooltips": "Hide empty item tooltips in menus",
+  "skyblocker.config.uiAndVisuals.hideEmptyTooltips.@Tooltip": "Hides the tooltip of an item if it doesn't have any information to display. Also blocks clicks on filler items like glass panes.",
+
   "skyblocker.config.uiAndVisuals.inputCalculator": "Input Calculator",
   "skyblocker.config.uiAndVisuals.inputCalculator.enabled": "Enable Sign Calculator",
   "skyblocker.config.uiAndVisuals.inputCalculator.enabled.@Tooltip": "Enables the ability for you to do calculations when inputting values such as price for the ah.\n Key:\n  S = 64\n  E = 160\n  K = 1,000\n  M = 1,000,000\n  B = 1,000,000,000\n\n purse/P = current purse value",
@@ -740,7 +771,12 @@
 
   "skyblocker.config.uiAndVisuals.titleContainer": "Title Container",
   "skyblocker.config.uiAndVisuals.titleContainer.@Tooltip": "Used to display multiple titles at once, Example use: Vampire Slayer",
+  "skyblocker.config.uiAndVisuals.titleContainer.alignment.LEFT": "Left",
+  "skyblocker.config.uiAndVisuals.titleContainer.alignment.RIGHT": "Right",
+  "skyblocker.config.uiAndVisuals.titleContainer.alignment.MIDDLE": "Middle",
   "skyblocker.config.uiAndVisuals.titleContainer.config": "Title Container Placement Config...",
+  "skyblocker.config.uiAndVisuals.titleContainer.direction.HORIZONTAL": "Horizontal",
+  "skyblocker.config.uiAndVisuals.titleContainer.direction.VERTICAL": "Vertical",
   "skyblocker.config.uiAndVisuals.titleContainer.titleContainerScale": "Title Container Scale",
 
   "skyblocker.config.uiAndVisuals.waypoints": "Waypoints",
@@ -993,8 +1029,7 @@
   "skyblocker.partyFinder.deList": "Click to de-list",
   "skyblocker.partyFinder.join": "Click to join",
 
-  "skyblocker.reorderHelper.tooltip.line1": "[Skyblocker] You can copy the amount of items",
-  "skyblocker.reorderHelper.tooltip.line2": "by holding CTRL while clicking on the item!",
+  "skyblocker.reorderHelper.tooltip.line1": "[Skyblocker] You can copy the amount of items\nby holding CTRL while clicking on the item!",
 
   "skyblocker.fancyAuctionHouse.editBid": "Click to edit bid!",
   "skyblocker.fancyAuctionHouse.price": "Price:",
@@ -1050,6 +1085,12 @@
   "skyblocker.waypoints.ordered.import.coleWeight.groupAlreadyExists": "§cThere is already an ordered waypoints group under the name \"%s\", please choose another name to import your waypoints under.",
   "skyblocker.waypoints.ordered.import.coleWeight.success": "Successfully imported waypoints from the Cole Weight format.",
   "skyblocker.waypoints.ordered.import.coleWeight.fail": "§cFailed to import waypoints from the Cole Weight format. Make sure to have the waypoint data copied to your clipboard!",
+
+  "skyblocker.waypoints.type.WAYPOINT": "Waypoint",
+  "skyblocker.waypoints.type.OUTLINED_WAYPOINT": "Outlined Waypoint",
+  "skyblocker.waypoints.type.HIGHLIGHT": "Highlight",
+  "skyblocker.waypoints.type.OUTLINED_HIGHLIGHT": "Outlined Highlight",
+  "skyblocker.waypoints.type.OUTLINE": "Outline",
 
   "skyblocker.profileviewer.inventory.inventory": "Inventory",
   "skyblocker.profileviewer.inventory.armor": "Armor",


### PR DESCRIPTION
Fixes #846

Note that tab hud related enums have not been made translatable due to #816 modifying/removing them. The `Formatting` enum options for chest value/profit have also not been made translatable due to the usage of a vanilla enum that we cannot control the `toString` output for (well we could inject the NameableEnum interface or whatever but that's probably not a good idea).