### PR TITLE
Fix offhand slot moving around

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
@@ -140,7 +140,7 @@ public class SkyblockInventoryScreen extends InventoryScreen {
         for (Slot equipmentSlot : equipmentSlots) {
             boolean hovered = isPointWithinBounds(equipmentSlot.x, equipmentSlot.y, 16, 16, mouseX, mouseY);
 
-            if (hovered) context.drawGuiTexture(RenderLayer::getGuiTextured, HandledScreenAccessor.getSLOT_HIGHLIGHT_BACK_TEXTURE(), equipmentSlot.x - 4, equipmentSlot.y - 4, 24, 24);;
+            if (hovered) context.drawGuiTexture(RenderLayer::getGuiTextured, HandledScreenAccessor.getSLOT_HIGHLIGHT_BACK_TEXTURE(), equipmentSlot.x - 4, equipmentSlot.y - 4, 24, 24);
 
             drawSlot(context, equipmentSlot);
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
@@ -39,9 +39,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
- * Opened here {@code de.hysky.skyblocker.mixins.MinecraftClientMixin#skyblocker$skyblockInventoryScreen}
- * <br>
- * Book button is moved here {@code de.hysky.skyblocker.mixins.InventoryScreenMixin#skyblocker}
+ * <p>Adds equipment slots to the inventory screen and moves the offhand slot.</p>
+ * <p>Opened here {@link de.hysky.skyblocker.mixins.MinecraftClientMixin#skyblocker$skyblockInventoryScreen MinecraftClientMixin#skyblocker$skyblockInventoryScreen}</p>
+ * <p>Book button is moved here {@link de.hysky.skyblocker.mixins.InventoryScreenMixin#skyblocker$moveButton InventoryScreenMixin#skyblocker$moveButton}</p>
  */
 public class SkyblockInventoryScreen extends InventoryScreen {
     private static final Logger LOGGER = LoggerFactory.getLogger("Equipment");

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
@@ -91,7 +91,18 @@ public class SkyblockInventoryScreen extends InventoryScreen {
         }));
     }
 
-    @Init
+	@Override
+	public void onDisplayed() {
+		SimpleInventory inventory = new SimpleInventory(Utils.isInTheRift() ? equipment_rift: equipment);
+
+		Slot slot = handler.slots.get(45);
+		((SlotAccessor) slot).setX(slot.x + 21);
+		for (int i = 0; i < 4; i++) {
+			equipmentSlots[i] = new EquipmentSlot(inventory, i, 77, 8 + i * 18);
+		}
+	}
+
+	@Init
     public static void initEquipment() {
         SkyblockEvents.PROFILE_CHANGE.register(((prevProfileId, profileId) -> {
             if (!prevProfileId.isEmpty()) CompletableFuture.runAsync(() -> save(prevProfileId)).thenRun(() -> load(profileId));
@@ -108,13 +119,6 @@ public class SkyblockInventoryScreen extends InventoryScreen {
 
     public SkyblockInventoryScreen(PlayerEntity player) {
         super(player);
-        SimpleInventory inventory = new SimpleInventory(Utils.isInTheRift() ? equipment_rift: equipment);
-
-        Slot slot = handler.slots.get(45);
-        ((SlotAccessor) slot).setX(slot.x + 21);
-        for (int i = 0; i < 4; i++) {
-            equipmentSlots[i] = new EquipmentSlot(inventory, i, 77, 8 + i * 18);
-        }
     }
 
     @Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
@@ -93,13 +93,8 @@ public class SkyblockInventoryScreen extends InventoryScreen {
 
 	@Override
 	public void onDisplayed() {
-		SimpleInventory inventory = new SimpleInventory(Utils.isInTheRift() ? equipment_rift: equipment);
-
 		Slot slot = handler.slots.get(45);
 		((SlotAccessor) slot).setX(slot.x + 21);
-		for (int i = 0; i < 4; i++) {
-			equipmentSlots[i] = new EquipmentSlot(inventory, i, 77, 8 + i * 18);
-		}
 	}
 
 	@Init
@@ -119,6 +114,10 @@ public class SkyblockInventoryScreen extends InventoryScreen {
 
     public SkyblockInventoryScreen(PlayerEntity player) {
         super(player);
+	    SimpleInventory inventory = new SimpleInventory(Utils.isInTheRift() ? equipment_rift: equipment);
+	    for (int i = 0; i < 4; i++) {
+		    equipmentSlots[i] = new EquipmentSlot(inventory, i, 77, 8 + i * 18);
+	    }
     }
 
     @Override


### PR DESCRIPTION
I actually wanted to put the commit name as the PR title but it's kinda long, you can read that for the actual title

To explain the issue, REI recipes or any other screen that is opened from the inventory screen creates a call to the `removed` method in `SkyblockInventoryScreen`, but if that screen opens back the same instance of the `SkyblockInventoryScreen` the slot will be positioned 21 pixels to the left since the logic to move it back was in the constructor - which isn't called in this case.

This PR makes it move the slot in the `onDisplayed` method, which is called each time the current screen is set, just like `removed`.