### PR TITLE
More consistent wishing compass triangulation

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
@@ -265,15 +265,13 @@ public class WishingCompassSolver {
 
 		System.out.println("Distance: " + distance);
 
-		Vec3d intersection;
+		Vec3d intersection = null;
 		if (distance < DISTANCE_TOLERANCE) {
 			//average the two closest points
 			Vec3d c1 = new Vec3d(close.getX(), close.getY(), close.getZ());
 			Vec3d c2 = new Vec3d(close.getX(), close.getY(), close.getZ());
 
 			intersection = c1.add(c2).multiply(0.5);
-		} else {
-			intersection = null;
 		}
 
         //return final target location

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
@@ -57,6 +57,10 @@ public class WishingCompassSolver {
      * the distance squared the player has to be from where they used the first compass to where they use the second
      */
     private static final long DISTANCE_BETWEEN_USES = 64;
+	/**
+	 * Arbitrary distance below which skyblocker will consider two compass trails to be intersecting
+	 */
+	private static final double DISTANCE_TOLERANCE = 5.0;
 
     private static SolverStates currentState = SolverStates.NOT_STARTED;
     private static Vec3d startPosOne = Vec3d.ZERO;
@@ -254,13 +258,26 @@ public class WishingCompassSolver {
         Vector3D lineTwoEnd = new Vector3D(directionTwo.x, directionTwo.y, directionTwo.z).add(lineTwoStart);
         Line line = new Line(lineOneStart, lineOneEnd, 1);
         Line lineTwo = new Line(lineTwoStart, lineTwoEnd, 1);
-        Vector3D intersection = line.intersection(lineTwo);
+
+        Vector3D close = line.closestPoint(lineTwo);
+		Vector3D closeTwo = lineTwo.closestPoint(line);
+		double distance = close.distance(closeTwo);
+
+		System.out.println("Distance: " + distance);
+
+		Vec3d intersection;
+		if (distance < DISTANCE_TOLERANCE) {
+			//average the two closest points
+			Vec3d c1 = new Vec3d(close.getX(), close.getY(), close.getZ());
+			Vec3d c2 = new Vec3d(close.getX(), close.getY(), close.getZ());
+
+			intersection = c1.add(c2).multiply(0.5);
+		} else {
+			intersection = null;
+		}
 
         //return final target location
-        if (intersection == null || intersection.equals(new Vector3D(0, 0, 0))) {
-            return null;
-        }
-        return new Vec3d(intersection.getX(), intersection.getY(), intersection.getZ());
+        return intersection;
     }
 
     private static ActionResult onBlockInteract(PlayerEntity playerEntity, World world, Hand hand, BlockHitResult blockHitResult) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
@@ -263,8 +263,6 @@ public class WishingCompassSolver {
 		Vector3D closeTwo = lineTwo.closestPoint(line);
 		double distance = close.distance(closeTwo);
 
-		System.out.println("Distance: " + distance);
-
 		Vec3d intersection = null;
 		if (distance < DISTANCE_TOLERANCE) {
 			//average the two closest points


### PR DESCRIPTION
This PR adds some math to replace the strict intersection test with a distance test with an epsilon. This makes very close (but not _quite_ touching) lines still count as a successful triangulation. 

The limit of 5 blocks may seem high, but in my testing, several trails leading to the same location were still a few blocks apart sometimes. 