### PR TITLE
Fix dungeon score not working when fancy tab hud is disabled

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/PlayerListManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/util/PlayerListManager.java
@@ -40,15 +40,18 @@ import java.util.regex.Pattern;
 public class PlayerListManager {
 
 	public static final Logger LOGGER = LoggerFactory.getLogger("Skyblocker Regex");
-	private static final Pattern PLAYERS_COLUMN_PATTERN = Pattern.compile("(^|\\s*)(Players \\(\\d+\\)|Island|Coop \\(\\d+\\))(\\s*|$)");
-	private static final Pattern INFO_COLUMN_PATTERN = Pattern.compile("(^|\\s*)Info(\\s*|$)");
+	private static final Pattern PLAYERS_COLUMN_PATTERN = Pattern.compile("\\s*(Players \\(\\d+\\)|Island|Coop \\(\\d+\\))\\s*");
+	private static final Pattern INFO_COLUMN_PATTERN = Pattern.compile("\\s*Info\\s*");
 
 	/**
 	 * The player list in tab.
 	 */
 	private static List<PlayerListEntry> playerList = new ArrayList<>(); // Initialize to prevent npe.
+
 	/**
 	 * The player list in tab, but a list of strings instead of {@link PlayerListEntry}s.
+	 *
+	 * @implNote All leading and trailing whitespace is removed from the strings.
 	 */
 	private static List<String> playerStringList = new ArrayList<>();
 	@Nullable
@@ -56,31 +59,44 @@ public class PlayerListManager {
 	public static final Map<String, TabHudWidget> tabWidgetInstances = new Object2ObjectOpenHashMap<>();
 	public static final List<TabHudWidget> tabWidgetsToShow = new ObjectArrayList<>(5);
 
-	public static void updateList() {
+	private static void reset() {
+		if (!tabWidgetsToShow.isEmpty()) {
+			tabWidgetsToShow.clear();
+			ScreenBuilder.positionsNeedsUpdating = true;
+		}
+	}
 
-		if (!Utils.isOnSkyblock() || !SkyblockerConfigManager.get().uiAndVisuals.tabHud.tabHudEnabled) {
-			if (!tabWidgetsToShow.isEmpty()) {
-				tabWidgetsToShow.clear();
-				ScreenBuilder.positionsNeedsUpdating = true;
-			}
+	public static void updateList() {
+		if (!Utils.isOnSkyblock()) {
+			reset();
 			return;
 		}
 
-		ClientPlayNetworkHandler cpnwh = MinecraftClient.getInstance().getNetworkHandler();
+		ClientPlayNetworkHandler networkHandler = MinecraftClient.getInstance().getNetworkHandler();
 
 		// check is needed, else game crashes on server leave
-		if (cpnwh != null) {
-			playerList = cpnwh.getPlayerList().stream().sorted(PlayerListHudAccessor.getOrdering()).toList();
-			playerStringList = playerList.stream().map(PlayerListEntry::getDisplayName).filter(Objects::nonNull).map(Text::getString).map(String::strip).toList();
+		if (networkHandler != null) {
+			playerList = networkHandler.getPlayerList()
+			                           .stream()
+			                           .sorted(PlayerListHudAccessor.getOrdering())
+			                           .toList();
+			playerStringList = playerList.stream()
+			                             .map(PlayerListEntry::getDisplayName)
+			                             .filter(Objects::nonNull)
+			                             .map(Text::getString)
+			                             .map(String::strip)
+			                             .toList();
+		}
+
+		if (!SkyblockerConfigManager.get().uiAndVisuals.tabHud.tabHudEnabled) {
+			reset();
+			return;
 		}
 
 		if (MinecraftClient.getInstance().currentScreen instanceof WidgetsConfigurationScreen widgetsConfigurationScreen && widgetsConfigurationScreen.isPreviewVisible()) return;
 
-		if (Utils.isInDungeons()) {
-			updateDungeons(null);
-		} else {
-			updateWidgetsFrom(playerList);
-		}
+		if (Utils.isInDungeons()) updateDungeons(null);
+		else updateWidgetsFrom(playerList);
 	}
 
 	/**


### PR DESCRIPTION
I tried to separate the updating of the player list and the widgets around the config check, idk if I broke anything but I did a run with and without the fancy tab hud and both ways seem to work just fine. Nothing seemed broken about the tab hud when I tried it in the hub either.

Also took some liberties with the formatting and the regex, hehe

Closes #1142 