### PR TITLE
Add wardrobe helper based on hotbar keybinds

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/HelperCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/HelperCategory.java
@@ -26,6 +26,15 @@ public class HelperCategory {
                         .controller(ConfigUtils::createBooleanController)
                         .build())
 
+		        .option(Option.<Boolean>createBuilder()
+		                .name(Text.translatable("skyblocker.config.helpers.enableWardrobeHelper"))
+		                .description(OptionDescription.of(Text.translatable("skyblocker.config.helpers.enableWardrobeHelper.@Tooltip")))
+		                .binding(defaults.helpers.enableWardrobeHelper,
+				                () -> config.helpers.enableWardrobeHelper,
+				                newValue -> config.helpers.enableWardrobeHelper = newValue)
+		                .controller(ConfigUtils::createBooleanController)
+				        .build())
+
                 //Mythological Ritual
                 .group(OptionGroup.createBuilder()
                         .name(Text.translatable("skyblocker.config.helpers.mythologicalRitual"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/HelperConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/HelperConfig.java
@@ -9,6 +9,9 @@ public class HelperConfig {
     public boolean enableNewYearCakesHelper = true;
 
     @SerialEntry
+    public boolean enableWardrobeHelper = true;
+
+    @SerialEntry
     public MythologicalRitual mythologicalRitual = new MythologicalRitual();
 
     @SerialEntry

--- a/src/main/java/de/hysky/skyblocker/skyblock/WardrobeKeybinds.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/WardrobeKeybinds.java
@@ -5,11 +5,16 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.container.RegexContainerMatcher;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.option.KeyBinding;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.screen.slot.SlotActionType;
 import org.lwjgl.glfw.GLFW;
+
+import java.util.function.Predicate;
 
 @SuppressWarnings("unused")
 public class WardrobeKeybinds extends RegexContainerMatcher {
@@ -23,26 +28,34 @@ public class WardrobeKeybinds extends RegexContainerMatcher {
 	public static void init() {
 		ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
 			if (!(screen instanceof HandledScreen<?> handledScreen) || !INSTANCE.test(handledScreen) || !INSTANCE.isEnabled() || client.interactionManager == null) return;
-			ScreenKeyboardEvents.allowKeyPress(handledScreen).register((ignored, keyCode, scanCode, modifiers) -> {
-				boolean found = false;
-				int i;
-				for (i = 0; i < client.options.hotbarKeys.length; i++) {
-					if (client.options.hotbarKeys[i].matchesKey(keyCode, scanCode)) {
-						found = true;
-						break;
-					}
-				}
-				if (!found) return true;
-				// The items start from the 5th row in the inventory. The i number we have is the column, so we have to offset it by 4 rows to get the correct row
-				i += 9 * 4;
-				ItemStack itemStack = handledScreen.getScreenHandler().getSlot(i).getStack();
-				// Check if the item in the slot is a swap/unequip item before going further.
-				// This prevents usage when the inventory hasn't loaded fully or when the slot pressed is locked (which would be meaningless to click)
-				if (!itemStack.isOf(Items.PINK_DYE) && !itemStack.isOf(Items.LIME_DYE)) return true;
-				client.interactionManager.clickSlot(handledScreen.getScreenHandler().syncId, i, GLFW.GLFW_MOUSE_BUTTON_1, SlotActionType.PICKUP, client.player);
-				return false;
-			});
+			ScreenKeyboardEvents.allowKeyPress(handledScreen).register((ignored, keyCode, scanCode, modifiers) ->
+					allowInput(client, handledScreen, keybinding -> keybinding.matchesKey(keyCode, scanCode))
+			);
+			ScreenMouseEvents.allowMouseClick(handledScreen).register((ignored, mouseX, mouseY, button) ->
+					allowInput(client, handledScreen, keybinding -> keybinding.matchesMouse(button))
+			);
 		});
+	}
+
+	private static boolean allowInput(MinecraftClient client, HandledScreen<?> handledScreen, Predicate<KeyBinding> predicate) {
+		boolean found = false;
+		int i;
+		for (i = 0; i < client.options.hotbarKeys.length; i++) {
+			if (predicate.test(client.options.hotbarKeys[i])) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) return true;
+		// The items start from the 5th row in the inventory. The i number we have is the column in the first row, so we have to offset it by 4 rows to get the 5th row, which is where the items start.
+		i += 9 * 4;
+		ItemStack itemStack = handledScreen.getScreenHandler().getSlot(i).getStack();
+		// Check if the item in the slot is a swap/unequip item before going further.
+		// This prevents usage when the inventory hasn't loaded fully or when the slot pressed is locked (which would be meaningless to click)
+		if (!itemStack.isOf(Items.PINK_DYE) && !itemStack.isOf(Items.LIME_DYE)) return true;
+		assert client.interactionManager != null;
+		client.interactionManager.clickSlot(handledScreen.getScreenHandler().syncId, i, GLFW.GLFW_MOUSE_BUTTON_1, SlotActionType.PICKUP, client.player);
+		return false;
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/WardrobeKeybinds.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/WardrobeKeybinds.java
@@ -1,0 +1,52 @@
+package de.hysky.skyblocker.skyblock;
+
+import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.container.RegexContainerMatcher;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.screen.slot.SlotActionType;
+import org.lwjgl.glfw.GLFW;
+
+@SuppressWarnings("unused")
+public class WardrobeKeybinds extends RegexContainerMatcher {
+	private static final WardrobeKeybinds INSTANCE = new WardrobeKeybinds();
+
+	public WardrobeKeybinds() {
+		super("Wardrobe \\([12]/2\\)");
+	}
+
+	@Init
+	public static void init() {
+		ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+			if (!(screen instanceof HandledScreen<?> handledScreen) || !INSTANCE.test(handledScreen) || !INSTANCE.isEnabled() || client.interactionManager == null) return;
+			ScreenKeyboardEvents.allowKeyPress(handledScreen).register((ignored, keyCode, scanCode, modifiers) -> {
+				boolean found = false;
+				int i;
+				for (i = 0; i < client.options.hotbarKeys.length; i++) {
+					if (client.options.hotbarKeys[i].matchesKey(keyCode, scanCode)) {
+						found = true;
+						break;
+					}
+				}
+				if (!found) return true;
+				// The items start from the 5th row in the inventory. The i number we have is the column, so we have to offset it by 4 rows to get the correct row
+				i += 9 * 4;
+				ItemStack itemStack = handledScreen.getScreenHandler().getSlot(i).getStack();
+				// Check if the item in the slot is a swap/unequip item before going further.
+				// This prevents usage when the inventory hasn't loaded fully or when the slot pressed is locked (which would be meaningless to click)
+				if (!itemStack.isOf(Items.PINK_DYE) && !itemStack.isOf(Items.LIME_DYE)) return true;
+				client.interactionManager.clickSlot(handledScreen.getScreenHandler().syncId, i, GLFW.GLFW_MOUSE_BUTTON_1, SlotActionType.PICKUP, client.player);
+				return false;
+			});
+		});
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return SkyblockerConfigManager.get().helpers.enableWardrobeHelper;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/utils/container/RegexContainerMatcher.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/RegexContainerMatcher.java
@@ -23,7 +23,7 @@ public abstract class RegexContainerMatcher implements ContainerMatcher {
 	public final Pattern titlePattern;
 
 	@Nullable
-	public String[] groups = null;
+	protected String[] groups = null;
 
 	@Override
 	public boolean test(@NotNull Screen screen) {
@@ -60,9 +60,5 @@ public abstract class RegexContainerMatcher implements ContainerMatcher {
 
 	public @Nullable Pattern getTitlePattern() {
 		return titlePattern;
-	}
-
-	public final @Nullable String[] getGroups() {
-		return groups;
 	}
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -357,7 +357,7 @@
   "skyblocker.config.helpers.enableNewYearCakesHelper.@Tooltip": "Highlights the missing new year cakes green and the cakes you have already red.\n\nRequires you to open your cake bag at least once to work.",
 
   "skyblocker.config.helpers.enableWardrobeHelper": "Enable Wardrobe Helper",
-  "skyblocker.config.helpers.enableWardrobeHelper.@Tooltip": "Allows changing armor from the wardrobe by pressing hotbar keys 1-9. The corresponding armor set in the wardrobe menu will be equipped.",
+  "skyblocker.config.helpers.enableWardrobeHelper.@Tooltip": "Allows changing armor from the wardrobe by pressing hotbar keys 1-9 while the menu is open. The corresponding armor set in the wardrobe menu will be equipped.",
 
   "skyblocker.config.helpers.experiments": "Experiments Solver",
   "skyblocker.config.helpers.experiments.enableChronomatronSolver": "Enable Chronomatron Solver",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -356,6 +356,9 @@
   "skyblocker.config.helpers.enableNewYearCakesHelper": "Enable New Year Cakes Helper",
   "skyblocker.config.helpers.enableNewYearCakesHelper.@Tooltip": "Highlights the missing new year cakes green and the cakes you have already red.\n\nRequires you to open your cake bag at least once to work.",
 
+  "skyblocker.config.helpers.enableWardrobeHelper": "Enable Wardrobe Helper",
+  "skyblocker.config.helpers.enableWardrobeHelper.@Tooltip": "Allows changing armor from the wardrobe by pressing hotbar keys 1-9. The corresponding armor set in the wardrobe menu will be equipped.",
+
   "skyblocker.config.helpers.experiments": "Experiments Solver",
   "skyblocker.config.helpers.experiments.enableChronomatronSolver": "Enable Chronomatron Solver",
   "skyblocker.config.helpers.experiments.enableSuperpairsSolver": "Enable Superpairs Solver",


### PR DESCRIPTION
This is based on #924. Squash and merge, maybe.

The feature class extends ``RegexContainerMatcher`` to simplify regex checking and also gets a nice ``isEnabled`` override. It's not exactly necessary but it looks cleaner. The only downside is that it needs a singleton instance to use the methods on, because the methods in ``RegexContainerMatcher`` are not static.

There's also a config option in root of Helpers category outside of groups to toggle the feature.