### PR TITLE
Mixins Review

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerEntityMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerEntityMixin.java
@@ -49,17 +49,17 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
     }
 
     @Inject(method = "openEditSignScreen", at = @At("HEAD"), cancellable = true)
-    public void skyblocker$redirectEditSignScreen(SignBlockEntity sign, boolean front, CallbackInfo callbackInfo) {
+    public void skyblocker$redirectEditSignScreen(SignBlockEntity sign, boolean front, CallbackInfo ci) {
         // Fancy Party Finder
         if (!PartyFinderScreen.isInKuudraPartyFinder && client.currentScreen instanceof PartyFinderScreen partyFinderScreen && !partyFinderScreen.isAborted() && sign.getText(front).getMessage(3, false).getString().toLowerCase().contains("level")) {
             partyFinderScreen.updateSign(sign, front);
-            callbackInfo.cancel();
+            ci.cancel();
             return;
         }
 
         if (client.currentScreen instanceof AuctionViewScreen auctionViewScreen) {
             this.client.setScreen(new EditBidPopup(auctionViewScreen, sign, front, auctionViewScreen.minBid));
-            callbackInfo.cancel();
+            ci.cancel();
         }
 
         // Search Overlay
@@ -68,13 +68,13 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
                 if (sign.getText(front).getMessage(3, false).getString().equalsIgnoreCase("enter query")) {
                     SearchOverManager.updateSign(sign, front, true);
                     client.setScreen(new OverlayScreen(Text.of("")));
-                    callbackInfo.cancel();
+                    ci.cancel();
                 }
             } else if (SkyblockerConfigManager.get().uiAndVisuals.searchOverlay.enableBazaar && client.currentScreen.getTitle().getString().toLowerCase().contains("bazaar")) {
                 if (sign.getText(front).getMessage(3, false).getString().equalsIgnoreCase("enter query")) {
                     SearchOverManager.updateSign(sign, front, false);
                     client.setScreen(new OverlayScreen(Text.of("")));
-                    callbackInfo.cancel();
+                    ci.cancel();
                 }
             }
         }

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientWorldMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientWorldMixin.java
@@ -25,11 +25,10 @@ public class ClientWorldMixin {
     private void skyblocker$handleBlockUpdate(CallbackInfo ci, @Local(argsOnly = true) BlockPos pos, @Local(argsOnly = true) BlockState state) {
         if (Utils.isInCrimson()) {
             DojoManager.onBlockUpdate(pos.toImmutable(), state);
-        }
-        else if (Utils.isInCrystalHollows()) {
+        } else if (Utils.isInCrystalHollows()) {
             CrystalsChestHighlighter.onBlockUpdate(pos.toImmutable(), state);
         }
+
         SimonSays.onBlockUpdate(pos, state);
-        
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/DyedColorComponentMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/DyedColorComponentMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(DyedColorComponent.class)
-public record DyedColorComponentMixin() {
+public class DyedColorComponentMixin {
 
 	@ModifyReturnValue(method = "getColor", at = @At("RETURN"))
 	private static int skyblocker$customDyeColor(int originalColor, @Local(argsOnly = true) ItemStack stack) {

--- a/src/main/java/de/hysky/skyblocker/mixins/GenericContainerScreenHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/GenericContainerScreenHandlerMixin.java
@@ -31,7 +31,7 @@ public abstract class GenericContainerScreenHandlerMixin extends ScreenHandler {
         switch (currentScreen) {
             case PartyFinderScreen screen -> screen.markDirty();
             case GenericContainerScreen screen when screen.getTitle().getString().toLowerCase().contains("equipment") -> {
-                int line = slot/9;
+                int line = slot / 9;
                 if (line > 0 && line < 5 && slot % 9 == 1) {
                     boolean empty = stack.getName().getString().trim().toLowerCase().startsWith("empty");
                     if (Utils.isInTheRift())

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenProviderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenProviderMixin.java
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public interface HandledScreenProviderMixin<T extends ScreenHandler> {
 
 	@Inject(method = "open", at = @At("HEAD"), cancellable = true)
-	default void skyblocker$open(Text name, ScreenHandlerType<T> type, MinecraftClient client, int id, CallbackInfo ci) {
+	private void skyblocker$open(Text name, ScreenHandlerType<T> type, MinecraftClient client, int id, CallbackInfo ci) {
 		ClientPlayerEntity player = client.player;
 		if (player == null) return;
 		if (!Utils.isOnSkyblock()) return;

--- a/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
@@ -1,35 +1,29 @@
 package de.hysky.skyblocker.mixins;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.itemlist.ItemListWidget;
 import de.hysky.skyblocker.utils.Utils;
-import net.minecraft.client.gui.screen.ButtonTextures;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.gui.screen.recipebook.RecipeBookWidget;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.TexturedButtonWidget;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(InventoryScreen.class)
 public abstract class InventoryScreenMixin {
-    @ModifyExpressionValue(method = "<init>", at = @At(value = "NEW", target = "net/minecraft/client/gui/screen/recipebook/RecipeBookWidget"))
+    @ModifyExpressionValue(method = "<init>", at = @At(value = "NEW", target = "Lnet/minecraft/client/gui/screen/recipebook/RecipeBookWidget;"))
     private RecipeBookWidget skyblocker$replaceRecipeBook(RecipeBookWidget original) {
         return SkyblockerConfigManager.get().general.itemList.enableItemList && Utils.isOnSkyblock() ? new ItemListWidget() : original;
     }
 
-    @WrapOperation(method = "init", at = @At(value = "NEW", target = "(IIIILnet/minecraft/client/gui/screen/ButtonTextures;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/TexturedButtonWidget;"))
-    private TexturedButtonWidget skyblocker$moveButton(int x, int y, int width, int height, ButtonTextures textures, ButtonWidget.PressAction pressAction, Operation<TexturedButtonWidget> original) {
-        if (!Utils.isOnSkyblock() || !SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory) return original.call(x, y, width, height, textures, pressAction);
-        return new TexturedButtonWidget(x + 21, y, width, height, textures, pressAction);
+    @ModifyArg(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/TexturedButtonWidget;<init>(IIIILnet/minecraft/client/gui/screen/ButtonTextures;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)V"), index = 0)
+    private int skyblocker$moveButton(int x) {
+        return Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory ? x + 21 : x;
     }
 
-    @WrapOperation(method = "method_19891", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;setPosition(II)V"))
-    private void skyblocker$moveButtonWhenPressed(ButtonWidget instance, int i, int j, Operation<Void> original) {
-        if (!Utils.isOnSkyblock() || !SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory) original.call(instance, i, j);
-        else instance.setPosition(i + 21, j);
+    @ModifyArg(method = "method_19891", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;setPosition(II)V"), index = 0)
+    private int skyblocker$moveButtonWhenPressed(int x) {
+        return Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory ? x + 21 : x;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/MinecraftClientMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MinecraftClientMixin.java
@@ -61,9 +61,8 @@ public abstract class MinecraftClientMixin {
         return Utils.isOnSkyblock() ? new JoinWorldPlaceholderScreen() : screen;
     }
 
-    @WrapOperation(method = "handleInputEvents", at = @At(value = "NEW", target = "(Lnet/minecraft/entity/player/PlayerEntity;)Lnet/minecraft/client/gui/screen/ingame/InventoryScreen;"))
+    @WrapOperation(method = "handleInputEvents", at = @At(value = "NEW", target = "Lnet/minecraft/client/gui/screen/ingame/InventoryScreen;"))
     private InventoryScreen skyblocker$skyblockInventoryScreen(PlayerEntity player, Operation<InventoryScreen> original) {
-        if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory) return new SkyblockInventoryScreen(player);
-        else return original.call(player);
+        return Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory ? new SkyblockInventoryScreen(player) : original.call(player);
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/PingMeasurerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PingMeasurerMixin.java
@@ -1,22 +1,21 @@
 package de.hysky.skyblocker.mixins;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.network.PingMeasurer;
-import net.minecraft.util.profiler.MultiValueDebugSampleLogImpl;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(PingMeasurer.class)
 public class PingMeasurerMixin {
 
-    @WrapOperation(method = "onPingResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/MultiValueDebugSampleLogImpl;push(J)V"))
-    private void skyblocker$onPingResult(MultiValueDebugSampleLogImpl log, long ping, Operation<Void> operation) {
+    @ModifyArg(method = "onPingResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/MultiValueDebugSampleLogImpl;push(J)V"))
+    private long skyblocker$onPingResult(long ping) {
         if (Utils.isInCrimson()) {
             DojoManager.onPingResult(ping);
         }
-        operation.call(log, ping);
+
+        return ping;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/RenderFishMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/RenderFishMixin.java
@@ -1,23 +1,22 @@
 package de.hysky.skyblocker.mixins;
 
-
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.FishingBobberEntityRenderer;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.projectile.FishingBobberEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.sugar.Local;
+
 @Mixin(FishingBobberEntityRenderer.class)
 public abstract class RenderFishMixin {
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void skyblocker$render(FishingBobberEntity fishingBobberEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci) {
+    private void skyblocker$render(CallbackInfo ci, @Local(argsOnly = true) FishingBobberEntity fishingBobberEntity) {
         //if rendered bobber is not the players and option to hide  others is enabled do not render the bobber
         if (Utils.isOnSkyblock() && fishingBobberEntity.getPlayerOwner() != MinecraftClient.getInstance().player && SkyblockerConfigManager.get().helpers.fishing.hideOtherPlayersRods) {
             ci.cancel();

--- a/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
@@ -13,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.sugar.Local;
+
 import java.util.Objects;
 
 @Mixin(AbstractSignEditScreen.class)
@@ -22,7 +24,7 @@ public abstract class SignEditScreenMixin {
     private String[] messages;
 
     @Inject(method = "render", at = @At("HEAD"))
-    private void skyblocker$render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+    private void skyblocker$render(CallbackInfo ci, @Local(argsOnly = true) DrawContext context) {
         //if the sign is being used to enter number send it to the sign calculator
         if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.inputCalculator.enabled && Objects.equals(messages[1], "^^^^^^^^^^^^^^^")) {
             SignCalculator.renderCalculator(context, messages[0], context.getScaledWindowWidth() / 2, 55);

--- a/src/main/java/de/hysky/skyblocker/mixins/SocialInteractionsPlayerListWidgetMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/SocialInteractionsPlayerListWidgetMixin.java
@@ -5,8 +5,7 @@ import java.util.Map;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.gui.screen.multiplayer.SocialInteractionsPlayerListEntry;
@@ -15,10 +14,8 @@ import net.minecraft.client.gui.screen.multiplayer.SocialInteractionsPlayerListW
 @Mixin(SocialInteractionsPlayerListWidget.class)
 public class SocialInteractionsPlayerListWidgetMixin {
 
-	@WrapOperation(method = "setPlayers", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
-	private Object skyblocker$hideInvalidPlayers(Map<Object, Object> map, Object uuid, Object entry, Operation<Object> operation) {
-		if (Utils.isOnSkyblock() && !((SocialInteractionsPlayerListEntry) entry).getName().matches("[A-Za-z0-9_]+")) return null;
-
-		return operation.call(map, uuid, entry);
+	@WrapWithCondition(method = "setPlayers", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
+	private boolean skyblocker$hideInvalidPlayers(Map<Object, Object> map, Object uuid, Object entry) {
+		return !(Utils.isOnSkyblock() && !((SocialInteractionsPlayerListEntry) entry).getName().matches("[A-Za-z0-9_]+"));
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/WindowMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/WindowMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Window.class)
 public class WindowMixin {
     @Inject(method = "setScaleFactor", at = @At("TAIL"))
-    public void skyblocker$onScaleFactorChange(double scaleFactor, CallbackInfo ci) {
+    public void skyblocker$onScaleFactorChange(CallbackInfo ci) {
         FancyStatusBars.updatePositions();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/accessors/BeaconBlockEntityRendererInvoker.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/accessors/BeaconBlockEntityRendererInvoker.java
@@ -8,7 +8,6 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(BeaconBlockEntityRenderer.class)
 public interface BeaconBlockEntityRendererInvoker {
-    @SuppressWarnings("unused")
     @Invoker("renderBeam")
     static void renderBeam(MatrixStack matrices, VertexConsumerProvider vertexConsumers, float tickDelta, long worldTime, int yOffset, int maxY, int color) {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
- Fixes the DyeColorComponentMixin wiping out the target's `hashCode`, `toString`, and `equals` implementation due to the mixin class being a record
- Rewrote some mixins to be more precise/efficient
- Fixed some formatting issues
- Fixed the CallbackInfo param being named inconsistently