### PR TITLE
Class-based player glow

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -52,6 +52,14 @@ public class DungeonsCategory {
                         .controller(ConfigUtils::createBooleanController)
                         .build())
                 .option(Option.<Boolean>createBuilder()
+                        .name(Text.translatable("skyblocker.config.dungeons.classBasedPlayerGlow"))
+                        .description(OptionDescription.of(Text.translatable("skyblocker.config.dungeons.classBasedPlayerGlow.@Tooltip")))
+                        .binding(defaults.dungeons.classBasedPlayerGlow,
+                                () -> config.dungeons.classBasedPlayerGlow,
+                                newValue -> config.dungeons.classBasedPlayerGlow = newValue)
+                        .controller(ConfigUtils::createBooleanController)
+                        .build())
+                .option(Option.<Boolean>createBuilder()
                         .name(Text.translatable("skyblocker.config.dungeons.starredMobGlow"))
                         .description(OptionDescription.of(Text.translatable("skyblocker.config.dungeons.starredMobGlow.@Tooltip")))
                         .binding(defaults.dungeons.starredMobGlow,

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -19,6 +19,9 @@ public class DungeonsConfig {
     public boolean playerSecretsTracker = false;
 
     @SerialEntry
+    public boolean classBasedPlayerGlow = false;
+
+    @SerialEntry
     public boolean starredMobGlow = false;
 
     @SerialEntry

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -19,7 +19,7 @@ public class DungeonsConfig {
     public boolean playerSecretsTracker = false;
 
     @SerialEntry
-    public boolean classBasedPlayerGlow = false;
+    public boolean classBasedPlayerGlow = true;
 
     @SerialEntry
     public boolean starredMobGlow = false;

--- a/src/main/java/de/hysky/skyblocker/events/DungeonEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/DungeonEvents.java
@@ -7,24 +7,36 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 public class DungeonEvents {
-    public static final Event<RoomMatched> PUZZLE_MATCHED = EventFactory.createArrayBacked(RoomMatched.class, callbacks -> room -> {
-        for (RoomMatched callback : callbacks) {
-            callback.onRoomMatched(room);
-        }
-    });
+	public static final Event<RoomMatched> PUZZLE_MATCHED = EventFactory.createArrayBacked(RoomMatched.class, callbacks -> room -> {
+		for (RoomMatched callback : callbacks) {
+			callback.onRoomMatched(room);
+		}
+	});
 
-    public static final Event<RoomMatched> ROOM_MATCHED = EventFactory.createArrayBacked(RoomMatched.class, callbacks -> room -> {
-        for (RoomMatched callback : callbacks) {
-            callback.onRoomMatched(room);
-        }
-        if (room.getType() == Room.Type.PUZZLE) {
-            PUZZLE_MATCHED.invoker().onRoomMatched(room);
-        }
-    });
+	public static final Event<RoomMatched> ROOM_MATCHED = EventFactory.createArrayBacked(RoomMatched.class, callbacks -> room -> {
+		for (RoomMatched callback : callbacks) {
+			callback.onRoomMatched(room);
+		}
+		if (room.getType() == Room.Type.PUZZLE) {
+			PUZZLE_MATCHED.invoker().onRoomMatched(room);
+		}
+	});
 
-    @Environment(EnvType.CLIENT)
-    @FunctionalInterface
-    public interface RoomMatched {
-        void onRoomMatched(Room room);
-    }
+	public static final Event<DungeonStarted> DUNGEON_STARTED = EventFactory.createArrayBacked(DungeonStarted.class, callbacks -> () -> {
+		for (DungeonStarted callback : callbacks) {
+			callback.onDungeonStarted();
+		}
+	});
+
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface RoomMatched {
+		void onRoomMatched(Room room);
+	}
+
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface DungeonStarted {
+		void onDungeonStarted();
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/events/DungeonEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/DungeonEvents.java
@@ -22,6 +22,9 @@ public class DungeonEvents {
 		}
 	});
 
+	/**
+	 * Note: This event fires after the tab has changed to include additional information about the run such as each player's class.
+	 */
 	public static final Event<DungeonStarted> DUNGEON_STARTED = EventFactory.createArrayBacked(DungeonStarted.class, callbacks -> () -> {
 		for (DungeonStarted callback : callbacks) {
 			callback.onDungeonStarted();

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonClass.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonClass.java
@@ -1,0 +1,43 @@
+package de.hysky.skyblocker.skyblock.dungeon;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import de.hysky.skyblocker.skyblock.entity.MobGlow;
+
+public enum DungeonClass {
+	UNKNOWN("Unknown", MobGlow.NO_GLOW),
+	HEALER("Healer", 0x820dd1),
+	MAGE("Mage", 0x36c6e3),
+	BERSERK("Berserk", 0xfa5b16),
+	ARCHER("Archer", 0xed240e),
+	TANK("Tank", 0x138717);
+
+	private static final Map<String, DungeonClass> CLASSES = Arrays.stream(values())
+			.collect(Collectors.toUnmodifiableMap(DungeonClass::displayName, Function.identity()));
+
+	private final String name;
+	private final int color;
+
+	DungeonClass(String name, int colour) {
+		this.name = name;
+		this.color = colour;
+	}
+
+	public String displayName() {
+		return this.name;
+	}
+
+	/**
+	 * @return The color of the class in RGB format.
+	 */
+	public int color() {
+		return this.color;
+	}
+
+	public static DungeonClass from(String name) {
+		return CLASSES.getOrDefault(name, UNKNOWN);
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.DungeonsConfig;
+import de.hysky.skyblocker.events.DungeonEvents;
 import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListMgr;
 import de.hysky.skyblocker.utils.Constants;
@@ -67,12 +68,11 @@ public class DungeonScore {
     public static void init() {
 		Scheduler.INSTANCE.scheduleCyclic(DungeonScore::tick, 20);
 		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> reset());
+		DungeonEvents.DUNGEON_STARTED.register(DungeonScore::onDungeonStart);
 		ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
 			if (overlay || !Utils.isInDungeons()) return;
 			String str = message.getString();
-			if (!dungeonStarted) {
-				checkMessageForMort(str);
-			} else {
+			if (dungeonStarted) {
 				checkMessageForDeaths(str);
 				checkMessageForWatcher(str);
 				if (floorHasMimics) checkMessageForMimic(str); //Only called when the message is not cancelled & isn't on the action bar, complementing MimicFilter
@@ -313,11 +313,6 @@ public class DungeonScore {
 
 	private static void checkMessageForWatcher(String message) {
 		if (message.equals("[BOSS] The Watcher: You have proven yourself. You may pass.")) bloodRoomCompleted = true;
-	}
-
-	private static void checkMessageForMort(String message) {
-		if (!message.equals("§e[NPC] §bMort§f: You should find it useful if you get lost.")) return;
-		onDungeonStart();
 	}
 
 	private static void checkMessageForMimic(String message) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonManager.java
@@ -17,6 +17,7 @@ import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.DungeonsConfig;
 import de.hysky.skyblocker.debug.Debug;
+import de.hysky.skyblocker.events.DungeonEvents;
 import de.hysky.skyblocker.skyblock.dungeon.DungeonBoss;
 import de.hysky.skyblocker.skyblock.dungeon.DungeonMap;
 import de.hysky.skyblocker.utils.Constants;
@@ -675,6 +676,10 @@ public class DungeonManager {
             if (WITHER_DOOR_OPENED.matcher(message).matches()) {
                 hasKey = false;
             }
+        }
+
+        if (message.equals("§e[NPC] §bMort§f: You should find it useful if you get lost.")) {
+        	DungeonEvents.DUNGEON_STARTED.invoker().onDungeonStarted();
         }
 
         var newBoss = DungeonBoss.fromMessage(message);

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonPlayerManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonPlayerManager.java
@@ -1,0 +1,56 @@
+package de.hysky.skyblocker.skyblock.dungeon.secrets;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.Range;
+
+import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.events.DungeonEvents;
+import de.hysky.skyblocker.skyblock.dungeon.DungeonClass;
+import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListMgr;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceMap;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
+import net.minecraft.entity.player.PlayerEntity;
+
+public class DungeonPlayerManager {
+	/**
+	 * @implNote Same as {@link de.hysky.skyblocker.skyblock.tabhud.widget.DungeonPlayerWidget#PLAYER_PATTERN}
+	 */
+	private static final Pattern PLAYER_TAB_PATTERN = Pattern.compile("\\[\\d*\\] (?:\\[[A-Za-z]+\\] )?(?<name>[A-Za-z0-9_]*) (?:.* )?\\((?<class>\\S*) ?(?<level>[LXVI]*)\\)");
+	private static final Object2ReferenceMap<String, DungeonClass> PLAYER_CLASSES = new Object2ReferenceOpenHashMap<>(5);
+
+	@Init
+	public static void init() {
+		DungeonEvents.DUNGEON_STARTED.register(DungeonPlayerManager::onDungeonStart);
+	}
+
+	public static DungeonClass getClassFromPlayer(PlayerEntity player) {
+		String name = player.getGameProfile().getName();
+
+		return PLAYER_CLASSES.getOrDefault(name, DungeonClass.UNKNOWN);
+	}
+
+	private static void onDungeonStart() {
+		reset();
+
+		for (int i = 0; i < 5; i++) {
+			Matcher matcher = getPlayerFromTab(i + 1);
+
+			if (matcher != null) {
+				String name = matcher.group("name");
+				DungeonClass dungeonClass = DungeonClass.from(matcher.group("class"));
+
+				if (dungeonClass != DungeonClass.UNKNOWN) PLAYER_CLASSES.put(name, dungeonClass);
+			}
+		}
+	}
+
+	private static void reset() {
+		PLAYER_CLASSES.clear();
+	}
+
+	private static Matcher getPlayerFromTab(@Range(from = 1, to = 5) int index) {
+		return PlayerListMgr.regexAt(1 + (index - 1) * 4, PLAYER_TAB_PATTERN);
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretsTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretsTracker.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.DungeonEvents;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListMgr;
 import de.hysky.skyblocker.skyblock.tabhud.widget.DungeonPlayerWidget;
 import de.hysky.skyblocker.utils.ApiUtils;
@@ -41,6 +42,7 @@ public class SecretsTracker {
 	@Init
 	public static void init() {
 		ClientReceiveMessageEvents.GAME.register(SecretsTracker::onMessage);
+		DungeonEvents.DUNGEON_STARTED.register(() -> calculate(RunPhase.START));
 	}
 
 	private static void calculate(RunPhase phase) {
@@ -101,7 +103,6 @@ public class SecretsTracker {
 	}
 
 	private static void sendResultMessage(String player, SecretData secretData, boolean success) {
-		@SuppressWarnings("resource")
 		PlayerEntity playerEntity = MinecraftClient.getInstance().player;
 		if (playerEntity != null) {
 			if (success) {
@@ -122,7 +123,6 @@ public class SecretsTracker {
 			String message = Formatting.strip(text.getString());
 
 			try {
-				if (message.equals("[NPC] Mort: Here, I found this map when I first entered the dungeon.")) calculate(RunPhase.START);
 				if (TEAM_SCORE_PATTERN.matcher(message).matches()) calculate(RunPhase.END);
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker] Encountered an unknown error while trying to track player secrets!", e);

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlow.java
@@ -6,8 +6,10 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.SlayersConfig;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
 import de.hysky.skyblocker.skyblock.crimson.kuudra.Kuudra;
+import de.hysky.skyblocker.skyblock.dungeon.DungeonScore;
 import de.hysky.skyblocker.skyblock.dungeon.LividColor;
 import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
+import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonPlayerManager;
 import de.hysky.skyblocker.skyblock.end.TheEnd;
 import de.hysky.skyblocker.skyblock.slayers.SlayerManager;
 import de.hysky.skyblocker.skyblock.slayers.SlayerType;
@@ -32,6 +34,7 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class MobGlow {
+	public static final int NO_GLOW = 0;
 	/**
 	 * The Nukekubi head texture id is eb07594e2df273921a77c101d0bfdfa1115abed5b9b2029eb496ceba9bdbb4b3.
 	 */
@@ -58,7 +61,7 @@ public class MobGlow {
 			return true;
 		}
 		int color = computeMobGlow(entity);
-		if (color != 0) {
+		if (color != NO_GLOW) {
 			CACHE.put(entity, color);
 			return true;
 		}
@@ -93,6 +96,9 @@ public class MobGlow {
 				case PlayerEntity p when SkyblockerConfigManager.get().dungeons.starredMobGlow && !DungeonManager.getBoss().isFloor(4) && name.equals("Diamond Guy") -> 0x57c2f7;
 				case PlayerEntity p when entity.getId() == LividColor.getCorrectLividId() && LividColor.shouldGlow(name) -> LividColor.getGlowColor(name);
 
+				//Class-based glow
+				case PlayerEntity p when SkyblockerConfigManager.get().dungeons.classBasedPlayerGlow && DungeonScore.isDungeonStarted() -> DungeonPlayerManager.getClassFromPlayer(p).color();
+
 				// Bats
 				case BatEntity b when SkyblockerConfigManager.get().dungeons.starredMobGlow -> 0xf57738;
 
@@ -104,7 +110,7 @@ public class MobGlow {
 
 				// Regular Mobs
 				case Entity e when SkyblockerConfigManager.get().dungeons.starredMobGlow && isStarred(entity) -> 0xf57738;
-				default -> 0;
+				default -> NO_GLOW;
 			};
 		}
 
@@ -137,7 +143,7 @@ public class MobGlow {
 			case WitherSkeletonEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW && SlayerManager.isInSlayerType(SlayerType.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 15 -> AttunementColors.getColor(e);
 			case ZombifiedPiglinEntity e when SkyblockerConfigManager.get().slayers.highlightBosses == SlayersConfig.HighlightSlayerEntities.GLOW && SlayerManager.isInSlayerType(SlayerType.DEMONLORD) && e.distanceTo(MinecraftClient.getInstance().player) <= 15 -> AttunementColors.getColor(e);
 
-			default -> 0;
+			default -> NO_GLOW;
 		};
 	}
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -77,6 +77,9 @@
   "skyblocker.config.dungeons.croesusHelper": "Croesus Helper",
   "skyblocker.config.dungeons.croesusHelper.@Tooltip": "Gray out chests that have already been opened.",
 
+  "skyblocker.config.dungeons.classBasedPlayerGlow": "Class-based Player Glow",
+  "skyblocker.config.dungeons.classBasedPlayerGlow.@Tooltip": "Changes the color of your teammates glow to be based on their class rather than their rank.",
+
   "skyblocker.config.dungeons.goldorWaypoints": "Goldor Tasks Waypoints (F7/M7)",
   "skyblocker.config.dungeons.goldorWaypoints.enableGoldorWaypoints": "Enable waypoints for terminals/devices/levers during Goldor",
   "skyblocker.config.dungeons.goldorWaypoints.waypointType": "Task waypoint type",


### PR DESCRIPTION
Adds an option to change the glow colour from being based on rank to being based on the players class, the colours come from M7 strategies and relate to wither armour somewhat.

Also adds an event for the dungeon starting since a few different places across the codebase seemed to detect it already and it would be good to avoid duplicating the logic.