### PR TITLE
Change Rarity Background Default Settings

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -181,10 +181,10 @@ public class GeneralConfig {
         public boolean attributeShardInfo = true;
 
         @SerialEntry
-        public boolean itemRarityBackgrounds = false;
+        public boolean itemRarityBackgrounds = true;
 
         @SerialEntry
-        public RarityBackgroundStyle itemRarityBackgroundStyle = RarityBackgroundStyle.CIRCULAR;
+        public RarityBackgroundStyle itemRarityBackgroundStyle = RarityBackgroundStyle.SQUARE;
 
         @SerialEntry
         public float itemRarityBackgroundsOpacity = 1f;


### PR DESCRIPTION
Most people I've seen have this feature enabled (in 1.8 and 1.21), and the square style is a little better fit to the vanilla style.