### PR TITLE
Clamp between 0 and 1

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/GameRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/GameRendererMixin.java
@@ -14,7 +14,7 @@ public class GameRendererMixin {
 	private static float onGetNightVisionStrength(float original) {
 		if (original == 1.0F && Utils.isOnSkyblock()) {
 			var strength = SkyblockerConfigManager.get().uiAndVisuals.nightVisionStrength;
-			if (strength == 0.0D) return 0.0D;
+			if (strength == 0.0F) return 0.0F;
 			return Math.clamp(strength / 100.0F, 0, 1);
 		}
 		return original;

--- a/src/main/java/de/hysky/skyblocker/mixins/GameRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/GameRendererMixin.java
@@ -14,7 +14,8 @@ public class GameRendererMixin {
 	private static float onGetNightVisionStrength(float original) {
 		if (original == 1.0F && Utils.isOnSkyblock()) {
 			var strength = SkyblockerConfigManager.get().uiAndVisuals.nightVisionStrength;
-			return Math.clamp(strength / 100.0F, 0, 100);
+			if (strength == 0.0D) return 0.0D;
+			return Math.clamp(strength / 100.0F, 0, 1);
 		}
 		return original;
 	}


### PR DESCRIPTION
Updated the GameRenderMixin#getNightVisionStrength method to properly clamp the return value between 0 and 1, instead of 0 and 100. Added an additional check to reduce objectively pointless computation.