### PR TITLE
Block JGit from loading the system Git config

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/jgit/SystemReaderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/jgit/SystemReaderMixin.java
@@ -1,0 +1,16 @@
+package de.hysky.skyblocker.mixins.jgit;
+
+import org.eclipse.jgit.lib.Constants;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+
+@Mixin(targets = "org.eclipse.jgit.util.SystemReader$Default", remap = false)
+public class SystemReaderMixin {
+
+	@ModifyReturnValue(method = "getenv", at = @At("RETURN"))
+	private String skyblocker$blockLoadingSystemGitConfig(String original, String variable) {
+		return variable.equals(Constants.GIT_CONFIG_NOSYSTEM_KEY) ? "FORCE-ENABLE" : original;
+	}
+}

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -55,7 +55,8 @@
     "accessors.SkullBlockEntityAccessor",
     "accessors.SlotAccessor",
     "accessors.WorldRendererAccessor",
-    "discordipc.ConnectionMixin"
+    "discordipc.ConnectionMixin",
+    "jgit.SystemReaderMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Values that JGit doesn't accept such as out of range ints causes the NEU repo loading to fail unless the user deletes their `.gitconfig` file, so we will just block JGit from loading the values in this file to avoid the issues.