### PR TITLE
Fixed mana and overflow bar

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
@@ -301,7 +301,8 @@ public class FancyStatusBars {
 		StatusBarTracker.Resource health = statusBarTracker.getHealth();
 		statusBars.get(StatusBarType.HEALTH).updateValues(health.value() / (float) health.max(), health.overflow() / (float) health.max(), health.value());
 		StatusBarTracker.Resource intelligence = statusBarTracker.getMana();
-		statusBars.get(StatusBarType.INTELLIGENCE).updateValues(intelligence.value() / (float) intelligence.max(), intelligence.overflow() / (float) intelligence.max(), intelligence.value());
+		float totalIntelligence = (float) intelligence.max() + intelligence.overflow();
+		statusBars.get(StatusBarType.INTELLIGENCE).updateValues(intelligence.value() / totalIntelligence + intelligence.overflow() / totalIntelligence, intelligence.overflow() / totalIntelligence, intelligence.value());
 		int defense = statusBarTracker.getDefense();
 		statusBars.get(StatusBarType.DEFENSE).updateValues(defense / (defense + 100.f), 0, defense);
 		StatusBarTracker.Resource speed = statusBarTracker.getSpeed();


### PR DESCRIPTION
Now the mana bar starts where the overflow bar ends, and the whole bar is equal to the sum of the overflow and max mana.