### PR TITLE
Add powder mining tracker

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/MiningCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/MiningCategory.java
@@ -3,14 +3,17 @@ package de.hysky.skyblocker.config.categories;
 import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.configs.MiningConfig;
+import de.hysky.skyblocker.config.screens.powdertracker.PowderFilterConfigScreen;
 import de.hysky.skyblocker.skyblock.dwarven.CrystalsHudWidget;
 import de.hysky.skyblocker.skyblock.dwarven.CarpetHighlighter;
+import de.hysky.skyblocker.skyblock.dwarven.PowderMiningTracker;
 import dev.isxander.yacl3.api.*;
 import dev.isxander.yacl3.api.controller.ColorControllerBuilder;
 import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
 import de.hysky.skyblocker.utils.Location;
 import dev.isxander.yacl3.api.controller.FloatFieldControllerBuilder;
 import dev.isxander.yacl3.api.controller.IntegerSliderControllerBuilder;
+import it.unimi.dsi.fastutil.objects.ObjectImmutableList;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 
@@ -112,6 +115,12 @@ public class MiningCategory {
                                         newValue -> config.mining.crystalHollows.chestHighlightColor = newValue)
                                 .controller(v -> ColorControllerBuilder.create(v).allowAlpha(true))
                                 .build())
+		                .option(ButtonOption.createBuilder()
+				                .name(Text.translatable("skyblocker.config.mining.crystalHollows.powderTrackerFilter"))
+				                .description(OptionDescription.of(Text.translatable("skyblocker.config.mining.crystalHollows.powderTrackerFilter.@Tooltip")))
+				                .text(Text.translatable("text.skyblocker.open"))
+				                .action((screen, opt) -> MinecraftClient.getInstance().setScreen(new PowderFilterConfigScreen(screen, new ObjectImmutableList<>(PowderMiningTracker.getName2IdMap().keySet()))))
+				                .build())
                         .build())
 
                 //Crystal Hollows Map

--- a/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
@@ -4,6 +4,8 @@ import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import net.minecraft.client.resource.language.I18n;
 
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MiningConfig {
     @SerialEntry
@@ -89,6 +91,9 @@ public class MiningConfig {
 
 	    @SerialEntry
 	    public boolean countNaturalChestsInTracker = true;
+
+		@SerialEntry
+	    public List<String> powderTrackerFilter = new ArrayList<>();
     }
 
     public static class CrystalsHud {

--- a/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/MiningConfig.java
@@ -83,6 +83,12 @@ public class MiningConfig {
 
         @SerialEntry
         public Color chestHighlightColor = new Color(0, 0, 255, 128);
+
+	    @SerialEntry
+	    public boolean enablePowderTracker = true;
+
+	    @SerialEntry
+	    public boolean countNaturalChestsInTracker = true;
     }
 
     public static class CrystalsHud {

--- a/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/ItemTickList.java
+++ b/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/ItemTickList.java
@@ -1,0 +1,79 @@
+package de.hysky.skyblocker.config.screens.powdertracker;
+
+import de.hysky.skyblocker.mixins.accessors.CheckboxWidgetAccessor;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.Selectable;
+import net.minecraft.client.gui.widget.CheckboxWidget;
+import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.text.Text;
+
+import java.util.List;
+
+public class ItemTickList extends ElementListWidget<ItemTickList.ItemTickEntry> {
+	private final List<String> filters;
+	private final List<String> allItems;
+
+	public ItemTickList(MinecraftClient minecraftClient, int width, int height, int y, int entryHeight, List<String> filters, List<String> allItems) {
+		super(minecraftClient, width, height, y, entryHeight);
+		this.filters = filters;
+		this.allItems = allItems;
+	}
+
+	public void clearAndInit() {
+		clearEntries();
+		init();
+	}
+
+	public ItemTickList init() {
+		for (String item : allItems) {
+			ItemTickEntry entry = new ItemTickEntry(
+					CheckboxWidget.builder(Text.of(item), client.textRenderer)
+					              .checked(!filters.contains(item))
+					              .callback((checkbox1, checked) -> {
+						              if (checked) filters.remove(item);
+						              else filters.add(item);
+					              })
+					              .build()
+			);
+			addEntry(entry);
+		}
+		return this;
+	}
+
+	public static class ItemTickEntry extends ElementListWidget.Entry<ItemTickEntry> {
+		private final List<CheckboxWidget> children;
+
+		ItemTickEntry(CheckboxWidget checkboxWidget) {
+			children = List.of(checkboxWidget);
+		}
+
+		public void setChecked(boolean checked) {
+			for (CheckboxWidget child : children) {
+				((CheckboxWidgetAccessor) child).setChecked(checked);
+			}
+		}
+
+		@Override
+		public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+			for (CheckboxWidget child : children) {
+				child.setX(x);
+				child.setY(y);
+				child.setWidth(entryWidth);
+				child.setHeight(entryHeight);
+				child.render(context, mouseX, mouseY, tickDelta);
+			}
+		}
+
+		@Override
+		public List<? extends Selectable> selectableChildren() {
+			return children;
+		}
+
+		@Override
+		public List<? extends Element> children() {
+			return children;
+		}
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
@@ -50,9 +50,11 @@ public class PowderFilterConfigScreen extends Screen {
 			itemTickList.clearAndInit();
 		}).build());
 		adder.add(ButtonWidget.builder(ScreenTexts.DONE, button -> {
-			saveFilters();
-			close();
-		}).build(), 2);
+			                      saveFilters();
+			                      close();
+		                      })
+		                      .width((ButtonWidget.DEFAULT_WIDTH * 2) + 10)
+		                      .build(), 2);
 		gridWidget.refreshPositions();
 		SimplePositioningWidget.setPos(gridWidget, 0, this.height - 64, this.width, 64);
 		gridWidget.forEachChild(this::addDrawableChild);

--- a/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
@@ -32,7 +32,7 @@ public class PowderFilterConfigScreen extends Screen {
 	protected void init() {
 		addDrawable((context, mouseX, mouseY, delta) -> {
 			assert client != null;
-			context.drawCenteredTextWithShadow(client.textRenderer, Text.literal("Shown Items").formatted(Formatting.BOLD), width / 2, (32 - client.textRenderer.fontHeight) / 2, 0xFFFFFF);
+			context.drawCenteredTextWithShadow(client.textRenderer, Text.translatable("skyblocker.config.mining.crystalHollows.powderTrackerFilter.screenTitle").formatted(Formatting.BOLD), width / 2, (32 - client.textRenderer.fontHeight) / 2, 0xFFFFFF);
 		});
 		ItemTickList itemTickList = addDrawableChild(new ItemTickList(MinecraftClient.getInstance(), width, height - 96, 32, 24, filters, allItems).init());
 		//Grid code gratuitously stolen from WaypointsScreen. Same goes for the y and heights above.

--- a/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
@@ -1,0 +1,72 @@
+package de.hysky.skyblocker.config.screens.powdertracker;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.dwarven.PowderMiningTracker;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.GridWidget;
+import net.minecraft.client.gui.widget.SimplePositioningWidget;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PowderFilterConfigScreen extends Screen {
+	@Nullable
+	private final Screen parent;
+	private final List<String> filters;
+	private final List<String> allItems;
+
+	public PowderFilterConfigScreen(@Nullable Screen parent, List<String> allItems) {
+		super(Text.of("Powder Mining Tracker Filter Config"));
+		this.parent = parent;
+		this.filters = new ArrayList<>(SkyblockerConfigManager.get().mining.crystalHollows.powderTrackerFilter); // Copy the list so we can undo changes when necessary
+		this.allItems = allItems;
+	}
+
+	@Override
+	protected void init() {
+		addDrawable((context, mouseX, mouseY, delta) -> {
+			assert client != null;
+			context.drawCenteredTextWithShadow(client.textRenderer, Text.literal("Shown Items").formatted(Formatting.BOLD), width / 2, (32 - client.textRenderer.fontHeight) / 2, 0xFFFFFF);
+		});
+		ItemTickList itemTickList = addDrawableChild(new ItemTickList(MinecraftClient.getInstance(), width, height - 96, 32, 24, filters, allItems).init());
+		//Grid code gratuitously stolen from WaypointsScreen. Same goes for the y and heights above.
+		GridWidget gridWidget = new GridWidget();
+		gridWidget.getMainPositioner().marginX(5).marginY(2);
+		GridWidget.Adder adder = gridWidget.createAdder(2);
+
+		adder.add(ButtonWidget.builder(Text.translatable("text.skyblocker.reset"), button -> {
+			filters.clear();
+			itemTickList.clearAndInit();
+		}).build());
+		adder.add(ButtonWidget.builder(Text.translatable("text.skyblocker.undo"), button -> {
+			filters.clear();
+			filters.addAll(SkyblockerConfigManager.get().mining.crystalHollows.powderTrackerFilter);
+			itemTickList.clearAndInit();
+		}).build());
+		adder.add(ButtonWidget.builder(ScreenTexts.DONE, button -> {
+			saveFilters();
+			close();
+		}).build(), 2);
+		gridWidget.refreshPositions();
+		SimplePositioningWidget.setPos(gridWidget, 0, this.height - 64, this.width, 64);
+		gridWidget.forEachChild(this::addDrawableChild);
+	}
+
+	public void saveFilters() {
+		SkyblockerConfigManager.get().mining.crystalHollows.powderTrackerFilter = filters;
+		SkyblockerConfigManager.save();
+		PowderMiningTracker.filterChangeCallback();
+	}
+
+	@Override
+	public void close() {
+		assert client != null;
+		client.setScreen(parent);
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/config/screens/powdertracker/PowderFilterConfigScreen.java
@@ -63,7 +63,7 @@ public class PowderFilterConfigScreen extends Screen {
 	public void saveFilters() {
 		SkyblockerConfigManager.get().mining.crystalHollows.powderTrackerFilter = filters;
 		SkyblockerConfigManager.save();
-		PowderMiningTracker.filterChangeCallback();
+		PowderMiningTracker.recalculateAll();
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
@@ -5,12 +5,16 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Environment(EnvType.CLIENT)
 public class ChatEvents {
 	/**
 	 * This will be called when a game message is received, cancelled or not.
+	 *
+	 * @implNote Not fired when {@code overlay} is {@code true}. See {@link de.hysky.skyblocker.mixins.MessageHandlerMixin#skyblocker$monitorGameMessage(Text, boolean, CallbackInfo) the mixin} for more information.
 	 */
+	@SuppressWarnings("JavadocReference")
 	public static final Event<ChatTextEvent> RECEIVE_TEXT = EventFactory.createArrayBacked(ChatTextEvent.class, listeners -> message -> {
 		for (ChatTextEvent listener : listeners) {
 			listener.onMessage(message);
@@ -20,7 +24,10 @@ public class ChatEvents {
 	/**
 	 * This will be called when a game message is received, cancelled or not.
 	 * This method is called with the result of {@link Text#getString()} to avoid each listener having to call it.
+	 *
+	 * @implNote Not fired when {@code overlay} is {@code true}. See {@link de.hysky.skyblocker.mixins.MessageHandlerMixin#skyblocker$monitorGameMessage(Text, boolean, CallbackInfo) the mixin} for more information.
 	 */
+	@SuppressWarnings("JavadocReference")
 	public static final Event<ChatStringEvent> RECEIVE_STRING = EventFactory.createArrayBacked(ChatStringEvent.class, listeners -> message -> {
 		for (ChatStringEvent listener : listeners) {
 			listener.onMessage(message);

--- a/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
@@ -1,0 +1,39 @@
+package de.hysky.skyblocker.events;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.text.Text;
+
+@Environment(EnvType.CLIENT)
+public class ChatEvents {
+	/**
+	 * This will be called when a game message is received, cancelled or not.
+	 */
+	public static final Event<ChatTextEvent> RECEIVE_TEXT = EventFactory.createArrayBacked(ChatTextEvent.class, listeners -> message -> {
+		for (ChatTextEvent listener : listeners) {
+			listener.onMessage(message);
+		}
+	});
+
+	/**
+	 * This will be called when a game message is received, cancelled or not.
+	 * This method is called with the result of {@link Text#getString()} to avoid each listener having to call it.
+	 */
+	public static final Event<ChatStringEvent> RECEIVE_STRING = EventFactory.createArrayBacked(ChatStringEvent.class, listeners -> message -> {
+		for (ChatStringEvent listener : listeners) {
+			listener.onMessage(message);
+		}
+	});
+
+	@FunctionalInterface
+	public interface ChatTextEvent {
+		void onMessage(Text message);
+	}
+
+	@FunctionalInterface
+	public interface ChatStringEvent {
+		void onMessage(String message);
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/events/ItemPriceUpdateEvent.java
+++ b/src/main/java/de/hysky/skyblocker/events/ItemPriceUpdateEvent.java
@@ -1,0 +1,21 @@
+package de.hysky.skyblocker.events;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+@FunctionalInterface
+@Environment(EnvType.CLIENT)
+public interface ItemPriceUpdateEvent {
+	void onPriceUpdate();
+
+	/**
+	 * An event that is fired when all prices are updated.
+	 */
+	Event<ItemPriceUpdateEvent> ON_PRICE_UPDATE = EventFactory.createArrayBacked(ItemPriceUpdateEvent.class, listeners -> () -> {
+		for (ItemPriceUpdateEvent listener : listeners) {
+			listener.onPriceUpdate();
+		}
+	});
+}

--- a/src/main/java/de/hysky/skyblocker/events/SkyblockEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/SkyblockEvents.java
@@ -9,68 +9,86 @@ import net.fabricmc.fabric.api.event.EventFactory;
 
 @Environment(EnvType.CLIENT)
 public final class SkyblockEvents {
-    public static final Event<SkyblockJoin> JOIN = EventFactory.createArrayBacked(SkyblockJoin.class, callbacks -> () -> {
-        for (SkyblockEvents.SkyblockJoin callback : callbacks) {
-            callback.onSkyblockJoin();
-        }
-    });
+	public static final Event<SkyblockJoin> JOIN = EventFactory.createArrayBacked(SkyblockJoin.class, callbacks -> () -> {
+		for (SkyblockEvents.SkyblockJoin callback : callbacks) {
+			callback.onSkyblockJoin();
+		}
+	});
 
-    public static final Event<SkyblockLeave> LEAVE = EventFactory.createArrayBacked(SkyblockLeave.class, callbacks -> () -> {
-        for (SkyblockLeave callback : callbacks) {
-            callback.onSkyblockLeave();
-        }
-    });
+	public static final Event<SkyblockLeave> LEAVE = EventFactory.createArrayBacked(SkyblockLeave.class, callbacks -> () -> {
+		for (SkyblockLeave callback : callbacks) {
+			callback.onSkyblockLeave();
+		}
+	});
 
-    public static final Event<SkyblockLocationChange> LOCATION_CHANGE = EventFactory.createArrayBacked(SkyblockLocationChange.class, callbacks -> location -> {
-        for (SkyblockLocationChange callback : callbacks) {
-            callback.onSkyblockLocationChange(location);
-        }
-    });
+	public static final Event<SkyblockLocationChange> LOCATION_CHANGE = EventFactory.createArrayBacked(SkyblockLocationChange.class, callbacks -> location -> {
+		for (SkyblockLocationChange callback : callbacks) {
+			callback.onSkyblockLocationChange(location);
+		}
+	});
 
-    /**
-     * Called when the player's Skyblock profile changes.
-     *
-     * @implNote This is called upon receiving the chat message for the profile change rather than the exact moment of profile change, so it may be delayed by a few seconds.
-     */
-    public static final Event<ProfileChange> PROFILE_CHANGE = EventFactory.createArrayBacked(ProfileChange.class, callbacks -> (prev, profile) -> {
-        for (ProfileChange callback : callbacks) {
-            callback.onSkyblockProfileChange(prev, profile);
-        }
-    });
+	/**
+	 * Called when the player's Skyblock profile changes.
+	 *
+	 * @implNote This is called upon receiving the chat message for the profile change rather than the exact moment of profile change, so it may be delayed by a few seconds.
+	 */
+	public static final Event<ProfileChange> PROFILE_CHANGE = EventFactory.createArrayBacked(ProfileChange.class, callbacks -> (prev, profile) -> {
+		for (ProfileChange callback : callbacks) {
+			callback.onSkyblockProfileChange(prev, profile);
+		}
+	});
 
-    public static final Event<PurseChange> PURSE_CHANGE = EventFactory.createArrayBacked(PurseChange.class, callbacks -> (diff, cause) -> {
-        for (PurseChange callback : callbacks) {
-            callback.onPurseChange(diff, cause);
-        }
-    });
+	/**
+	 * <p>Called when the player's skyblock profile is first detected via chat messages.</p>
+	 * <p>This is useful for initializing data on features that track data for separate profiles separately.</p>
+	 *
+	 * @implNote This is called upon receiving the chat message for the profile change rather than the exact moment of profile change, so it may be delayed by a few seconds.
+	 */
+	public static final Event<ProfileInit> PROFILE_INIT = EventFactory.createArrayBacked(ProfileInit.class, callbacks -> profile -> {
+		for (ProfileInit callback : callbacks) {
+			callback.onSkyblockProfileInit(profile);
+		}
+	});
 
-    @Environment(EnvType.CLIENT)
-    @FunctionalInterface
-    public interface SkyblockJoin {
-        void onSkyblockJoin();
-    }
+	public static final Event<PurseChange> PURSE_CHANGE = EventFactory.createArrayBacked(PurseChange.class, callbacks -> (diff, cause) -> {
+		for (PurseChange callback : callbacks) {
+			callback.onPurseChange(diff, cause);
+		}
+	});
 
-    @Environment(EnvType.CLIENT)
-    @FunctionalInterface
-    public interface SkyblockLeave {
-        void onSkyblockLeave();
-    }
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface SkyblockJoin {
+		void onSkyblockJoin();
+	}
 
-    @Environment(EnvType.CLIENT)
-    @FunctionalInterface
-    public interface SkyblockLocationChange {
-        void onSkyblockLocationChange(Location location);
-    }
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface SkyblockLeave {
+		void onSkyblockLeave();
+	}
 
-    @Environment(EnvType.CLIENT)
-    @FunctionalInterface
-    public interface ProfileChange {
-        void onSkyblockProfileChange(String prevProfileId, String profileId);
-    }
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface SkyblockLocationChange {
+		void onSkyblockLocationChange(Location location);
+	}
 
-    @Environment(EnvType.CLIENT)
-    @FunctionalInterface
-    public interface PurseChange {
-        void onPurseChange(double diff, PurseChangeCause cause);
-    }
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface ProfileChange {
+		void onSkyblockProfileChange(String prevProfileId, String profileId);
+	}
+
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface ProfileInit {
+		void onSkyblockProfileInit(String profileId);
+	}
+
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface PurseChange {
+		void onPurseChange(double diff, PurseChangeCause cause);
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
@@ -1,0 +1,19 @@
+package de.hysky.skyblocker.mixins;
+
+import de.hysky.skyblocker.events.ChatEvents;
+import net.minecraft.client.network.message.MessageHandler;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = MessageHandler.class, priority = 600) //Inject before the default of 1000 so it bypasses fabric's injections
+public class MessageHandlerMixin {
+	@Inject(method = "onGameMessage", at = @At("HEAD"))
+	private void skyblocker$monitorGameMessage(Text message, boolean overlay, CallbackInfo ci) {
+		if (overlay) return; //Can add overlay-specific events in the future or incorporate it into the existing events. For now, it's not necessary.
+		ChatEvents.RECEIVE_TEXT.invoker().onMessage(message);
+		ChatEvents.RECEIVE_STRING.invoker().onMessage(message.getString());
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
@@ -4,14 +4,12 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.HudRenderEvents;
+import de.hysky.skyblocker.skyblock.item.ItemPrice;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.Utils;
 import it.unimi.dsi.fastutil.doubles.DoubleBooleanPair;
-import it.unimi.dsi.fastutil.objects.Object2IntAVLTreeMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
-import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.*;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
@@ -103,6 +101,14 @@ public class PowderMiningTracker {
 				y += 10;
 			}
 			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.literal("Gain: " + NumberFormat.getInstance().format(profit) + " coins").formatted(Formatting.GOLD), 5, y + 10, 0xFFFFFF);
+		});
+
+		ItemPrice.ON_PRICE_UPDATE.register(() -> {
+			profit = 0;
+			ObjectSortedSet<Object2IntMap.Entry<Text>> set = REWARDS.object2IntEntrySet();
+			for (Object2IntMap.Entry<Text> entry : set) {
+				calculateProfitForItem(entry.getKey(), entry.getIntValue());
+			}
 		});
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> dispatcher.register(

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
@@ -9,7 +9,7 @@ import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.HudRenderEvents;
-import de.hysky.skyblocker.skyblock.item.ItemPrice;
+import de.hysky.skyblocker.events.ItemPriceUpdateEvent;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.Location;
@@ -116,7 +116,7 @@ public class PowderMiningTracker {
 			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.literal("Gain: " + NumberFormat.getInstance().format(profit) + " coins").formatted(Formatting.GOLD), 5, y + 10, 0xFFFFFF);
 		});
 
-		ItemPrice.ON_PRICE_UPDATE.register(() -> {
+		ItemPriceUpdateEvent.ON_PRICE_UPDATE.register(() -> {
 			if (isEnabled()) recalculatePrices();
 		});
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
@@ -1,0 +1,223 @@
+package de.hysky.skyblocker.skyblock.dwarven;
+
+import de.hysky.skyblocker.SkyblockerMod;
+import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.events.ChatEvents;
+import de.hysky.skyblocker.events.HudRenderEvents;
+import de.hysky.skyblocker.utils.ItemUtils;
+import de.hysky.skyblocker.utils.Location;
+import de.hysky.skyblocker.utils.Utils;
+import it.unimi.dsi.fastutil.doubles.DoubleBooleanPair;
+import it.unimi.dsi.fastutil.objects.Object2IntAVLTreeMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
+
+public class PowderMiningTracker {
+	private static final Pattern GEMSTONE_SYMBOLS = Pattern.compile("[α☘☠✎✧❁❂❈❤⸕] ");
+	private static final Object2IntAVLTreeMap<Text> REWARDS = new Object2IntAVLTreeMap<>((o1, o2) -> {
+				String o1String = GEMSTONE_SYMBOLS.matcher(o1.getString()).replaceAll("");
+				String o2String = GEMSTONE_SYMBOLS.matcher(o2.getString()).replaceAll("");
+				int priority1 = comparePriority(o1String);
+				int priority2 = comparePriority(o2String);
+				if (priority1 != priority2) return Integer.compare(priority1, priority2);
+				return o1String.compareTo(o2String);
+			}
+	);
+	private static final Object2ObjectMap<String, String> NAME2ID_MAP = new Object2ObjectArrayMap<>(50);
+	private static boolean insideChestMessage = false;
+	private static boolean accountForLootChestsAsWell = true; // TODO: Add a config option for this
+	private static double profit = 0;
+
+	@Init
+	public static void init() {
+		ChatEvents.RECEIVE_TEXT.register(text -> {
+			if (Utils.getLocation() != Location.CRYSTAL_HOLLOWS) return;
+			List<Text> siblings = text.getSiblings();
+			switch (siblings.size()) {
+				// The separator message has 1 sibling: "▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬" for which we can just use .getString on the main text
+				case 1 -> {
+					if (insideChestMessage && text.getString().equals("▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬")) insideChestMessage = false;
+				}
+				// CHEST LOCKPICKED message has 2 siblings: "  ", "CHEST LOCKPICKED "
+				// LOOT CHEST COLLECTED message has 2 siblings: "  ", "LOOT CHEST COLLECTED "
+				// Reward message with 1 item count has 2 siblings: "    ", "item name"
+				case 2 -> {
+					String space = siblings.get(0).getString();
+					Text second = siblings.get(1);
+					String secondString = second.getString();
+					if (!insideChestMessage && space.equals("  ") && (secondString.equals("CHEST LOCKPICKED ") || (accountForLootChestsAsWell && secondString.equals("LOOT CHEST COLLECTED ")))) {
+						insideChestMessage = true;
+						return;
+					}
+
+					if (insideChestMessage && space.equals("    ")) {
+						REWARDS.mergeInt(second, 1, Integer::sum);
+						calculateProfitForItem(second, 1);
+					}
+				}
+				// Reward message with more than 1 item count has 3 siblings: "    ", "item name ", "x<count>" (the space at the end of the item name is not a typo, it's there)
+				// For some reason the green goblin egg and 1 more that I can't figure out have an extra sibling that is always empty (at the 2nd position)
+				// To account for that, this case includes 4 size and there's a check for the 2nd sibling to be empty and the amount parsing has getLast() instead of hardcoded position
+				case 3, 4 -> {
+					if (!insideChestMessage) return;
+					String space = siblings.get(0).getString();
+					if (!space.equals("    ")) return;
+
+					Text itemName = siblings.get(1);
+					int amount;
+
+					if (itemName.getString().isEmpty() && siblings.size() == 3) {
+						itemName = siblings.get(2);
+						amount = 1;
+					} else {
+						String nameTrimmed = itemName.getString().stripTrailing();
+						itemName = Text.literal(nameTrimmed).setStyle(itemName.getStyle());
+						amount = Integer.parseInt(siblings.getLast().getString().substring(1).replace(",", ""));
+					}
+
+					REWARDS.mergeInt(itemName, amount, Integer::sum);
+					calculateProfitForItem(itemName, amount);
+				}
+				default -> {}
+			}
+		});
+
+		HudRenderEvents.AFTER_MAIN_HUD.register((context, tickCounter) -> {
+			if (Utils.getLocation() != Location.CRYSTAL_HOLLOWS) return;
+			int y = MinecraftClient.getInstance().getWindow().getScaledHeight() / 2 - 100;
+			var set = REWARDS.object2IntEntrySet();
+			for (Object2IntMap.Entry<Text> entry : set) {
+				context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, entry.getKey(), 5, y, 0xFFFFFF);
+				context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.of(String.valueOf(entry.getIntValue())), 10 + MinecraftClient.getInstance().textRenderer.getWidth(entry.getKey()), y, 0xFFFFFF);
+				y += 10;
+			}
+			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.literal("Gain: " + NumberFormat.getInstance().format(profit) + " coins").formatted(Formatting.GOLD), 5, y + 10, 0xFFFFFF);
+		});
+
+		ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> dispatcher.register(
+				literal(SkyblockerMod.NAMESPACE)
+						.then(
+								literal("clearrewards")
+										.executes(context -> {
+											REWARDS.clear();
+											return 1;
+										})
+						)
+						.then(
+								literal("listrewards")
+										.executes(context -> {
+											var set = REWARDS.object2IntEntrySet();
+											for (Object2IntMap.Entry<Text> entry : set) {
+												MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(entry.getKey().copy().append(" ").append(Text.of(String.valueOf(entry.getIntValue()))));
+											}
+											return 1;
+										})
+						)
+		));
+	}
+
+	private static int comparePriority(String s) {
+		// Puts gemstone powder at the top of the list, then gold and diamond essence, then gemstones by ascending rarity and then whatever else.
+		switch (s) {
+			case "Gemstone Powder" -> {
+				return 1;
+			}
+			case "Gold Essence" -> {
+				return 2;
+			}
+			case "Diamond Essence" -> {
+				return 3;
+			}
+			default -> {
+				if (s.startsWith("Rough")) return 4;
+				if (s.startsWith("Flawed")) return 5;
+				if (s.startsWith("Fine")) return 6;
+				if (s.startsWith("Flawless")) return 7;
+			}
+		}
+		return 8;
+	}
+
+	private static void calculateProfitForItem(Text text, int amount) {
+		String id = getItemId(text);
+		DoubleBooleanPair price = ItemUtils.getItemPrice(id);
+		if (price.rightBoolean()) profit += price.leftDouble() * amount;
+	}
+
+	static {
+		NAME2ID_MAP.put("Rough Ruby Gemstone", "ROUGH_RUBY_GEM");
+		NAME2ID_MAP.put("Flawed Ruby Gemstone", "FLAWED_RUBY_GEM");
+		NAME2ID_MAP.put("Fine Ruby Gemstone", "FINE_RUBY_GEM");
+		NAME2ID_MAP.put("Flawless Ruby Gemstone", "FLAWLESS_RUBY_GEM");
+
+		NAME2ID_MAP.put("Rough Amethyst Gemstone", "ROUGH_AMETHYST_GEM");
+		NAME2ID_MAP.put("Flawed Amethyst Gemstone", "FLAWED_AMETHYST_GEM");
+		NAME2ID_MAP.put("Fine Amethyst Gemstone", "FINE_AMETHYST_GEM");
+		NAME2ID_MAP.put("Flawless Amethyst Gemstone", "FLAWLESS_AMETHYST_GEM");
+
+		NAME2ID_MAP.put("Rough Jade Gemstone", "ROUGH_JADE_GEM");
+		NAME2ID_MAP.put("Flawed Jade Gemstone", "FLAWED_JADE_GEM");
+		NAME2ID_MAP.put("Fine Jade Gemstone", "FINE_JADE_GEM");
+		NAME2ID_MAP.put("Flawless Jade Gemstone", "FLAWLESS_JADE_GEM");
+
+		NAME2ID_MAP.put("Rough Amber Gemstone", "ROUGH_AMBER_GEM");
+		NAME2ID_MAP.put("Flawed Amber Gemstone", "FLAWED_AMBER_GEM");
+		NAME2ID_MAP.put("Fine Amber Gemstone", "FINE_AMBER_GEM");
+		NAME2ID_MAP.put("Flawless Amber Gemstone", "FLAWLESS_AMBER_GEM");
+
+		NAME2ID_MAP.put("Rough Sapphire Gemstone", "ROUGH_SAPPHIRE_GEM");
+		NAME2ID_MAP.put("Flawed Sapphire Gemstone", "FLAWED_SAPPHIRE_GEM");
+		NAME2ID_MAP.put("Fine Sapphire Gemstone", "FINE_SAPPHIRE_GEM");
+		NAME2ID_MAP.put("Flawless Sapphire Gemstone", "FLAWLESS_SAPPHIRE_GEM");
+
+		NAME2ID_MAP.put("Rough Topaz Gemstone", "ROUGH_TOPAZ_GEM");
+		NAME2ID_MAP.put("Flawed Topaz Gemstone", "FLAWED_TOPAZ_GEM");
+		NAME2ID_MAP.put("Fine Topaz Gemstone", "FINE_TOPAZ_GEM");
+		NAME2ID_MAP.put("Flawless Topaz Gemstone", "FLAWLESS_TOPAZ_GEM");
+
+		NAME2ID_MAP.put("Rough Jasper Gemstone", "ROUGH_JASPER_GEM");
+		NAME2ID_MAP.put("Flawed Jasper Gemstone", "FLAWED_JASPER_GEM");
+		NAME2ID_MAP.put("Fine Jasper Gemstone", "FINE_JASPER_GEM");
+		NAME2ID_MAP.put("Flawless Jasper Gemstone", "FLAWLESS_JASPER_GEM");
+
+		NAME2ID_MAP.put("Pickonimbus 2000", "PICKONIMBUS");
+		NAME2ID_MAP.put("Ascension Rope", "ASCENSION_ROPE");
+		NAME2ID_MAP.put("Wishing Compass", "WISHING_COMPASS");
+		NAME2ID_MAP.put("Gold Essence", "ESSENCE_GOLD");
+		NAME2ID_MAP.put("Diamond Essence", "ESSENCE_DIAMOND");
+		NAME2ID_MAP.put("Prehistoric Egg", "PREHISTORIC_EGG");
+		NAME2ID_MAP.put("Sludge Juice", "SLUDGE_JUICE");
+		NAME2ID_MAP.put("Oil Barrel", "OIL_BARREL");
+		NAME2ID_MAP.put("Jungle Heart", "JUNGLE_HEART");
+		NAME2ID_MAP.put("Treasurite", "TREASURITE");
+		NAME2ID_MAP.put("Yoggie", "YOGGIE");
+
+		NAME2ID_MAP.put("Goblin Egg", "GOBLIN_EGG");
+		NAME2ID_MAP.put("Green Goblin Egg", "GOBLIN_EGG_GREEN");
+		NAME2ID_MAP.put("Blue Goblin Egg", "GOBLIN_EGG_BLUE");
+		NAME2ID_MAP.put("Red Goblin Egg", "GOBLIN_EGG_RED");
+		NAME2ID_MAP.put("Yellow Goblin Egg", "GOBLIN_EGG_YELLOW");
+
+		NAME2ID_MAP.put("Control Switch", "CONTROL_SWITCH");
+		NAME2ID_MAP.put("Electron Transmitter", "ELECTRON_TRANSMITTER");
+		NAME2ID_MAP.put("FTX 3070", "FTX_3070");
+		NAME2ID_MAP.put("Synthetic Heart", "SYNTHETIC_HEART");
+		NAME2ID_MAP.put("Robotron Reflector", "ROBOTRON_REFLECTOR");
+		NAME2ID_MAP.put("Superlite Motor", "SUPERLITE_MOTOR");
+	}
+
+	private static String getItemId(Text text) {
+		return NAME2ID_MAP.getOrDefault(GEMSTONE_SYMBOLS.matcher(text.getString()).replaceAll(""), "");
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
@@ -357,7 +357,7 @@ public class PowderMiningTracker {
 		var set = SHOWN_REWARDS.object2IntEntrySet();
 		for (Object2IntMap.Entry<Text> entry : set) {
 			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, entry.getKey(), 5, y, 0xFFFFFF);
-			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.of(String.valueOf(entry.getIntValue())), 10 + MinecraftClient.getInstance().textRenderer.getWidth(entry.getKey()), y, 0xFFFFFF);
+			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.of(NumberFormat.getInstance().format(entry.getIntValue())), 10 + MinecraftClient.getInstance().textRenderer.getWidth(entry.getKey()), y, 0xFFFFFF);
 			y += 10;
 		}
 		if (!set.isEmpty()) context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.literal("Gain: " + NumberFormat.getInstance().format(profit) + " coins").formatted(Formatting.GOLD), 5, y + 10, 0xFFFFFF);

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
@@ -162,27 +162,19 @@ public class PowderMiningTracker {
 		}
 	}
 
-	private static int comparePriority(String s) {
-		s = GEMSTONE_SYMBOLS.matcher(s).replaceAll(""); // Removes the gemstone symbol from the string to make it easier to compare
+	private static int comparePriority(String string) {
+		string = GEMSTONE_SYMBOLS.matcher(string).replaceAll(""); // Removes the gemstone symbol from the string to make it easier to compare
 		// Puts gemstone powder at the top of the list, then gold and diamond essence, then gemstones by ascending rarity and then whatever else.
-		switch (s) {
-			case "Gemstone Powder" -> {
-				return 1;
-			}
-			case "Gold Essence" -> {
-				return 2;
-			}
-			case "Diamond Essence" -> {
-				return 3;
-			}
-			default -> {
-				if (s.startsWith("Rough")) return 4;
-				if (s.startsWith("Flawed")) return 5;
-				if (s.startsWith("Fine")) return 6;
-				if (s.startsWith("Flawless")) return 7;
-			}
-		}
-		return 8;
+		return switch (string) {
+			case "Gemstone Powder" -> 1;
+			case "Gold Essence" -> 2;
+			case "Diamond Essence" -> 3;
+			case String s when s.startsWith("Rough") -> 4;
+			case String s when s.startsWith("Flawed") -> 5;
+			case String s when s.startsWith("Fine") -> 6;
+			case String s when s.startsWith("Flawless") -> 7;
+			default -> 8;
+		};
 	}
 
 	/**

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PowderMiningTracker.java
@@ -360,6 +360,6 @@ public class PowderMiningTracker {
 			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.of(String.valueOf(entry.getIntValue())), 10 + MinecraftClient.getInstance().textRenderer.getWidth(entry.getKey()), y, 0xFFFFFF);
 			y += 10;
 		}
-		context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.literal("Gain: " + NumberFormat.getInstance().format(profit) + " coins").formatted(Formatting.GOLD), 5, y + 10, 0xFFFFFF);
+		if (!set.isEmpty()) context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.literal("Gain: " + NumberFormat.getInstance().format(profit) + " coins").formatted(Formatting.GOLD), 5, y + 10, 0xFFFFFF);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.item;
 
+import de.hysky.skyblocker.events.ItemPriceUpdateEvent;
 import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.DataTooltipInfoType;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
@@ -8,8 +9,6 @@ import de.hysky.skyblocker.skyblock.searchoverlay.SearchOverManager;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.fabricmc.fabric.api.event.Event;
-import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.item.ItemStack;
@@ -33,15 +32,6 @@ public class ItemPrice {
             GLFW.GLFW_KEY_Z,
             "key.categories.skyblocker"
     ));
-
-	/**
-	 * An event that is fired when all prices are updated.
-	 */
-	public static final Event<OnPriceUpdate> ON_PRICE_UPDATE = EventFactory.createArrayBacked(OnPriceUpdate.class, listeners -> () -> {
-		for (OnPriceUpdate listener : listeners) {
-			listener.onPriceUpdate();
-		}
-	});
 
     public static void itemPriceLookup(ClientPlayerEntity player, @NotNull Slot slot) {
         ItemStack stack = slot.getStack();
@@ -77,7 +67,7 @@ public class ItemPrice {
                         .map(DataTooltipInfoType::downloadIfEnabled)
                         .toArray(CompletableFuture[]::new)
         ).thenRun(() -> {
-	        ON_PRICE_UPDATE.invoker().onPriceUpdate();
+	        ItemPriceUpdateEvent.ON_PRICE_UPDATE.invoker().onPriceUpdate();
 	        player.sendMessage(Constants.PREFIX.get().append(Text.translatable("skyblocker.config.helpers.itemPrice.refreshedItemPrices")), false);
 		}).exceptionally(e -> {
 			ItemTooltip.LOGGER.error("[Skyblocker Item Price] Failed to refresh item prices", e);
@@ -85,9 +75,4 @@ public class ItemPrice {
 			return null;
 		});
     }
-
-	@FunctionalInterface
-	public interface OnPriceUpdate {
-		void onPriceUpdate();
-	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.item;
 
+import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.events.ItemPriceUpdateEvent;
 import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.DataTooltipInfoType;
@@ -32,6 +33,22 @@ public class ItemPrice {
             GLFW.GLFW_KEY_Z,
             "key.categories.skyblocker"
     ));
+
+	/**
+	 * <h2>Crucial init method, do not remove.</h2>
+	 *
+	 * <p>This is required due to the way keybindings are registered via Fabric api and lazy static initialization.</p>
+	 * <p>
+	 *     Key bindings are required to be registered before {@link net.minecraft.client.MinecraftClient#options MinecraftClient#options} is initialized.
+	 *     This is probably due to how fabric adds key binding options to the key binding options screen.
+	 *     Since {@link #ITEM_PRICE_LOOKUP} and {@link #ITEM_PRICE_REFRESH} are static fields, they are initialized lazily, which means they are only initialized when the class is accessed for the first time.
+	 *     That first time is generally when the player is already in the game and tries to use the key bindings in a handled screen, which is much later than the possible initialization period.
+	 *     This causes an {@link IllegalStateException} to be thrown from {@link net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl#registerKeyBinding(KeyBinding) KeyBindingRegistryImpl#registerKeybinding} and the game to crash.
+	 * </p>
+	 */
+	@SuppressWarnings("UnstableApiUsage") //For the javadoc reference.
+	@Init
+	public static void init() {}
 
     public static void itemPriceLookup(ClientPlayerEntity player, @NotNull Slot slot) {
         ItemStack stack = slot.getStack();

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.skyblock.item.tooltip;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.GeneralConfig;
+import de.hysky.skyblocker.skyblock.item.ItemPrice;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.CraftPriceTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.DataTooltipInfoType;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
@@ -83,6 +84,7 @@ public class ItemTooltip {
                     .map(DataTooltipInfoType.class::cast)
                     .map(DataTooltipInfoType::downloadIfEnabled)
                     .toArray(CompletableFuture[]::new)
+            ).thenRun(() -> ItemPrice.ON_PRICE_UPDATE.invoker().onPriceUpdate()
             ).exceptionally(e -> {
                 LOGGER.error("[Skyblocker] Encountered unknown error while downloading tooltip data", e);
                 return null;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
@@ -3,7 +3,7 @@ package de.hysky.skyblocker.skyblock.item.tooltip;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.GeneralConfig;
-import de.hysky.skyblocker.skyblock.item.ItemPrice;
+import de.hysky.skyblocker.events.ItemPriceUpdateEvent;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.CraftPriceTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.DataTooltipInfoType;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
@@ -84,7 +84,7 @@ public class ItemTooltip {
                     .map(DataTooltipInfoType.class::cast)
                     .map(DataTooltipInfoType::downloadIfEnabled)
                     .toArray(CompletableFuture[]::new)
-            ).thenRun(() -> ItemPrice.ON_PRICE_UPDATE.invoker().onPriceUpdate()
+            ).thenRun(ItemPriceUpdateEvent.ON_PRICE_UPDATE.invoker()::onPriceUpdate
             ).exceptionally(e -> {
                 LOGGER.error("[Skyblocker] Encountered unknown error while downloading tooltip data", e);
                 return null;

--- a/src/main/java/de/hysky/skyblocker/utils/Utils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Utils.java
@@ -98,6 +98,8 @@ public class Utils {
     @NotNull
     public static double purse = 0;
 
+	private static boolean firstProfileUpdate = true;
+
     /**
      * @implNote The parent text will always be empty, the actual text content is inside the text's siblings.
      */
@@ -513,6 +515,9 @@ public class Utils {
 
                 if (!prevProfileId.equals(profileId)) {
                     SkyblockEvents.PROFILE_CHANGE.invoker().onSkyblockProfileChange(prevProfileId, profileId);
+                } else if (firstProfileUpdate) {
+					SkyblockEvents.PROFILE_INIT.invoker().onSkyblockProfileInit(profileId);
+	                firstProfileUpdate = false;
                 }
 
                 MuseumItemCache.tick(profileId);

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -23,6 +23,8 @@
   "text.skyblocker.quit_discard": "Quit & Discard Changes",
   "text.skyblocker.confirm": "Confirm",
   "text.skyblocker.config": "Open Config...",
+  "text.skyblocker.reset": "Reset",
+  "text.skyblocker.undo": "Undo",
   "text.skyblocker.source": "Source",
   "text.skyblocker.website": "Website",
   "text.skyblocker.translate": "Translate",
@@ -558,6 +560,8 @@
   "skyblocker.config.mining.crystalHollows.chestHighlighter.@Tooltip": "Highlight found treasure chests and lock pick locations when powder mining.",
   "skyblocker.config.mining.crystalHollows.chestHighlighter.color": "Chest Highlight Color",
   "skyblocker.config.mining.crystalHollows.chestHighlighter.color.@Tooltip": "What color the treasure chests / lock pick should be highlighted.",
+  "skyblocker.config.mining.crystalHollows.powderTrackerFilter": "Powder Tracker Shown Items",
+  "skyblocker.config.mining.crystalHollows.powderTrackerFilter.@Tooltip": "Choose which items to show & include in the profit calculation for the powder tracker.",
 
   "skyblocker.config.mining.crystalsHud": "Crystal Hollows Map",
   "skyblocker.config.mining.crystalsHud.enabled": "Enabled",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -562,6 +562,7 @@
   "skyblocker.config.mining.crystalHollows.chestHighlighter.color.@Tooltip": "What color the treasure chests / lock pick should be highlighted.",
   "skyblocker.config.mining.crystalHollows.powderTrackerFilter": "Powder Tracker Shown Items",
   "skyblocker.config.mining.crystalHollows.powderTrackerFilter.@Tooltip": "Choose which items to show & include in the profit calculation for the powder tracker.",
+  "skyblocker.config.mining.crystalHollows.powderTrackerFilter.screenTitle": "Shown Items",
 
   "skyblocker.config.mining.crystalsHud": "Crystal Hollows Map",
   "skyblocker.config.mining.crystalsHud.enabled": "Enabled",

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -27,6 +27,7 @@
     "InventoryScreenMixin",
     "ItemStackMixin",
     "LeverBlockMixin",
+    "MessageHandlerMixin",
     "MinecraftClientMixin",
     "MouseMixin",
     "MushroomPlantBlockMixin",


### PR DESCRIPTION
Powder mining tracker that tracks rewards and calculates your total profit.
This does not include the money from blocks/other drops you might gain along the way (such as sludge from jungle pick if you go down that route).

![image](https://github.com/user-attachments/assets/5fd4031e-66b8-4d11-b67c-1d287e62703d)


Has a configurable filter to block items from being listed and used in profit calculation.

![image](https://github.com/user-attachments/assets/1be45ff5-b22e-494d-aca4-d06bbde21155)

Saves rewards to disk upon closing the game and reads from disk upon launching the game.

Also adds some chat events that are fired regardless of cancels with no modifications (realistically only against those done via fabric's events).

## Some considerations
- [ ] A timer that can be started/stopped via commands or config buttons, to display alongside the total profit and powder to see average coins/powder per hour
- [ ] Perhaps a proper movable gui element? Not sure since it can go very tall and our gui elements have very opaque backgrounds. Though, it could at least be movable if not one of those gui elements.
- [ ] Some actual commands. There are currently 2 commands that were my initial way of debugging the rewards, with no categorization whatsoever. I have no idea what would be useful, though.
- [ ] Confirmation screen for the config filter? It's probably very easy considering how the list works, just didn't bother.