### PR TITLE
Fix crash on missing pet info in slayer rewards

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemRarityBackgrounds.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemRarityBackgrounds.java
@@ -91,10 +91,11 @@ public class ItemRarityBackgrounds {
 			}
 		} else {
 			PetInfo info = stack.getPetInfo();
-			SkyblockItemRarity rarity = info.rarity();
-
-			CACHE.put(hashCode, rarity);
-			return rarity;
+			if (!info.isEmpty()) {
+				SkyblockItemRarity rarity = info.rarity();
+				CACHE.put(hashCode, rarity);
+				return rarity;
+			}
 		}
 
 		CACHE.put(hashCode, null);


### PR DESCRIPTION
Rewards of inferno slayer:
![image](https://github.com/user-attachments/assets/88fa4fb7-ca7b-420a-b2b1-d4658ba29d3c)
```
java.lang.IllegalArgumentException: No enum constant de.hysky.skyblocker.skyblock.item.SkyblockItemRarity.
	at java.base/java.lang.Enum.valueOf(Unknown Source)
	at knot//de.hysky.skyblocker.skyblock.item.SkyblockItemRarity.valueOf(SkyblockItemRarity.java:5)
	at knot//de.hysky.skyblocker.skyblock.item.PetInfo.rarity(PetInfo.java:20)
	at knot//de.hysky.skyblocker.skyblock.item.ItemRarityBackgrounds.getItemRarity(ItemRarityBackgrounds.java:94)
	at knot//de.hysky.skyblocker.skyblock.item.ItemRarityBackgrounds.tryDraw(ItemRarityBackgrounds.java:63)
	at knot//net.minecraft.class_465.handler$cfn000$skyblocker$drawOnItem(class_465.java:5077)
	at knot//net.minecraft.class_465.method_2385(class_465.java:305)
	at knot//net.minecraft.class_465.method_64508(class_465.java:179)
	at knot//net.minecraft.class_465.method_25394(class_465.java:128)
	at knot//net.minecraft.class_476.method_25394(class_476.java:28)
	at knot//net.minecraft.class_437.method_47413(class_437.java:116)
	at knot//net.minecraft.class_757.mixinextras$bridge$method_47413$72(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$bfm000$fabric-screen-api-v1$onRenderScreen(class_757.java:1412)
	at knot//net.minecraft.class_757.mixinextras$bridge$wrapOperation$bfm000$fabric-screen-api-v1$onRenderScreen$74(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$zzl000$aaron-mod$aaronMod$separateGUIScaleForScreens(class_757.java:4972)
	at knot//net.minecraft.class_757.wrapOperation$zzl000$aaron-mod$aaronMod$separateGUIScaleForScreens$mixinextras$bridge$71(class_757.java)
	at knot//net.minecraft.class_757.method_3192(class_757.java:549)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1352)
	at knot//net.minecraft.class_310.method_1514(class_310.java:933)
	at knot//net.minecraft.client.main.Main.main(Main.java:265)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
```