### PR TITLE
Add unbreakable carpet highlighter

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/MiningCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/MiningCategory.java
@@ -4,7 +4,7 @@ import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.configs.MiningConfig;
 import de.hysky.skyblocker.skyblock.dwarven.CrystalsHudWidget;
-import de.hysky.skyblocker.skyblock.dwarven.MithrilCarpetHighlighter;
+import de.hysky.skyblocker.skyblock.dwarven.CarpetHighlighter;
 import dev.isxander.yacl3.api.*;
 import dev.isxander.yacl3.api.controller.ColorControllerBuilder;
 import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
@@ -71,7 +71,7 @@ public class MiningCategory {
 		                                () -> config.mining.dwarvenMines.carpetHighlightColor,
 		                                newValue -> {
 											config.mining.dwarvenMines.carpetHighlightColor = newValue;
-			                                MithrilCarpetHighlighter.INSTANCE.configCallback(newValue);
+			                                CarpetHighlighter.INSTANCE.configCallback(newValue);
 		                                })
                                 .controller(opt -> ColorControllerBuilder.create(opt).allowAlpha(true))
                                 .build())

--- a/src/main/java/de/hysky/skyblocker/config/categories/MiningCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/MiningCategory.java
@@ -4,6 +4,7 @@ import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.configs.MiningConfig;
 import de.hysky.skyblocker.skyblock.dwarven.CrystalsHudWidget;
+import de.hysky.skyblocker.skyblock.dwarven.MithrilCarpetHighlighter;
 import dev.isxander.yacl3.api.*;
 import dev.isxander.yacl3.api.controller.ColorControllerBuilder;
 import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
@@ -54,6 +55,25 @@ public class MiningCategory {
                                         () -> config.mining.dwarvenMines.solvePuzzler,
                                         newValue -> config.mining.dwarvenMines.solvePuzzler = newValue)
                                 .controller(ConfigUtils::createBooleanController)
+                                .build())
+		                .option(Option.<Boolean>createBuilder()
+				                .name(Text.translatable("skyblocker.config.mining.dwarvenMines.enableCarpetHighlight"))
+				                .description(OptionDescription.of(Text.translatable("skyblocker.config.mining.dwarvenMines.enableCarpetHighlight.@Tooltip")))
+                                .binding(defaults.mining.dwarvenMines.enableCarpetHighlighter,
+		                                () -> config.mining.dwarvenMines.enableCarpetHighlighter,
+                                       newValue -> config.mining.dwarvenMines.enableCarpetHighlighter = newValue)
+                                .controller(ConfigUtils::createBooleanController)
+	                            .build())
+                        .option(Option.<Color>createBuilder()
+                                .name(Text.translatable("skyblocker.config.mining.dwarvenMines.carpetHighlightColor"))
+                                .description(OptionDescription.of(Text.translatable("skyblocker.config.mining.dwarvenMines.carpetHighlightColor.@Tooltip")))
+                                .binding(defaults.mining.dwarvenMines.carpetHighlightColor,
+		                                () -> config.mining.dwarvenMines.carpetHighlightColor,
+		                                newValue -> {
+											config.mining.dwarvenMines.carpetHighlightColor = newValue;
+			                                MithrilCarpetHighlighter.INSTANCE.configCallback(newValue);
+		                                })
+                                .controller(opt -> ColorControllerBuilder.create(opt).allowAlpha(true))
                                 .build())
                         .build())
 

--- a/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
@@ -39,6 +39,12 @@ public class MiningConfig {
 
         @SerialEntry
         public boolean solvePuzzler = true;
+
+		@SerialEntry
+	    public boolean enableCarpetHighlighter = true;
+
+		@SerialEntry
+	    public Color carpetHighlightColor = new Color(255, 0, 0, 76);
     }
 
 	@Deprecated

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
@@ -23,15 +23,19 @@ import net.minecraft.util.math.Vec3d;
 
 import java.awt.*;
 
-public final class MithrilCarpetHighlighter implements Renderable, Tickable, Resettable {
-	public static final MithrilCarpetHighlighter INSTANCE = new MithrilCarpetHighlighter();
+/**
+ * Highlights unbreakable carpets within ore veins in the Dwarven Mines.
+ */
+public final class CarpetHighlighter implements Renderable, Tickable, Resettable {
+	public static final CarpetHighlighter INSTANCE = new CarpetHighlighter();
 
 	private static final Vec3d CARPET_BOUNDING_BOX = Boxes.getLengthVec(CarpetBlock.SHAPE.getBoundingBox());
 	private static final int SEARCH_RADIUS = 15;
-	private static float[] colorComponents;
 	private static final int TICK_INTERVAL = 15;
-	private static int tickCounter = 0;
 	private static final ObjectArraySet<BlockPos> CARPET_LOCATIONS = new ObjectArraySet<>();
+
+	private static float[] colorComponents;
+	private static int tickCounter = 0;
 	private static boolean isLocationValid = false;
 
 	@Init
@@ -70,14 +74,21 @@ public final class MithrilCarpetHighlighter implements Renderable, Tickable, Res
 
 	/**
 	 * @param blockPos The position to check for a carpet
-	 * @return Whether the block at the given position is a gray carpet with a sea lantern below it, which is how all mithril carpets are placed
+	 * @return Whether the block at the given position is a gray carpet with a sea lantern below it, which is how all unbreakable carpets are placed
 	 * @implNote <p>getBlockState is a heavy method, so this method will become a hot spot as the search radius increases || the tick interval decreases.</p>
-	 * 	         <p>Consider profiling this method if either of those values are changed.</p>
+	 * 		<p>Consider profiling this method if either of those values are changed.</p>
 	 */
 	private boolean checkForCarpet(BlockPos blockPos) {
 		@SuppressWarnings("DataFlowIssue") // Null check is already done in the run method
 		BlockState actualBlock = MinecraftClient.getInstance().world.getBlockState(blockPos);
-		if (!actualBlock.isOf(Blocks.GRAY_CARPET) && !actualBlock.isOf(Blocks.LIGHT_BLUE_CARPET)) return false;
+		// Gray/light blue - mithril
+		// Light gray - tungsten
+		// There are other colors for some ores in the royal mines,
+		// but since the actual ores don't include wool blocks
+		// they're not easily confused as ores so they are not accounted for here
+		if (!(actualBlock.isOf(Blocks.GRAY_CARPET) ||
+				actualBlock.isOf(Blocks.LIGHT_BLUE_CARPET) ||
+				actualBlock.isOf(Blocks.LIGHT_GRAY_CARPET))) return false;
 		BlockState blockBelow = MinecraftClient.getInstance().world.getBlockState(blockPos.down());
 		return blockBelow.isOf(Blocks.SEA_LANTERN);
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
@@ -9,8 +9,8 @@ import de.hysky.skyblocker.utils.Resettable;
 import de.hysky.skyblocker.utils.Tickable;
 import de.hysky.skyblocker.utils.render.RenderHelper;
 import de.hysky.skyblocker.utils.render.Renderable;
-import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import it.unimi.dsi.fastutil.objects.ObjectAVLTreeSet;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -32,7 +32,7 @@ public final class CarpetHighlighter implements Renderable, Tickable, Resettable
 	private static final Vec3d CARPET_BOUNDING_BOX = Boxes.getLengthVec(CarpetBlock.SHAPE.getBoundingBox());
 	private static final int SEARCH_RADIUS = 15;
 	private static final int TICK_INTERVAL = 15;
-	private static final ObjectArraySet<BlockPos> CARPET_LOCATIONS = new ObjectArraySet<>();
+	private static final ObjectAVLTreeSet<BlockPos> CARPET_LOCATIONS = new ObjectAVLTreeSet<>();
 
 	private static float[] colorComponents;
 	private static int tickCounter = 0;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
@@ -50,7 +50,7 @@ public final class CarpetHighlighter implements Renderable, Resettable {
 	public void render(WorldRenderContext context) {
 		if (!isLocationValid || !SkyblockerConfigManager.get().mining.dwarvenMines.enableCarpetHighlighter) return;
 		for (BlockPos carpetLocation : CARPET_LOCATIONS) {
-			RenderHelper.renderFilled(context, carpetLocation, CARPET_BOUNDING_BOX, colorComponents, colorComponents[3], false);
+			RenderHelper.renderFilled(context, Vec3d.of(carpetLocation), CARPET_BOUNDING_BOX, colorComponents, colorComponents[3], false);
 		}
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
@@ -32,9 +32,7 @@ public final class CarpetHighlighter implements Renderable, Resettable {
 	private static final int SEARCH_RADIUS = 15;
 	private static final int TICK_INTERVAL = 15;
 	private static final ObjectAVLTreeSet<BlockPos> CARPET_LOCATIONS = new ObjectAVLTreeSet<>();
-
 	private static float[] colorComponents;
-	private static int tickCounter = 0;
 	private static boolean isLocationValid = false;
 
 	@Init

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CarpetHighlighter.java
@@ -59,7 +59,7 @@ public final class CarpetHighlighter implements Renderable, Resettable {
 	}
 
 	public void tick() {
-		if (!isLocationValid || MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().player == null) return;
+		if (!isLocationValid || !SkyblockerConfigManager.get().mining.dwarvenMines.enableCarpetHighlighter || MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().player == null) return;
 		Iterable<BlockPos> iterable = BlockPos.iterateOutwards(MinecraftClient.getInstance().player.getBlockPos(), SEARCH_RADIUS, SEARCH_RADIUS, SEARCH_RADIUS);
 		for (BlockPos blockPos : iterable) {
 			//The iterator contains a BlockPos.Mutable that it changes the position of to iterate over blocks,

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
@@ -77,8 +77,9 @@ public final class MithrilCarpetHighlighter implements Renderable, Tickable, Res
 	private boolean checkForCarpet(BlockPos blockPos) {
 		@SuppressWarnings("DataFlowIssue") // Null check is already done in the run method
 		BlockState actualBlock = MinecraftClient.getInstance().world.getBlockState(blockPos);
+		if (!actualBlock.isOf(Blocks.GRAY_CARPET)) return false;
 		BlockState blockBelow = MinecraftClient.getInstance().world.getBlockState(blockPos.down());
-		return actualBlock.isOf(Blocks.GRAY_CARPET) && blockBelow.isOf(Blocks.SEA_LANTERN);
+		return blockBelow.isOf(Blocks.SEA_LANTERN);
 	}
 
 	/**

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
@@ -1,14 +1,17 @@
 package de.hysky.skyblocker.skyblock.dwarven;
 
 import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.Boxes;
 import de.hysky.skyblocker.utils.Location;
+import de.hysky.skyblocker.utils.Resettable;
 import de.hysky.skyblocker.utils.Tickable;
 import de.hysky.skyblocker.utils.render.RenderHelper;
 import de.hysky.skyblocker.utils.render.Renderable;
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.minecraft.block.BlockState;
@@ -18,52 +21,77 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 
-public final class MithrilCarpetHighlighter implements Renderable, Tickable {
+import java.awt.*;
+
+public final class MithrilCarpetHighlighter implements Renderable, Tickable, Resettable {
+	public static final MithrilCarpetHighlighter INSTANCE = new MithrilCarpetHighlighter();
+
 	private static final Vec3d CARPET_BOUNDING_BOX = Boxes.getLengthVec(CarpetBlock.SHAPE.getBoundingBox());
-	private static final float[] RED_COLOR_COMPONENTS = {1.0F, 0.0F, 0.0F};
-	private static final float BOX_ALPHA = 0.3F;
 	private static final int SEARCH_RADIUS = 15;
+	private static float[] colorComponents;
 	private static final int TICK_INTERVAL = 15;
 	private static int tickCounter = 0;
-	private static final MithrilCarpetHighlighter INSTANCE = new MithrilCarpetHighlighter();
 	private static final ObjectArraySet<BlockPos> CARPET_LOCATIONS = new ObjectArraySet<>();
 	private static boolean isLocationValid = false;
 
 	@Init
 	public static void init() {
+		INSTANCE.configCallback(SkyblockerConfigManager.get().mining.dwarvenMines.carpetHighlightColor);
 		WorldRenderEvents.AFTER_TRANSLUCENT.register(INSTANCE::render);
 		SkyblockEvents.LOCATION_CHANGE.register(INSTANCE::onLocationChange);
 		ClientTickEvents.END_CLIENT_TICK.register(INSTANCE::tick);
+		ClientPlayConnectionEvents.JOIN.register(INSTANCE);
 	}
 
 	@Override
 	public void render(WorldRenderContext context) {
-		if (!isLocationValid) return;
+		if (!isLocationValid || !SkyblockerConfigManager.get().mining.dwarvenMines.enableCarpetHighlighter) return;
 		for (BlockPos carpetLocation : CARPET_LOCATIONS) {
-			RenderHelper.renderFilled(context, carpetLocation, CARPET_BOUNDING_BOX, RED_COLOR_COMPONENTS, BOX_ALPHA, false);
+			RenderHelper.renderFilled(context, carpetLocation, CARPET_BOUNDING_BOX, colorComponents, colorComponents[3], false);
 		}
 	}
 
 	public void onLocationChange(Location location) {
 		isLocationValid = location == Location.DWARVEN_MINES;
-		CARPET_LOCATIONS.clear();
 	}
 
 	@Override
 	public void tick(MinecraftClient client) {
 		if (!isLocationValid || MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().player == null) return;
-		if (tickCounter++ < TICK_INTERVAL) return; // Only search for carpets every 15 ticks
+		if (tickCounter++ < TICK_INTERVAL) return; // Only search for carpets every TICK_INTERVAL ticks
 		Iterable<BlockPos> iterable = BlockPos.iterateOutwards(MinecraftClient.getInstance().player.getBlockPos(), SEARCH_RADIUS, SEARCH_RADIUS, SEARCH_RADIUS);
 		for (BlockPos blockPos : iterable) {
+			//The iterator contains a BlockPos.Mutable that it changes the position of to iterate over blocks,
+			// so it has to be converted to an immutable BlockPos or the position will change based on the player's position && the search radius
 			if (checkForCarpet(blockPos)) CARPET_LOCATIONS.add(blockPos.toImmutable());
 		}
 		tickCounter = 0;
 	}
 
+	/**
+	 * @param blockPos The position to check for a carpet
+	 * @return Whether the block at the given position is a gray carpet with a sea lantern below it, which is how all mithril carpets are placed
+	 * @implNote <p>getBlockState is a heavy method, so this method will become a hot spot as the search radius increases || the tick interval decreases.</p>
+	 * 	         <p>Consider profiling this method if either of those values are changed.</p>
+	 */
 	private boolean checkForCarpet(BlockPos blockPos) {
 		@SuppressWarnings("DataFlowIssue") // Null check is already done in the run method
 		BlockState actualBlock = MinecraftClient.getInstance().world.getBlockState(blockPos);
 		BlockState blockBelow = MinecraftClient.getInstance().world.getBlockState(blockPos.down());
 		return actualBlock.isOf(Blocks.GRAY_CARPET) && blockBelow.isOf(Blocks.SEA_LANTERN);
+	}
+
+	/**
+	 * <p>Caches the color components from the given color for rendering to avoid recalculating them every frame.</p>
+	 * <p>Called by the {@link de.hysky.skyblocker.config.categories.MiningCategory MiningCategory} > carpetHighlightColor when the color is updated.</p>
+	 */
+	public void configCallback(Color color) {
+		colorComponents = color.getRGBComponents(null);
+	}
+
+	@Override
+	public void reset() {
+		isLocationValid = false;
+		CARPET_LOCATIONS.clear();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
@@ -1,0 +1,69 @@
+package de.hysky.skyblocker.skyblock.dwarven;
+
+import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.events.SkyblockEvents;
+import de.hysky.skyblocker.utils.Boxes;
+import de.hysky.skyblocker.utils.Location;
+import de.hysky.skyblocker.utils.Tickable;
+import de.hysky.skyblocker.utils.render.RenderHelper;
+import de.hysky.skyblocker.utils.render.Renderable;
+import it.unimi.dsi.fastutil.objects.ObjectArraySet;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.CarpetBlock;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+
+public final class MithrilCarpetHighlighter implements Renderable, Tickable {
+	private static final Vec3d CARPET_BOUNDING_BOX = Boxes.getLengthVec(CarpetBlock.SHAPE.getBoundingBox());
+	private static final float[] RED_COLOR_COMPONENTS = {1.0F, 0.0F, 0.0F};
+	private static final float BOX_ALPHA = 0.3F;
+	private static final int SEARCH_RADIUS = 15;
+	private static final int TICK_INTERVAL = 15;
+	private static int tickCounter = 0;
+	private static final MithrilCarpetHighlighter INSTANCE = new MithrilCarpetHighlighter();
+	private static final ObjectArraySet<BlockPos> CARPET_LOCATIONS = new ObjectArraySet<>();
+	private static boolean isLocationValid = false;
+
+	@Init
+	public static void init() {
+		WorldRenderEvents.AFTER_TRANSLUCENT.register(INSTANCE::render);
+		SkyblockEvents.LOCATION_CHANGE.register(INSTANCE::onLocationChange);
+		ClientTickEvents.END_CLIENT_TICK.register(INSTANCE::tick);
+	}
+
+	@Override
+	public void render(WorldRenderContext context) {
+		if (!isLocationValid) return;
+		for (BlockPos carpetLocation : CARPET_LOCATIONS) {
+			RenderHelper.renderFilled(context, carpetLocation, CARPET_BOUNDING_BOX, RED_COLOR_COMPONENTS, BOX_ALPHA, false);
+		}
+	}
+
+	public void onLocationChange(Location location) {
+		isLocationValid = location == Location.DWARVEN_MINES;
+		CARPET_LOCATIONS.clear();
+	}
+
+	@Override
+	public void tick(MinecraftClient client) {
+		if (!isLocationValid || MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().player == null) return;
+		if (tickCounter++ < TICK_INTERVAL) return; // Only search for carpets every 15 ticks
+		Iterable<BlockPos> iterable = BlockPos.iterateOutwards(MinecraftClient.getInstance().player.getBlockPos(), SEARCH_RADIUS, SEARCH_RADIUS, SEARCH_RADIUS);
+		for (BlockPos blockPos : iterable) {
+			if (checkForCarpet(blockPos)) CARPET_LOCATIONS.add(blockPos.toImmutable());
+		}
+		tickCounter = 0;
+	}
+
+	private boolean checkForCarpet(BlockPos blockPos) {
+		@SuppressWarnings("DataFlowIssue") // Null check is already done in the run method
+		BlockState actualBlock = MinecraftClient.getInstance().world.getBlockState(blockPos);
+		BlockState blockBelow = MinecraftClient.getInstance().world.getBlockState(blockPos.down());
+		return actualBlock.isOf(Blocks.GRAY_CARPET) && blockBelow.isOf(Blocks.SEA_LANTERN);
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MithrilCarpetHighlighter.java
@@ -77,7 +77,7 @@ public final class MithrilCarpetHighlighter implements Renderable, Tickable, Res
 	private boolean checkForCarpet(BlockPos blockPos) {
 		@SuppressWarnings("DataFlowIssue") // Null check is already done in the run method
 		BlockState actualBlock = MinecraftClient.getInstance().world.getBlockState(blockPos);
-		if (!actualBlock.isOf(Blocks.GRAY_CARPET)) return false;
+		if (!actualBlock.isOf(Blocks.GRAY_CARPET) && !actualBlock.isOf(Blocks.LIGHT_BLUE_CARPET)) return false;
 		BlockState blockBelow = MinecraftClient.getInstance().world.getBlockState(blockPos.down());
 		return blockBelow.isOf(Blocks.SEA_LANTERN);
 	}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -603,6 +603,11 @@
   "skyblocker.config.mining.dwarvenMines": "Dwarven Mines",
   "skyblocker.config.mining.dwarvenMines.solveFetchur": "Solve Fetchur",
   "skyblocker.config.mining.dwarvenMines.solvePuzzler": "Solve Puzzler Puzzle",
+  "skyblocker.config.mining.dwarvenMines.enableCarpetHighlight": "Enable Mithril Carpet Highlighter",
+  "skyblocker.config.mining.dwarvenMines.enableCarpetHighlight.@Tooltip": "Highlights unbreakable gray carpets within mithril ore veins in the dwarven mines.",
+  "skyblocker.config.mining.dwarvenMines.carpetHighlightColor": "Mithril Carpet Highlight Color",
+  "skyblocker.config.mining.dwarvenMines.carpetHighlightColor.@Tooltip": "Sets the color of the highlight for the mithril carpets.",
+
 
   "skyblocker.config.mining.enableDrillFuel": "Enable Drill Fuel",
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -603,10 +603,10 @@
   "skyblocker.config.mining.dwarvenMines": "Dwarven Mines",
   "skyblocker.config.mining.dwarvenMines.solveFetchur": "Solve Fetchur",
   "skyblocker.config.mining.dwarvenMines.solvePuzzler": "Solve Puzzler Puzzle",
-  "skyblocker.config.mining.dwarvenMines.enableCarpetHighlight": "Enable Mithril Carpet Highlighter",
-  "skyblocker.config.mining.dwarvenMines.enableCarpetHighlight.@Tooltip": "Highlights unbreakable gray carpets within mithril ore veins in the dwarven mines.",
-  "skyblocker.config.mining.dwarvenMines.carpetHighlightColor": "Mithril Carpet Highlight Color",
-  "skyblocker.config.mining.dwarvenMines.carpetHighlightColor.@Tooltip": "Sets the color of the highlight for the mithril carpets.",
+  "skyblocker.config.mining.dwarvenMines.enableCarpetHighlight": "Enable Unbreakable Carpet Highlighter",
+  "skyblocker.config.mining.dwarvenMines.enableCarpetHighlight.@Tooltip": "Highlights unbreakable carpets within ore veins in the Dwarven Mines.",
+  "skyblocker.config.mining.dwarvenMines.carpetHighlightColor": "Carpet Highlight Color",
+  "skyblocker.config.mining.dwarvenMines.carpetHighlightColor.@Tooltip": "Sets the color of the highlight for the unbreakable carpets.",
 
 
   "skyblocker.config.mining.enableDrillFuel": "Enable Drill Fuel",

--- a/src/main/resources/skyblocker.accesswidener
+++ b/src/main/resources/skyblocker.accesswidener
@@ -27,3 +27,6 @@ extendable method net/minecraft/nbt/StringNbtReader readCompound ()Lnet/minecraf
 extendable method net/minecraft/nbt/StringNbtReader parseList ()Lnet/minecraft/nbt/NbtElement;
 extendable method net/minecraft/nbt/StringNbtReader readComma ()Z
 extendable method net/minecraft/nbt/StringNbtReader expect (C)V
+
+# Block Shapes
+accessible field net/minecraft/block/CarpetBlock SHAPE Lnet/minecraft/util/shape/VoxelShape;


### PR DESCRIPTION
Renders a colored box around nearby carpets within mithril ore veins in dwarven mines.
![image](https://github.com/user-attachments/assets/e284026c-b262-47a9-bce0-50d3bc7ed5e0)
It can be toggled on and off, and the color is configurable.
![image](https://github.com/user-attachments/assets/ae1563a7-d6fe-46b7-985d-20cb356c6ae9)
Uses up about 0.30% of tick time for scanning & rendering while in dwarven mines. Didn't test outside but it should be much less, probably not even worth mentioning as it's just a boolean if check on each tick.
![image](https://github.com/user-attachments/assets/2168eca6-9f62-4c25-8207-dacba7af11a3)

