### PR TITLE
Hide latency icons in the tab

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/PlayerListHudMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PlayerListHudMixin.java
@@ -1,0 +1,18 @@
+package de.hysky.skyblocker.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import de.hysky.skyblocker.utils.Utils;
+import net.minecraft.client.gui.hud.PlayerListHud;
+
+@Mixin(PlayerListHud.class)
+public class PlayerListHudMixin {
+
+	@Inject(method = "renderLatencyIcon", at = @At("HEAD"), cancellable = true)
+	private void skyblocker$hideLatencyIcon(CallbackInfo ci) {
+		if (Utils.isOnSkyblock()) ci.cancel();
+	}
+}

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -31,6 +31,7 @@
     "MushroomPlantBlockMixin",
     "PingMeasurerMixin",
     "PlayerInventoryMixin",
+    "PlayerListHudMixin",
     "PlayerSkinProviderMixin",
     "PlayerSkinTextureDownloaderMixin",
     "RenderFishMixin",


### PR DESCRIPTION
Removes the latency icons in the tab while in skyblock since they are useless and just clutter the screen making it much harder to read the tab at higher gui scales. The mixin has been placed in a separate file to avoid conflicts and being blocked by #816.