### PR TITLE
Fix Ultrasequencer Bugs

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.mixins;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
@@ -201,7 +202,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	}
 
 	@ModifyVariable(method = "drawSlot", at = @At(value = "LOAD", ordinal = 3), ordinal = 0)
-	private ItemStack skyblocker$experimentSolvers$replaceDisplayStack(ItemStack stack, DrawContext context, Slot slot) {
+	private ItemStack skyblocker$experimentSolvers$replaceDisplayStack(ItemStack stack, @Local(argsOnly = true) Slot slot) {
 		return skyblocker$experimentSolvers$getStack(slot, stack);
 	}
 
@@ -219,8 +220,8 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 */
 	@Unique
 	private ItemStack skyblocker$experimentSolvers$getStack(Slot slot, @NotNull ItemStack stack, ContainerSolver currentSolver) {
-		if ((currentSolver instanceof SuperpairsSolver || currentSolver instanceof UltrasequencerSolver) && ((ExperimentSolver) currentSolver).getState() == ExperimentSolver.State.SHOW && slot.inventory instanceof SimpleInventory) {
-			ItemStack itemStack = ((ExperimentSolver) currentSolver).getSlots().get(slot.getIndex());
+		if (currentSolver instanceof ExperimentSolver experimentSolver && (experimentSolver instanceof SuperpairsSolver || experimentSolver instanceof UltrasequencerSolver) && experimentSolver.getState() == ExperimentSolver.State.SHOW && slot.inventory instanceof SimpleInventory) {
+			ItemStack itemStack = experimentSolver.getSlots().get(slot.getIndex());
 			return itemStack == null ? stack : itemStack;
 		}
 		return stack;

--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
@@ -4,18 +4,40 @@ import de.hysky.skyblocker.config.configs.HelperConfig;
 import de.hysky.skyblocker.utils.container.ContainerSolverManager;
 import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.block.StainedGlassPaneBlock;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.inventory.Inventory;
+import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.DyeColor;
 
 import java.util.List;
+import java.util.stream.IntStream;
+
+import org.jetbrains.annotations.Nullable;
 
 public final class UltrasequencerSolver extends ExperimentSolver {
 	public static final UltrasequencerSolver INSTANCE = new UltrasequencerSolver();
 	/**
+	 * The playable slots of Ultrasequencer in the Metaphysical level.
+	 * 
+	 * Even though the Supreme/Transcendent levels have less playable slots we filter out black glass panes later on
+	 * since black isn't in the color sequence.
+	 */
+	private static final int[] PANE_SLOTS = IntStream.rangeClosed(9, 44).toArray();
+
+	/**
 	 * The slot id of the next slot to click.
 	 */
 	private int ultrasequencerNextSlot;
+	/**
+	 * Saves the {@link DyeColor} instance corresponding to the color of the pane showed in the screen as it changes each round.
+	 * Used for detecting when the round ends.
+	 */
+	@Nullable
+	private DyeColor lastColor;
 
 	private UltrasequencerSolver() {
 		super("^Ultrasequencer \\(\\w+\\)$");
@@ -49,12 +71,15 @@ public final class UltrasequencerSolver extends ExperimentSolver {
 							getSlots().put(index, itemStack);
 						}
 					}
+					// Note: This relies on Hypixel sending items sequentially, hopefully this doesn't change in the future
 					setState(State.WAIT);
 				}
 			}
 			case WAIT -> {
 				if (screen.getScreenHandler().getInventory().getStack(49).getName().getString().startsWith("Timer: ")) {
 					setState(State.SHOW);
+					//This doesn't trigger the markDirty method in this class as the pane color is already updated
+					//as the chain goes END -> REMEMBER -> WAIT
 					ContainerSolverManager.markHighlightsDirty();
 				}
 			}
@@ -89,14 +114,46 @@ public final class UltrasequencerSolver extends ExperimentSolver {
 					.filter(entry -> entry.getValue().getCount() == count)
 					.findAny()
 					.map(Int2ObjectMap.Entry::getIntKey)
-					.ifPresentOrElse(nextSlot -> this.ultrasequencerNextSlot = nextSlot, () -> setState(ExperimentSolver.State.END));
+					.ifPresent(nextSlot -> this.ultrasequencerNextSlot = nextSlot);
 		}
 		return super.onClickSlot(slot, stack, screenId);
+	}
+
+	/**
+	 * Keeps track of when rounds end. The state is set to END when the colour of the glass panes change (excluding the border panes) and we aren't on the first round.
+	 */
+	@Override
+	public void markDirty() {
+		if (MinecraftClient.getInstance().currentScreen instanceof GenericContainerScreen genericContainerScreen) {
+			List<Slot> slots = genericContainerScreen.getScreenHandler().slots.subList(0, genericContainerScreen.getScreenHandler().getRows() * 9);
+			Int2ObjectMap<ItemStack> slotMap = ContainerSolverManager.slotMap(slots);
+
+			for (int paneSlot : PANE_SLOTS) {
+				ItemStack slotItem = slotMap.get(paneSlot);
+
+				if (slotItem != null && !slotItem.isEmpty() && slotItem.getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof StainedGlassPaneBlock stainedGlassPaneBlock) {
+					DyeColor paneColor = stainedGlassPaneBlock.getColor();
+
+					// Filter out black stained glass panes that border the solver
+					if (paneColor == DyeColor.BLACK) continue;
+
+					if (lastColor != paneColor) {
+						// Null check to prevent setting the state to END when its showing the first sequence
+						if (lastColor != null) setState(State.END);
+
+						lastColor = paneColor;
+
+						return;
+					}
+				}
+			}
+		}
 	}
 
 	@Override
 	public void reset() {
 		ultrasequencerNextSlot = 0;
+		lastColor = null;
 		super.reset();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolver.java
@@ -17,6 +17,11 @@ public interface ContainerSolver extends ContainerMatcher, Resettable {
 	default void reset() {}
 
 	/**
+	 * Called upon marking highlights dirty in {@link ContainerSolverManager#markHighlightsDirty()}.
+	 */
+	default void markDirty() {}
+
+	/**
 	 * Called when the slot is clicked.
 	 * @return {@code true} if the click should be canceled, {@code false} otherwise. Defaults to {@code false} if not overridden.
 	 */

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
@@ -111,6 +111,10 @@ public class ContainerSolverManager {
 
 	public static void markHighlightsDirty() {
 		highlights = null;
+
+		if (currentSolver != null) {
+			currentSolver.markDirty();
+		}
 	}
 
 	/**
@@ -133,7 +137,7 @@ public class ContainerSolverManager {
 		RenderSystem.colorMask(true, true, true, true);
 	}
 
-	private static Int2ObjectMap<ItemStack> slotMap(List<Slot> slots) {
+	public static Int2ObjectMap<ItemStack> slotMap(List<Slot> slots) {
 		Int2ObjectMap<ItemStack> slotMap = new Int2ObjectRBTreeMap<>();
 		for (int i = 0; i < slots.size(); i++) {
 			slotMap.put(i, slots.get(i).getStack());


### PR DESCRIPTION
- Fixes the solver losing track of the round and showing an old solution if the player completes it too fast
- Fixes the solver incorrectly thinking the round has ended which resulted in the solution not being shown and soft locked the experiment if you had hide empty tooltips on (since you wouldn't be able to click anything)

Since the colour of the glass panes changes between each round we use that to set the `END` state.

Fixes #892