### PR TITLE
Chat events refactor

### DIFF
--- a/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
@@ -5,6 +5,7 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Environment(EnvType.CLIENT)
@@ -23,7 +24,7 @@ public class ChatEvents {
 
 	/**
 	 * This will be called when a game message is received, cancelled or not.
-	 * This method is called with the result of {@link Text#getString()} to avoid each listener having to call it.
+	 * This method is called with the result of {@link Text#getString} and {@link Formatting#strip} to avoid each listener having to call it.
 	 *
 	 * @implNote Not fired when {@code overlay} is {@code true}. See {@link de.hysky.skyblocker.mixins.MessageHandlerMixin#skyblocker$monitorGameMessage(Text, boolean, CallbackInfo) the mixin} for more information.
 	 */

--- a/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/ChatEvents.java
@@ -35,6 +35,31 @@ public class ChatEvents {
 		}
 	});
 
+	/**
+	 * This will be called when a game message is received, cancelled or not.
+	 *
+	 * @implNote Not fired when {@code overlay} is {@code false}. See {@link de.hysky.skyblocker.mixins.MessageHandlerMixin#skyblocker$monitorGameMessage(Text, boolean, CallbackInfo) the mixin} for more information.
+	 */
+	@SuppressWarnings("JavadocReference")
+	public static final Event<ChatTextEvent> RECEIVE_OVERLAY_TEXT = EventFactory.createArrayBacked(ChatTextEvent.class, listeners -> message -> {
+		for (ChatTextEvent listener : listeners) {
+			listener.onMessage(message);
+		}
+	});
+
+	/**
+	 * This will be called when a game message is received, cancelled or not.
+	 * This method is called with the result of {@link Text#getString} and {@link Formatting#strip} to avoid each listener having to call it.
+	 *
+	 * @implNote Not fired when {@code overlay} is {@code false}. See {@link de.hysky.skyblocker.mixins.MessageHandlerMixin#skyblocker$monitorGameMessage(Text, boolean, CallbackInfo) the mixin} for more information.
+	 */
+	@SuppressWarnings("JavadocReference")
+	public static final Event<ChatStringEvent> RECEIVE_OVERLAY_STRING = EventFactory.createArrayBacked(ChatStringEvent.class, listeners -> message -> {
+		for (ChatStringEvent listener : listeners) {
+			listener.onMessage(message);
+		}
+	});
+
 	@FunctionalInterface
 	public interface ChatTextEvent {
 		void onMessage(Text message);

--- a/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.mixins;
 import de.hysky.skyblocker.events.ChatEvents;
 import net.minecraft.client.network.message.MessageHandler;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,6 +15,6 @@ public class MessageHandlerMixin {
 	private void skyblocker$monitorGameMessage(Text message, boolean overlay, CallbackInfo ci) {
 		if (overlay) return; //Can add overlay-specific events in the future or incorporate it into the existing events. For now, it's not necessary.
 		ChatEvents.RECEIVE_TEXT.invoker().onMessage(message);
-		ChatEvents.RECEIVE_STRING.invoker().onMessage(message.getString());
+		ChatEvents.RECEIVE_STRING.invoker().onMessage(Formatting.strip(message.getString()));
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
@@ -13,8 +13,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MessageHandlerMixin {
 	@Inject(method = "onGameMessage", at = @At("HEAD"))
 	private void skyblocker$monitorGameMessage(Text message, boolean overlay, CallbackInfo ci) {
-		if (overlay) return; //Can add overlay-specific events in the future or incorporate it into the existing events. For now, it's not necessary.
-		ChatEvents.RECEIVE_TEXT.invoker().onMessage(message);
-		ChatEvents.RECEIVE_STRING.invoker().onMessage(Formatting.strip(message.getString()));
+		String stripped = Formatting.strip(message.getString());
+		if (overlay) {
+			ChatEvents.RECEIVE_TEXT.invoker().onMessage(message);
+			ChatEvents.RECEIVE_STRING.invoker().onMessage(stripped);
+		} else {
+			ChatEvents.RECEIVE_OVERLAY_TEXT.invoker().onMessage(message);
+			ChatEvents.RECEIVE_OVERLAY_STRING.invoker().onMessage(stripped);
+		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/accessories/newyearcakes/NewYearCakesHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/accessories/newyearcakes/NewYearCakesHelper.java
@@ -1,15 +1,14 @@
 package de.hysky.skyblocker.skyblock.accessories.newyearcakes;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Utils;
-import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import de.hysky.skyblocker.utils.container.SimpleContainerSolver;
+import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.item.ItemStack;
-import net.minecraft.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +28,7 @@ public class NewYearCakesHelper extends SimpleContainerSolver {
 
     private NewYearCakesHelper() {
         super("Auctions: \".*\"");
-        ClientReceiveMessageEvents.GAME.register(this::onChatMessage);
+	    ChatEvents.RECEIVE_STRING.register(this::onChatMessage);
     }
 
     public static int getCakeYear(ItemStack stack) {
@@ -58,9 +57,9 @@ public class NewYearCakesHelper extends SimpleContainerSolver {
         return cakes.computeIfAbsent(Utils.getProfile(), _profile -> new IntOpenHashSet()).add(year);
     }
 
-    private void onChatMessage(Text message, boolean overlay) {
+    private void onChatMessage(String message) {
         if (isEnabled()) {
-            addCake(getCakeYear(NEW_YEAR_CAKE_PURCHASE, message.getString()));
+            addCake(getCakeYear(NEW_YEAR_CAKE_PURCHASE, message));
         }
     }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
@@ -3,13 +3,13 @@ package de.hysky.skyblocker.skyblock.chat;
 import com.mojang.brigadier.Command;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.HoverEvent;
@@ -38,7 +38,7 @@ public class ChatPositionShare {
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> dispatcher.register(
 				ClientCommandManager.literal("skyblocker").then(ClientCommandManager.literal("sharePosition").executes(context -> sharePlayerPosition(context.getSource())))
 		));
-        ClientReceiveMessageEvents.GAME.register(ChatPositionShare::onMessage);
+	    ChatEvents.RECEIVE_STRING.register(ChatPositionShare::onMessage);
     }
 
 	private static int sharePlayerPosition(FabricClientCommandSource source) {
@@ -47,10 +47,8 @@ public class ChatPositionShare {
 		return Command.SINGLE_SUCCESS;
 	}
 
-    private static void onMessage(Text text, boolean overlay) {
+    private static void onMessage(String message) {
         if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.waypoints.enableWaypoints) {
-            String message = text.getString();
-
             for (Pattern pattern : PATTERNS) {
                 Matcher matcher = pattern.matcher(message);
                 if (matcher.find()) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ConfirmationPromptHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ConfirmationPromptHelper.java
@@ -4,10 +4,10 @@ import java.util.Optional;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
@@ -23,7 +23,7 @@ public class ConfirmationPromptHelper {
 
 	@Init
 	public static void init() {
-		ClientReceiveMessageEvents.GAME.register(ConfirmationPromptHelper::onMessage);
+		ChatEvents.RECEIVE_TEXT.register(ConfirmationPromptHelper::onMessage);
 		ScreenEvents.AFTER_INIT.register((_client, screen, _scaledWidth, _scaledHeight) -> {
 			//Don't check for the command being present in case the user opens the chat before the prompt is sent
 			if (Utils.isOnSkyblock() && screen instanceof ChatScreen && SkyblockerConfigManager.get().chat.confirmationPromptHelper) {
@@ -46,12 +46,12 @@ public class ConfirmationPromptHelper {
 		return command != null && commandFoundAt + 60_000 > System.currentTimeMillis();
 	}
 
-	private static void onMessage(Text message, boolean overlay) {
-		if (Utils.isOnSkyblock() && !overlay && SkyblockerConfigManager.get().chat.confirmationPromptHelper && message.getString().contains("[YES]")) {
+	private static void onMessage(Text message) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().chat.confirmationPromptHelper && message.getString().contains("[YES]")) {
 			Optional<String> confirmationCommand = message.visit((style, asString) -> {
 				ClickEvent event = style.getClickEvent();
 
-				//Check to see if its a yes and has the proper command
+				//Check to see if it's a yes and has the proper command
 				if (asString.equals("§a§l[YES]") && event != null && event.getAction() == ClickEvent.Action.RUN_COMMAND && event.getValue().startsWith("/chatprompt")) {
 					return Optional.of(event.getValue());
 				}

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/SkyblockXpMessages.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/SkyblockXpMessages.java
@@ -2,30 +2,28 @@ package de.hysky.skyblocker.skyblock.chat;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.text.Text;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SkyblockXpMessages {
 	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
-	private static final Pattern SKYBLOCK_XP_PATTERN = Pattern.compile("§b\\+\\d+ SkyBlock XP §7\\([^()]+§7\\)§b \\(\\d+\\/\\d+\\)");
+	private static final Pattern SKYBLOCK_XP_PATTERN = Pattern.compile("\\+\\d+ SkyBlock XP \\([^()]+\\) \\(\\d+/\\d+\\)");
 	private static final IntOpenHashSet RECENT_MESSAGES = new IntOpenHashSet();
 
 	@Init
 	public static void init() {
-		ClientReceiveMessageEvents.GAME.register(SkyblockXpMessages::onMessage);
+		ChatEvents.RECEIVE_OVERLAY_STRING.register(SkyblockXpMessages::onOverlayMessage);
 	}
 
-	private static void onMessage(Text text, boolean overlay) {
-		if (Utils.isOnSkyblock() && overlay && SkyblockerConfigManager.get().chat.skyblockXpMessages) {
-			String message = text.getString();
+	private static void onOverlayMessage(String message) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().chat.skyblockXpMessages) {
 			Matcher matcher = SKYBLOCK_XP_PATTERN.matcher(message);
 
 			if (matcher.find()) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/MimicFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/MimicFilter.java
@@ -1,15 +1,9 @@
 package de.hysky.skyblocker.skyblock.chat.filters;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
-import de.hysky.skyblocker.skyblock.dungeon.DungeonScore;
-import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.chat.ChatFilterResult;
-import de.hysky.skyblocker.utils.chat.ChatPatternListener;
-import net.minecraft.text.Text;
 
-import java.util.regex.Matcher;
-
-public class MimicFilter extends ChatPatternListener {
+public class MimicFilter extends SimpleChatFilter {
     public MimicFilter() {
         super(".*?(?:Mimic dead!?|Mimic Killed!|\\$SKYTILS-DUNGEON-SCORE-MIMIC\\$|\\Q" + SkyblockerConfigManager.get().dungeons.mimicMessage.mimicMessage + "\\E)$");
     }
@@ -17,12 +11,5 @@ public class MimicFilter extends ChatPatternListener {
     @Override
     public ChatFilterResult state() {
         return SkyblockerConfigManager.get().chat.hideMimicKill;
-    }
-
-    @Override
-    protected boolean onMatch(Text message, Matcher matcher) {
-        if (!Utils.isInDungeons() || !DungeonScore.isDungeonStarted() || !DungeonScore.isMimicOnCurrentFloor()) return false;
-        DungeonScore.onMimicKill(); //Only called when the message is cancelled | sent to action bar, complementing DungeonScore#checkMessageForMimic
-        return true;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
@@ -4,6 +4,7 @@ import com.mojang.brigadier.Command;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.*;
 import de.hysky.skyblocker.utils.command.argumenttypes.EggTypeArgumentType;
@@ -15,7 +16,6 @@ import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import it.unimi.dsi.fastutil.objects.ObjectImmutableList;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -67,7 +67,7 @@ public class EggFinder {
 			}
 		});
 		SkyblockEvents.LOCATION_CHANGE.register(EggFinder::handleLocationChange);
-		ClientReceiveMessageEvents.GAME.register(EggFinder::onChatMessage);
+		ChatEvents.RECEIVE_STRING.register(EggFinder::onChatMessage);
 		WorldRenderEvents.AFTER_TRANSLUCENT.register(EggFinder::renderWaypoints);
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			if (!SkyblockerConfigManager.get().helpers.chocolateFactory.enableEggFinder || client.player == null) return;
@@ -147,9 +147,9 @@ public class EggFinder {
 		}
 	}
 
-	private static void onChatMessage(Text text, boolean overlay) {
-		if (overlay || !SkyblockerConfigManager.get().helpers.chocolateFactory.enableEggFinder) return;
-		Matcher matcher = eggFoundPattern.matcher(text.getString());
+	private static void onChatMessage(String message) {
+		if (!SkyblockerConfigManager.get().helpers.chocolateFactory.enableEggFinder) return;
+		Matcher matcher = eggFoundPattern.matcher(message);
 		if (matcher.find()) {
 			try {
 				EggType eggType = EggType.valueOf(matcher.group(1).toUpperCase());

--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/TimeTowerReminder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/TimeTowerReminder.java
@@ -1,14 +1,13 @@
 package de.hysky.skyblocker.skyblock.chocolatefactory;
 
-import com.mojang.brigadier.Message;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -34,11 +33,11 @@ public class TimeTowerReminder {
 	@Init
 	public static void init() {
 		SkyblockEvents.JOIN.register(TimeTowerReminder::checkTempFile);
-		ClientReceiveMessageEvents.GAME.register(TimeTowerReminder::checkIfTimeTower);
+		ChatEvents.RECEIVE_STRING.register(TimeTowerReminder::checkIfTimeTower);
 	}
 
-	public static void checkIfTimeTower(Message message, boolean overlay) {
-		if (!TIME_TOWER_PATTERN.matcher(message.getString()).matches() || scheduled) return;
+	public static void checkIfTimeTower(String message) {
+		if (!TIME_TOWER_PATTERN.matcher(message).matches() || scheduled) return;
 		Scheduler.INSTANCE.schedule(TimeTowerReminder::sendMessage, 60 * 60 * 20); // 1 hour
 		scheduled = true;
 		File tempFile = SkyblockerMod.CONFIG_DIR.resolve(TIME_TOWER_FILE).toFile();

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/kuudra/Kuudra.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/kuudra/Kuudra.java
@@ -1,11 +1,9 @@
 package de.hysky.skyblocker.skyblock.crimson.kuudra;
 
 import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Utils;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 
 public class Kuudra { 
 	public static final int KUUDRA_MAGMA_CUBE_SIZE = 30;
@@ -15,13 +13,11 @@ public class Kuudra {
 	@Init
 	public static void init() {
 		ClientPlayConnectionEvents.JOIN.register((_handler, _sender, _client) -> reset());
-		ClientReceiveMessageEvents.GAME.register(Kuudra::onMessage);
+		ChatEvents.RECEIVE_STRING.register(Kuudra::onMessage);
 	}
 
-	private static void onMessage(Text text, boolean overlay) {
-		if (Utils.isInKuudra() && !overlay) {
-			String message = Formatting.strip(text.getString());
-
+	private static void onMessage(String message) {
+		if (Utils.isInKuudra()) {
 			if (message.equals("[NPC] Elle: ARGH! All of the supplies fell into the lava! You need to retrieve them quickly!")) {
 				phase = KuudraPhase.RETRIEVE_SUPPLIES;
 			}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
@@ -90,11 +90,11 @@ public class DungeonScore {
 		score = calculateScore();
 		if (!sent270 && !sent300 && score >= 270 && score < 300) {
 			if (SCORE_CONFIG.enableDungeonScore270Message) {
-				MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + Constants.PREFIX.get().getString() + SCORE_CONFIG.dungeonScore270Message.replaceAll("\\[score]", "270"), false);
+				MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + Constants.PREFIX.get().getString() + SCORE_CONFIG.dungeonScore270Message.replace("[score]", "270"), false);
 			}
 			if (SCORE_CONFIG.enableDungeonScore270Title) {
 				client.inGameHud.setDefaultTitleFade();
-				client.inGameHud.setTitle(Constants.PREFIX.get().append(SCORE_CONFIG.dungeonScore270Message.replaceAll("\\[score]", "270")));
+				client.inGameHud.setTitle(Constants.PREFIX.get().append(SCORE_CONFIG.dungeonScore270Message.replace("[score]", "270")));
 			}
 			if (SCORE_CONFIG.enableDungeonScore270Sound) {
 				client.player.playSound(SoundEvents.BLOCK_NOTE_BLOCK_PLING.value(), 100f, 0.1f);
@@ -105,18 +105,18 @@ public class DungeonScore {
 		int crypts = getCrypts();
 		if (!sentCrypts && score >= SCORE_CONFIG.dungeonCryptsMessageThreshold && crypts < 5) {
 			if (SCORE_CONFIG.enableDungeonCryptsMessage) {
-				MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + Constants.PREFIX.get().getString() + SCORE_CONFIG.dungeonCryptsMessage.replaceAll("\\[crypts]", String.valueOf(crypts)), false);
+				MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + Constants.PREFIX.get().getString() + SCORE_CONFIG.dungeonCryptsMessage.replace("[crypts]", String.valueOf(crypts)), false);
 			}
 			sentCrypts = true;
 		}
 
 		if (!sent300 && score >= 300) {
 			if (SCORE_CONFIG.enableDungeonScore300Message) {
-				MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + Constants.PREFIX.get().getString() + SCORE_CONFIG.dungeonScore300Message.replaceAll("\\[score]", "300"), false);
+				MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + Constants.PREFIX.get().getString() + SCORE_CONFIG.dungeonScore300Message.replace("[score]", "300"), false);
 			}
 			if (SCORE_CONFIG.enableDungeonScore300Title) {
 				client.inGameHud.setDefaultTitleFade();
-				client.inGameHud.setTitle(Constants.PREFIX.get().append(SCORE_CONFIG.dungeonScore300Message.replaceAll("\\[score]", "300")));
+				client.inGameHud.setTitle(Constants.PREFIX.get().append(SCORE_CONFIG.dungeonScore300Message.replace("[score]", "300")));
 			}
 			if (SCORE_CONFIG.enableDungeonScore300Sound) {
 				client.player.playSound(SoundEvents.BLOCK_NOTE_BLOCK_PLING.value(), 100f, 0.1f);

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/FireFreezeStaffTimer.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/FireFreezeStaffTimer.java
@@ -2,15 +2,13 @@ package de.hysky.skyblocker.skyblock.dungeon;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.HudRenderEvents;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderTickCounter;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 
 public class FireFreezeStaffTimer {
     private static long fireFreezeTimer;
@@ -18,7 +16,7 @@ public class FireFreezeStaffTimer {
     @Init
     public static void init() {
         HudRenderEvents.BEFORE_CHAT.register(FireFreezeStaffTimer::onDraw);
-        ClientReceiveMessageEvents.GAME.register(FireFreezeStaffTimer::onChatMessage);
+        ChatEvents.RECEIVE_STRING.register(FireFreezeStaffTimer::onChatMessage);
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> FireFreezeStaffTimer.reset());
     }
 
@@ -53,9 +51,9 @@ public class FireFreezeStaffTimer {
         fireFreezeTimer = 0;
     }
 
-    private static void onChatMessage(Text text, boolean overlay) {
-        if (!overlay && SkyblockerConfigManager.get().dungeons.theProfessor.fireFreezeStaffTimer && Formatting.strip(text.getString())
-                .equals("[BOSS] The Professor: Oh? You found my Guardians' one weakness?")) {
+    private static void onChatMessage(String message) {
+        if (SkyblockerConfigManager.get().dungeons.theProfessor.fireFreezeStaffTimer
+		            && message.equals("[BOSS] The Professor: Oh? You found my Guardians' one weakness?")) {
             fireFreezeTimer = System.currentTimeMillis() + 5000L;
         }
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GoldorWaypointsManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GoldorWaypointsManager.java
@@ -8,13 +8,13 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.waypoint.NamedWaypoint;
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -65,8 +65,7 @@ public class GoldorWaypointsManager {
 	public static void init() {
         WorldRenderEvents.AFTER_TRANSLUCENT.register(GoldorWaypointsManager::render);
         ClientLifecycleEvents.CLIENT_STARTED.register(GoldorWaypointsManager::load);
-        ClientReceiveMessageEvents.GAME.register(GoldorWaypointsManager::onChatMessage);
-        ClientReceiveMessageEvents.GAME_CANCELED.register(GoldorWaypointsManager::onChatMessage);
+		ChatEvents.RECEIVE_STRING.register(GoldorWaypointsManager::onChatMessage);
         ClientPlayConnectionEvents.JOIN.register(((handler, sender, client) -> reset()));
     }
 
@@ -153,10 +152,8 @@ public class GoldorWaypointsManager {
         return matcher.matches() ? matcher.group("name") : null;
     }
 
-    private static void onChatMessage(Text text, boolean overlay) {
-        if (overlay || !shouldProcessMsgs()) return;
-        String message = text.getString();
-
+    private static void onChatMessage(String message) {
+        if (!shouldProcessMsgs()) return;
         if (active) {
             if (PHASE_COMPLETE.matcher(message).matches()) {
                 currentPhase++;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GuardianHealth.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GuardianHealth.java
@@ -2,9 +2,9 @@ package de.hysky.skyblocker.skyblock.dungeon;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.RenderHelper;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -28,7 +28,7 @@ public class GuardianHealth {
 
     @Init
     public static void init() {
-        ClientReceiveMessageEvents.GAME.register(GuardianHealth::onChatMessage);
+        ChatEvents.RECEIVE_STRING.register(GuardianHealth::onChatMessage);
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> GuardianHealth.reset());
         WorldRenderEvents.AFTER_ENTITIES.register(GuardianHealth::onWorldRender);
     }
@@ -79,11 +79,9 @@ public class GuardianHealth {
         inBoss = false;
     }
 
-    private static void onChatMessage(Text text, boolean overlay) {
+    private static void onChatMessage(String message) {
         if (Utils.isInDungeons() && SkyblockerConfigManager.get().dungeons.theProfessor.floor3GuardianHealthDisplay && !inBoss) {
-            String unformatted = Formatting.strip(text.getString());
-
-            inBoss = unformatted.equals("[BOSS] The Professor: I was burdened with terrible news recently...");
+            inBoss = message.equals("[BOSS] The Professor: I was burdened with terrible news recently...");
         }
     }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/ThreeWeirdos.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/ThreeWeirdos.java
@@ -2,10 +2,10 @@ package de.hysky.skyblocker.skyblock.dungeon.puzzle;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
 import de.hysky.skyblocker.skyblock.dungeon.secrets.Room;
 import de.hysky.skyblocker.utils.render.RenderHelper;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.minecraft.client.MinecraftClient;
@@ -32,12 +32,11 @@ public class ThreeWeirdos extends DungeonPuzzle {
 
     private ThreeWeirdos() {
         super("three-weirdos", "three-chests");
-        ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
+	    ChatEvents.RECEIVE_STRING.register(message -> {
             ClientWorld world = MinecraftClient.getInstance().world;
-            if (overlay || !shouldSolve() || !SkyblockerConfigManager.get().dungeons.puzzleSolvers.solveThreeWeirdos || world == null || !DungeonManager.isCurrentRoomMatched()) return;
+            if (!shouldSolve() || !SkyblockerConfigManager.get().dungeons.puzzleSolvers.solveThreeWeirdos || world == null || !DungeonManager.isCurrentRoomMatched()) return;
 
-            @SuppressWarnings("DataFlowIssue")
-            Matcher matcher = PATTERN.matcher(Formatting.strip(message.getString()));
+            Matcher matcher = PATTERN.matcher(message);
             if (!matcher.matches()) return;
             String name = matcher.group(1);
             Room room = DungeonManager.getCurrentRoom();

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretsTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretsTracker.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.DungeonEvents;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListMgr;
 import de.hysky.skyblocker.skyblock.tabhud.widget.DungeonPlayerWidget;
@@ -13,12 +14,10 @@ import de.hysky.skyblocker.utils.Http;
 import de.hysky.skyblocker.utils.Http.ApiResponse;
 import de.hysky.skyblocker.utils.Utils;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +40,7 @@ public class SecretsTracker {
 
 	@Init
 	public static void init() {
-		ClientReceiveMessageEvents.GAME.register(SecretsTracker::onMessage);
+		ChatEvents.RECEIVE_STRING.register(SecretsTracker::onMessage);
 		DungeonEvents.DUNGEON_STARTED.register(() -> calculate(RunPhase.START));
 	}
 
@@ -118,10 +117,8 @@ public class SecretsTracker {
 				new HoverEvent(HoverEvent.Action.SHOW_TEXT, cached ? Text.translatable("skyblocker.api.cache.HIT", cacheAge) : Text.translatable("skyblocker.api.cache.MISS"))));
 	}
 
-	private static void onMessage(Text text, boolean overlay) {
-		if (Utils.isInDungeons() && SkyblockerConfigManager.get().dungeons.playerSecretsTracker && !overlay) {
-			String message = Formatting.strip(text.getString());
-
+	private static void onMessage(String message) {
+		if (Utils.isInDungeons() && SkyblockerConfigManager.get().dungeons.playerSecretsTracker) {
 			try {
 				if (TEAM_SCORE_PATTERN.matcher(message).matches()) calculate(RunPhase.END);
 			} catch (Exception e) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CrystalsChestHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CrystalsChestHighlighter.java
@@ -2,10 +2,10 @@ package de.hysky.skyblocker.skyblock.dwarven;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.RenderHelper;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -44,7 +44,7 @@ public class CrystalsChestHighlighter {
 
 	@Init
 	public static void init() {
-		ClientReceiveMessageEvents.GAME.register(CrystalsChestHighlighter::extractLocationFromMessage);
+		ChatEvents.RECEIVE_STRING.register(CrystalsChestHighlighter::extractLocationFromMessage);
 		WorldRenderEvents.AFTER_TRANSLUCENT.register(CrystalsChestHighlighter::render);
 		ClientPlayConnectionEvents.JOIN.register((_handler, _sender, _client) -> reset());
 	}
@@ -56,12 +56,12 @@ public class CrystalsChestHighlighter {
 		currentLockCount = 0;
 	}
 
-	private static void extractLocationFromMessage(Text text, boolean b) {
+	private static void extractLocationFromMessage(String message) {
 		if (!Utils.isInCrystalHollows() || !SkyblockerConfigManager.get().mining.crystalHollows.chestHighlighter) {
 			return;
 		}
 		//if a chest is spawned add chest to look for
-		if (text.getString().matches(CHEST_SPAWN_MESSAGE)) {
+		if (message.equals(CHEST_SPAWN_MESSAGE)) {
 			waitingForChest += 1;
 		}
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/GlaciteColdOverlay.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/GlaciteColdOverlay.java
@@ -2,12 +2,12 @@ package de.hysky.skyblocker.skyblock.dwarven;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.client.render.RenderLayer;
-import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ColorHelper;
 
@@ -23,14 +23,11 @@ public class GlaciteColdOverlay {
     @Init
     public static void init() {
         Scheduler.INSTANCE.scheduleCyclic(GlaciteColdOverlay::update, 20);
-        ClientReceiveMessageEvents.GAME.register(GlaciteColdOverlay::coldReset);
+        ChatEvents.RECEIVE_STRING.register(GlaciteColdOverlay::coldReset);
     }
 
-    private static void coldReset(Text text, boolean b) {
-        if (!Utils.isInDwarvenMines() || b) {
-            return;
-        }
-        String message = text.getString();
+    private static void coldReset(String message) {
+        if (!Utils.isInDwarvenMines()) return;
         if (message.equals("The warmth of the campfire reduced your ❄ Cold to 0!")) {
             cold = 0;
             resetTime = System.currentTimeMillis();
@@ -56,6 +53,7 @@ public class GlaciteColdOverlay {
     /**
      * @see InGameHud#renderOverlay as this is a carbon copy of it
      */
+    @SuppressWarnings("JavadocReference")
     private static void renderOverlay(DrawContext context, Identifier texture, float opacity) {
 		int white = ColorHelper.getWhite(opacity);
 		context.drawTexture(

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
@@ -2,10 +2,10 @@ package de.hysky.skyblocker.skyblock.dwarven;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListMgr;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
@@ -75,20 +75,15 @@ public class WishingCompassSolver {
     public static void init() {
         UseItemCallback.EVENT.register(WishingCompassSolver::onItemInteract);
         UseBlockCallback.EVENT.register(WishingCompassSolver::onBlockInteract);
-        ClientReceiveMessageEvents.GAME.register(WishingCompassSolver::failMessageListener);
+	    ChatEvents.RECEIVE_STRING.register(WishingCompassSolver::failMessageListener);
         ClientPlayConnectionEvents.JOIN.register((_handler, _sender, _client) -> reset());
     }
 
     /**
-     * When a filed message is sent in chat, reset the wishing compass solver to start
-     * @param text message
-     * @param b overlay
+     * When a failed message is sent in chat, reset the wishing compass solver to start
      */
-    private static void failMessageListener(Text text, boolean b) {
-        if (!Utils.isInCrystalHollows()) {
-            return;
-        }
-        if (Formatting.strip(text.getString()).equals("The Wishing Compass can't seem to locate anything!")) {
+    private static void failMessageListener(String message) {
+        if (Utils.isInCrystalHollows() && message.equals("The Wishing Compass can't seem to locate anything!")) {
             currentState = SolverStates.NOT_STARTED;
         }
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/end/TheEnd.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/end/TheEnd.java
@@ -5,13 +5,13 @@ import com.google.gson.JsonObject;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.ColorUtils;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
@@ -101,9 +101,9 @@ public class TheEnd {
         // Save when leaving as well
         ClientLifecycleEvents.CLIENT_STOPPING.register((client) -> save());
 
-        ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
-            if (!Utils.isInTheEnd() || overlay) return;
-            String lowerCase = message.getString().toLowerCase();
+	    ChatEvents.RECEIVE_STRING.register(message -> {
+            if (!Utils.isInTheEnd()) return;
+            String lowerCase = message.toLowerCase();
             if (lowerCase.contains("tremor")) {
                 if (stage == 0) checkAllProtectorLocations();
                 else stage += 1;

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/FarmingHud.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/FarmingHud.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.skyblock.garden;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.HudRenderEvents;
 import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
 import de.hysky.skyblocker.utils.ItemUtils;
@@ -14,7 +15,6 @@ import it.unimi.dsi.fastutil.ints.IntLongPair;
 import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
 import it.unimi.dsi.fastutil.longs.LongPriorityQueue;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.event.client.player.ClientPlayerBlockBreakEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
@@ -37,7 +37,7 @@ import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.lit
 public class FarmingHud {
     private static final Logger LOGGER = LoggerFactory.getLogger(FarmingHud.class);
     public static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final Pattern FARMING_XP = Pattern.compile("§3\\+(?<xp>\\d+.?\\d*) Farming \\((?<percent>[\\d,]+.?\\d*)%\\)");
+    private static final Pattern FARMING_XP = Pattern.compile("\\+(?<xp>\\d+.?\\d*) Farming \\((?<percent>[\\d,]+.?\\d*)%\\)");
     private static final MinecraftClient client = MinecraftClient.getInstance();
     private static CounterType counterType = CounterType.NONE;
     private static final Deque<IntLongPair> counter = new ArrayDeque<>();
@@ -70,9 +70,9 @@ public class FarmingHud {
                 blockBreaks.enqueue(System.currentTimeMillis());
             }
         });
-        ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
-            if (shouldRender() && overlay) {
-                Matcher matcher = FARMING_XP.matcher(message.getString());
+        ChatEvents.RECEIVE_OVERLAY_STRING.register(message -> {
+            if (shouldRender()) {
+                Matcher matcher = FARMING_XP.matcher(message);
                 if (matcher.matches()) {
                     try {
                         farmingXp.offer(FloatLongPair.of(NUMBER_FORMAT.parse(matcher.group("xp")).floatValue(), System.currentTimeMillis()));

--- a/src/main/java/de/hysky/skyblocker/skyblock/mayors/JerryTimer.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/mayors/JerryTimer.java
@@ -2,11 +2,11 @@ package de.hysky.skyblocker.skyblock.mayors;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.mayor.MayorUtils;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.sound.SoundCategory;
@@ -22,8 +22,8 @@ public final class JerryTimer {
 	public static void init() {
 		//Example message: "§b ☺ §eThere is a §aGreen Jerry§e!"
 		//There are various formats, all of which start with the "§b ☺ " prefix and contain the word "<color> Jerry"
-		ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
-			if (overlay || !MayorUtils.getMayor().name().equals("Jerry") || !SkyblockerConfigManager.get().helpers.jerry.enableJerryTimer) return;
+		ChatEvents.RECEIVE_TEXT.register(message -> {
+			if (!MayorUtils.getMayor().name().equals("Jerry") || !SkyblockerConfigManager.get().helpers.jerry.enableJerryTimer) return;
 			String text = message.getString();
 			//This part of hypixel still uses legacy text formatting, so we can't directly check for the actual text
 			if (!text.startsWith("§b ☺ ") || !text.contains("Jerry")) return;

--- a/src/main/java/de/hysky/skyblocker/skyblock/rift/EnigmaSouls.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/rift/EnigmaSouls.java
@@ -22,7 +22,6 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.text.Text;
 import net.minecraft.util.DyeColor;
-import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import org.slf4j.Logger;
@@ -121,13 +120,10 @@ public class EnigmaSouls {
 		}
 	}
 
-	static void onMessage(Text text, boolean overlay) {
-		if (Utils.isInTheRift() && !overlay) {
-			String message = text.getString();
-
-			if (message.equals("You have already found that Enigma Soul!") || Formatting.strip(message).equals("SOUL! You unlocked an Enigma Soul!"))
-				markClosestSoulAsFound();
-		}
+	static void onMessage(String message) {
+		if (!Utils.isInTheRift()) return;
+		if (message.equals("You have already found that Enigma Soul!") || message.equals("SOUL! You unlocked an Enigma Soul!"))
+			markClosestSoulAsFound();
 	}
 
 	static void registerCommands(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/rift/TheRift.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/rift/TheRift.java
@@ -2,10 +2,10 @@ package de.hysky.skyblocker.skyblock.rift;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 
 public class TheRift {
@@ -17,7 +17,7 @@ public class TheRift {
         ClientLifecycleEvents.CLIENT_STARTED.register(MirrorverseWaypoints::load);
         ClientLifecycleEvents.CLIENT_STARTED.register(EnigmaSouls::load);
         ClientLifecycleEvents.CLIENT_STOPPING.register(EnigmaSouls::save);
-        ClientReceiveMessageEvents.GAME.register(EnigmaSouls::onMessage);
+        ChatEvents.RECEIVE_STRING.register(EnigmaSouls::onMessage);
         ClientCommandRegistrationCallback.EVENT.register(EnigmaSouls::registerCommands);
         Scheduler.INSTANCE.scheduleCyclic(EffigyWaypoints::updateEffigies, SkyblockerConfigManager.get().slayers.vampireSlayer.effigyUpdateFrequency);
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerManager.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.skyblock.slayers;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.SlayersConfig;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.skyblock.slayers.boss.vampire.ManiaIndicator;
 import de.hysky.skyblocker.skyblock.slayers.boss.vampire.StakeIndicator;
@@ -13,7 +14,6 @@ import de.hysky.skyblocker.utils.mayor.MayorUtils;
 import de.hysky.skyblocker.utils.render.title.Title;
 import de.hysky.skyblocker.utils.render.title.TitleContainer;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -54,7 +54,7 @@ public class SlayerManager {
 
 	@Init
 	public static void init() {
-		ClientReceiveMessageEvents.GAME.register(SlayerManager::onChatMessage);
+		ChatEvents.RECEIVE_STRING.register(SlayerManager::onChatMessage);
 		SkyblockEvents.LOCATION_CHANGE.register(SlayerManager::onLocationChange);
 		Scheduler.INSTANCE.scheduleCyclic(TwinClawsIndicator::updateIce, SkyblockerConfigManager.get().slayers.vampireSlayer.holyIceUpdateFrequency);
 		Scheduler.INSTANCE.scheduleCyclic(ManiaIndicator::updateMania, SkyblockerConfigManager.get().slayers.vampireSlayer.maniaUpdateFrequency);
@@ -68,9 +68,8 @@ public class SlayerManager {
 		}
 	}
 
-	private static void onChatMessage(Text text, boolean overlay) {
-		if (!Utils.isOnSkyblock() || overlay) return;
-		String message = text.getString();
+	private static void onChatMessage(String message) {
+		if (!Utils.isOnSkyblock()) return;
 
 		switch (message.replaceFirst("^\\s+", "")) {
 			case "Your Slayer Quest has been cancelled!", "SLAYER QUEST FAILED!" -> {

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/boss/voidgloom/BeaconHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/boss/voidgloom/BeaconHighlighter.java
@@ -2,14 +2,13 @@ package de.hysky.skyblocker.skyblock.slayers.boss.voidgloom;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.RenderHelper;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
-import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 
 public class BeaconHighlighter {
@@ -24,17 +23,15 @@ public class BeaconHighlighter {
     public static void init() {
         WorldRenderEvents.AFTER_TRANSLUCENT.register(BeaconHighlighter::render);
         ClientPlayConnectionEvents.JOIN.register((_handler, _sender, _client) -> reset());
-        ClientReceiveMessageEvents.GAME.register(BeaconHighlighter::onMessage);
+	    ChatEvents.RECEIVE_STRING.register(BeaconHighlighter::onMessage);
     }
 
     private static void reset() {
         beaconPositions.clear();
     }
 
-    private static void onMessage(Text text, boolean overlay) {
-        if (Utils.isInTheEnd() && !overlay) {
-            String message = text.getString();
-
+    private static void onMessage(String message) {
+        if (Utils.isInTheEnd()) {
             if (message.contains("SLAYER QUEST COMPLETE!") || message.contains("NICE! SLAYER BOSS SLAIN!")) reset();
         }
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/special/DungeonsSpecialEffects.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/special/DungeonsSpecialEffects.java
@@ -2,13 +2,12 @@ package de.hysky.skyblocker.skyblock.special;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.Utils;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
-import net.minecraft.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,16 +21,15 @@ public class DungeonsSpecialEffects {
 
 	@Init
 	public static void init() {
-		ClientReceiveMessageEvents.GAME.register(DungeonsSpecialEffects::displayRareDropEffect);
+		ChatEvents.RECEIVE_STRING.register(DungeonsSpecialEffects::displayRareDropEffect);
 	}
 
-	private static void displayRareDropEffect(Text message, boolean overlay) {
+	private static void displayRareDropEffect(String message) {
 		//We don't check if we're in dungeons because that check doesn't work in m7 which defeats the point of this
 		//It might also allow it to work with Croesus
-		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.specialEffects.rareDungeonDropEffects && !overlay) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.specialEffects.rareDungeonDropEffects) {
 			try {
-				String stringForm = message.getString();
-				Matcher matcher = DROP_PATTERN.matcher(stringForm);
+				Matcher matcher = DROP_PATTERN.matcher(message);
 
 				if (matcher.matches()) {
 					if (matcher.group("player").equals(CLIENT.getSession().getUsername())) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/special/DyeSpecialEffects.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/special/DyeSpecialEffects.java
@@ -3,13 +3,12 @@ package de.hysky.skyblocker.skyblock.special;
 import com.mojang.logging.LogUtils;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.Utils;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
-import net.minecraft.text.Text;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 
@@ -25,14 +24,13 @@ public class DyeSpecialEffects {
 
 	@Init
 	public static void init() {
-		ClientReceiveMessageEvents.GAME.register(DyeSpecialEffects::displayDyeDropEffect);
+		ChatEvents.RECEIVE_STRING.register(DyeSpecialEffects::displayDyeDropEffect);
 	}
 
-	private static void displayDyeDropEffect(Text message, boolean overlay) {
-		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.specialEffects.rareDyeDropEffects && !overlay) {
+	private static void displayDyeDropEffect(String message) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.specialEffects.rareDyeDropEffects) {
 			try {
-				String stringForm = message.getString();
-				Matcher matcher = DROP_PATTERN.matcher(stringForm);
+				Matcher matcher = DROP_PATTERN.matcher(message);
 
 				if (matcher.matches() && matcher.group("player").equals(CLIENT.getSession().getUsername())) {
 					ItemStack stack = findDyeStack(matcher.group("dye"));

--- a/src/main/java/de/hysky/skyblocker/skyblock/waypoint/FairySouls.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/waypoint/FairySouls.java
@@ -9,13 +9,13 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.HelperConfig;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.*;
 import de.hysky.skyblocker.utils.waypoint.ProfileAwareWaypoint;
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.minecraft.client.MinecraftClient;
@@ -66,7 +66,7 @@ public class FairySouls {
         ClientLifecycleEvents.CLIENT_STOPPING.register(FairySouls::saveFoundFairySouls);
         ClientCommandRegistrationCallback.EVENT.register(FairySouls::registerCommands);
         WorldRenderEvents.AFTER_TRANSLUCENT.register(FairySouls::render);
-        ClientReceiveMessageEvents.GAME.register(FairySouls::onChatMessage);
+	    ChatEvents.RECEIVE_STRING.register(FairySouls::onChatMessage);
     }
 
     private static void loadFairySouls() {
@@ -154,9 +154,8 @@ public class FairySouls {
         }
     }
 
-    private static void onChatMessage(Text text, boolean overlay) {
-        String message = text.getString();
-        if (message.equals("You have already found that Fairy Soul!") || message.equals("§d§lSOUL! §fYou found a §dFairy Soul§f!")) {
+    private static void onChatMessage(String message) {
+        if (message.equals("You have already found that Fairy Soul!") || message.equals("SOUL! You found a Fairy Soul!")) {
             markClosestFairyFound();
         }
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/waypoint/MythologicalRitual.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/waypoint/MythologicalRitual.java
@@ -4,6 +4,7 @@ import com.mojang.brigadier.Command;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.ColorUtils;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.Location;
@@ -13,7 +14,6 @@ import de.hysky.skyblocker.utils.command.argumenttypes.blockpos.ClientPosArgumen
 import de.hysky.skyblocker.utils.render.RenderHelper;
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
@@ -28,7 +28,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.s2c.play.ParticleS2CPacket;
 import net.minecraft.particle.ParticleType;
 import net.minecraft.particle.ParticleTypes;
-import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.Hand;
@@ -66,7 +65,7 @@ public class MythologicalRitual {
         AttackBlockCallback.EVENT.register(MythologicalRitual::onAttackBlock);
         UseBlockCallback.EVENT.register(MythologicalRitual::onUseBlock);
         UseItemCallback.EVENT.register(MythologicalRitual::onUseItem);
-        ClientReceiveMessageEvents.GAME.register(MythologicalRitual::onChatMessage);
+	    ChatEvents.RECEIVE_STRING.register(MythologicalRitual::onChatMessage);
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> reset());
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> dispatcher.register(literal(SkyblockerMod.NAMESPACE).then(literal("diana")
                 .then(literal("clearGriffinBurrows").executes(context -> {
@@ -250,8 +249,8 @@ public class MythologicalRitual {
         return ActionResult.PASS;
     }
 
-    public static void onChatMessage(Text message, boolean overlay) {
-        if (isActive() && GRIFFIN_BURROW_DUG.matcher(message.getString()).matches()) {
+    public static void onChatMessage(String message) {
+        if (isActive() && GRIFFIN_BURROW_DUG.matcher(message).matches()) {
             previousBurrow.confirmed = TriState.FALSE;
             previousBurrow = griffinBurrows.get(lastDugBurrowPos);
             previousBurrow.confirmed = TriState.DEFAULT;

--- a/src/main/java/de/hysky/skyblocker/skyblock/waypoint/Relics.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/waypoint/Relics.java
@@ -9,6 +9,7 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.OtherLocationsConfig;
+import de.hysky.skyblocker.events.ChatEvents;
 import de.hysky.skyblocker.utils.ColorUtils;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.PosUtils;
@@ -18,7 +19,6 @@ import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
-import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.minecraft.client.MinecraftClient;
@@ -56,7 +56,7 @@ public class Relics {
         ClientLifecycleEvents.CLIENT_STOPPING.register(Relics::saveFoundRelics);
         ClientCommandRegistrationCallback.EVENT.register(Relics::registerCommands);
         WorldRenderEvents.AFTER_TRANSLUCENT.register(Relics::render);
-        ClientReceiveMessageEvents.GAME.register(Relics::onChatMessage);
+	    ChatEvents.RECEIVE_STRING.register(Relics::onChatMessage);
     }
 
     private static void loadRelics(MinecraftClient client) {
@@ -144,8 +144,7 @@ public class Relics {
         }
     }
 
-    private static void onChatMessage(Text text, boolean overlay) {
-        String message = text.getString();
+    private static void onChatMessage(String message) {
         if (message.equals("You've already found this relic!") || message.startsWith("+10,000 Coins! (") && message.endsWith("/28 Relics)")) {
             markClosestRelicFound();
         }


### PR DESCRIPTION
Refactored most if not usages of `ClientReceiveMessageEvents.GAME` to use `ChatEvents.RECEIVE_TEXT` and `ChatEvents.RECEIVE_STRING`, or the overlay variants (which are also added in this PR) if they required so, with some exceptions because either their logic was complicated due to handling both overlay and chat messages or they already had a cancelled message fix which worked (I presume).

Some usages of `ClientReceiveMessageEvents.GAME` weren't clear in whether they used overlay messages or not, they didn't do anything with the variable. This refactor also clarifies those by using the relevant event.

As for why the overlay events are separate instead of being similar to fabric's events, it's because there were way too few uses of action bar messages, it's roughly 4 uses in total compared to 25 something chat message listeners. Each chat message listener had an ugly if check that increased the brain power required to understand. Each overlay message listener had the same if check, but reversed. It's just not good for anybody.
This fix also encourages any future dev to separate their overlay listener and chat listener logic because they're almost always different anyway, keeping them in the same method was complicating it.

Haven't tested.

---

If you're not satisfied with the event names, please lmk because I feel the same way yet I don't know what would be better alternatives to them.

