### PR TITLE
Use empty input for REI recepies intead of AIR

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockCraftingDisplayGenerator.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockCraftingDisplayGenerator.java
@@ -61,7 +61,11 @@ public class SkyblockCraftingDisplayGenerator implements DynamicDisplayGenerator
             recipe.getGrid().forEach((item) -> inputEntryStacks.add(EntryStacks.of(item)));
 
             for (EntryStack<ItemStack> entryStack : inputEntryStacks) {
-                inputs.add(EntryIngredient.of(entryStack));
+                if (entryStack.isEmpty()) {
+                    inputs.add(EntryIngredient.empty());
+                } else {
+                    inputs.add(EntryIngredient.of(entryStack));
+                }
             }
             outputs.add(EntryIngredient.of(EntryStacks.of(recipe.getResult())));
 


### PR DESCRIPTION
This PR was created because of AIR rendering issues in REI, but the original issue is fixed in https://github.com/shedaniel/RoughlyEnoughItems/commit/d698ee2add0caacf484fbe8677aa7c6606623688#diff-610a3d86e27ad89d25f97c7cf969f8dfc0990c902aa55aa637c51ec51b747b2b

Still, AIR produces weird behavior when clicking on empty slots, so it's worth changing: https://imgur.com/a/unH8d81

<details> 
<summary>Old description</summary>
Slots with `AIR` are not rendered properly.
Before: https://i.imgur.com/iYSemp7.png
After: https://i.imgur.com/HABgfbR.png

This is an issue with latest REI ([v17.0.792](https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files/5970164)) and Skyblocker for 1.21.3 (b6bfebcfb3a8bb27fcf1e21839b8f5db0b2eee3f).

Probably a REI issue, but I think it's still worth fixing in Skyblocker since there is a separate API for empty inputs. It is used for vanilla recipes too: https://github.com/shedaniel/RoughlyEnoughItems/blob/17.x-1.21.2/default-plugin/src/main/java/me/shedaniel/rei/plugin/common/displays/crafting/CraftingDisplay.java#L90

There is currently no release of REI for 1.21.4, so I will leave this PR as a draft until REI gets an update.
</details>

