### PR TITLE
Prevent swimming on Skyblock

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -57,6 +57,14 @@ public class GeneralCategory {
                                 newValue -> config.general.acceptReparty = newValue)
                         .controller(ConfigUtils::createBooleanController)
                         .build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.general.preventSwimming"))
+						.description(OptionDescription.of(Text.translatable("skyblocker.config.general.preventSwimming.@Tooltip")))
+						.binding(defaults.general.preventSwimming,
+								() -> config.general.preventSwimming,
+								newValue -> config.general.preventSwimming = newValue)
+						.controller(ConfigUtils::createBooleanController)
+						.build())
 
 				.group(OptionGroup.createBuilder()
 						.name(Text.translatable("skyblocker.config.general.speedPresets"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -22,6 +22,9 @@ public class GeneralConfig {
     @SerialEntry
     public boolean acceptReparty = true;
 
+    @SerialEntry
+    public boolean preventSwimming = true;
+
 	@SerialEntry
 	public SpeedPresets speedPresets = new SpeedPresets();
 

--- a/src/main/java/de/hysky/skyblocker/mixins/EntityMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/EntityMixin.java
@@ -84,4 +84,11 @@ public abstract class EntityMixin {
 			}
 		}
 	}
+
+	@Inject(method = "setSwimming", at = @At("HEAD"), cancellable = true)
+	private void preventSwimming(boolean swimming, CallbackInfo ci) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.preventSwimming) {
+			ci.cancel();
+		}
+	}
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -256,6 +256,9 @@
 
   "skyblocker.config.general.acceptReparty": "Auto accept Reparty",
 
+  "skyblocker.config.general.preventSwimming": "Prevent swimming on Skyblock",
+  "skyblocker.config.general.preventSwimming.@Tooltip": "Prevent players and NPCs from entering swimming state that does not exist in legacy servers. This may fix lag backs when in water.",
+
   "skyblocker.config.general.hitbox": "Hitboxes",
   "skyblocker.config.general.hitbox.oldFarmlandHitbox": "Enable 1.8 farmland hitbox",
   "skyblocker.config.general.hitbox.oldLeverHitbox": "Enable 1.8 lever hitbox",

--- a/src/main/resources/assets/skyblocker/lang/zh_cn.json
+++ b/src/main/resources/assets/skyblocker/lang/zh_cn.json
@@ -97,6 +97,8 @@
     "skyblocker.config.helpers.experiments.enableChronomatronSolver": "启用序列记忆实验助手",
     "skyblocker.config.helpers.experiments.enableUltrasequencerSolver": "启用超级序列实验助手",
     "skyblocker.config.general.acceptReparty": "自动接受重新组队",
+    "skyblocker.config.general.preventSwimming": "阻止在 Skyblock 中游泳",
+    "skyblocker.config.general.preventSwimming.@Tooltip": "防止玩家和 NPC 进入旧版服务器中不存在的游泳状态。这可能会修复在水中时回弹的问题。",
     "skyblocker.config.helpers.fairySouls": "仙女之魂助手",
     "skyblocker.config.helpers.fairySouls.enableFairySoulsHelper": "启用仙女之魂助手",
     "skyblocker.fairySouls.markAllFound": "§r将当前岛屿上的全部仙女之魂标记为已发现",

--- a/src/main/resources/assets/skyblocker/lang/zh_tw.json
+++ b/src/main/resources/assets/skyblocker/lang/zh_tw.json
@@ -51,6 +51,8 @@
     "skyblocker.config.general.itemTooltip.enableBazaarPrice": "顯示集市購買/賣出價格",
     "skyblocker.tips.clickNextTip": "§a[點擊看下一則提示]",
     "skyblocker.config.general.acceptReparty": "自動接受重新組隊",
+    "skyblocker.config.general.preventSwimming": "阻止在 Skyblock 中游泳",
+    "skyblocker.config.general.preventSwimming.@Tooltip": "防止玩家和 NPC 進入舊版伺服器中不存在的游泳狀態。這可能會修復在水中時回彈的問題。",
     "skyblocker.config.helpers.fairySouls": "仙女之魂助手",
     "skyblocker.config.uiAndVisuals.tabHud.tabHudScale.@Tooltip": "相對於原版GUI的百分比大小",
     "skyblocker.config.general.shortcuts.enableShortcuts": "啟用快捷指令",


### PR DESCRIPTION
Added as an option (default on).

"Prevent players and NPCs from entering swimming state that does not exist in legacy servers. This may fix lag backs when in water."