### PR TITLE
Add colored item dump output

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DebugCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DebugCategory.java
@@ -2,9 +2,11 @@ package de.hysky.skyblocker.config.categories;
 
 import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
+import de.hysky.skyblocker.debug.Debug;
 import dev.isxander.yacl3.api.ConfigCategory;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.OptionDescription;
+import dev.isxander.yacl3.api.controller.EnumControllerBuilder;
 import dev.isxander.yacl3.api.controller.IntegerSliderControllerBuilder;
 import net.minecraft.text.Text;
 
@@ -33,6 +35,14 @@ public class DebugCategory {
 								() -> config.debug.webSocketDebug,
 								newValue -> config.debug.webSocketDebug = newValue)
 						.controller(ConfigUtils::createBooleanController)
+						.build())
+				.option(Option.<Debug.DumpFormat>createBuilder()
+						.name(Text.translatable("skyblocker.config.debug.dumpFormat"))
+						.description(OptionDescription.of(Text.translatable("skyblocker.config.debug.dumpFormat.@Tooltip")))
+						.binding(defaults.debug.dumpFormat,
+								() -> config.debug.dumpFormat,
+								newValue -> config.debug.dumpFormat = newValue)
+						.controller(opt -> EnumControllerBuilder.create(opt).enumClass(Debug.DumpFormat.class)) // ConfigUtils::createEnumCyclingListController causes a NPE for some reason
 						.build())
 				.build();
 	}

--- a/src/main/java/de/hysky/skyblocker/config/configs/DebugConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DebugConfig.java
@@ -1,10 +1,14 @@
 package de.hysky.skyblocker.config.configs;
 
+import de.hysky.skyblocker.debug.Debug;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 
 public class DebugConfig {
 	@SerialEntry
 	public int dumpRange = 5;
+
+	@SerialEntry
+	public Debug.DumpFormat dumpFormat = Debug.DumpFormat.SNBT;
 
 	@SerialEntry
 	public boolean showInvisibleArmorStands = false;

--- a/src/main/java/de/hysky/skyblocker/debug/Debug.java
+++ b/src/main/java/de/hysky/skyblocker/debug/Debug.java
@@ -19,6 +19,7 @@ import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.option.KeyBinding;
@@ -26,6 +27,7 @@ import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtHelper;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
@@ -83,9 +85,9 @@ public class Debug {
 				Slot focusedSlot = ((HandledScreenAccessor) handledScreen).getFocusedSlot();
 				if (dumpHoveredItemKey.matchesKey(key, scancode) && client.player != null && focusedSlot != null && focusedSlot.hasStack()) {
 					if (!Screen.hasShiftDown()) {
-						client.player.sendMessage(Constants.PREFIX.get().append(Text.literal("Hovered Item: " + SkyblockerMod.GSON_COMPACT.toJson(ItemStack.CODEC.encodeStart(ItemStackComponentizationFixer.getRegistryLookup().getOps(JsonOps.INSTANCE), focusedSlot.getStack()).getOrThrow()))), false);
+						client.player.sendMessage(Constants.PREFIX.get().append("Hovered Item: ").append(SkyblockerConfigManager.get().debug.dumpFormat.format(focusedSlot.getStack())), false);
 					} else {
-						client.player.sendMessage(Constants.PREFIX.get().append(Text.literal("Held Item NW Calcs: " + SkyblockerMod.GSON_COMPACT.toJson(Calculation.LIST_CODEC.encodeStart(JsonOps.INSTANCE, NetworthCalculator.getItemNetworth(focusedSlot.getStack()).calculations()).getOrThrow()))), false);
+						client.player.sendMessage(Constants.PREFIX.get().append("Held Item NW Calcs: ").append(Text.literal(SkyblockerMod.GSON_COMPACT.toJson(Calculation.LIST_CODEC.encodeStart(JsonOps.INSTANCE, NetworthCalculator.getItemNetworth(focusedSlot.getStack()).calculations()).getOrThrow()))), false);
 					}
 				}
 			});
@@ -135,5 +137,22 @@ public class Debug {
 
 					return Command.SINGLE_SUCCESS;
 				});
+	}
+
+	public enum DumpFormat {
+		JSON {
+			@Override
+			public Text format(ItemStack stack) {
+				return Text.literal(SkyblockerMod.GSON_COMPACT.toJson(ItemStack.CODEC.encodeStart(ItemStackComponentizationFixer.getRegistryLookup().getOps(JsonOps.INSTANCE), stack).getOrThrow()));
+			}
+		},
+		SNBT {
+			@Override
+			public Text format(ItemStack stack) {
+				return NbtHelper.toPrettyPrintedText(ItemStack.CODEC.encodeStart(MinecraftClient.getInstance().player.getRegistryManager().getOps(NbtOps.INSTANCE), stack).getOrThrow());
+			}
+		};
+
+		abstract Text format(ItemStack stack);
 	}
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -62,6 +62,8 @@
 
   "skyblocker.config.debug": "Debug",
 
+  "skyblocker.config.debug.dumpFormat": "Dump Format",
+  "skyblocker.config.debug.dumpFormat.@Tooltip": "The format to use when dumping items. SNBT is colored and easier to read while JSON has escaped string characters (double quotes).",
   "skyblocker.config.debug.dumpRange": "Entity Dump Range",
   "skyblocker.config.debug.dumpRange.@Tooltip": "The range in blocks around the player to dump entities within.",
   "skyblocker.config.debug.showInvisibleArmorStands": "Show Invisible Armor Stands",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/116ad335-40bc-45af-bf28-2eb5e75c8df8)
or
![image](https://github.com/user-attachments/assets/11567cda-4cd8-4e68-9633-19dcf3fb75bc)
It configurable
![image](https://github.com/user-attachments/assets/2754f68c-5b4e-4121-b192-c581b54361e4)
Idk the actual use case for the json output so I just kept it as an option.

Also I didn't know abstract classes worked with enums and that each enum implemented their own methods, this is really cool and I'll certainly abuse it from here on.