### PR TITLE
Render Layer Migration

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/HealthBars.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/HealthBars.java
@@ -229,8 +229,9 @@ public class HealthBars {
 			int mixedColor = ColorUtils.interpolate(health, emptyColor.getRGB(), halfColor.getRGB(), fullColor.getRGB());
 			float[] components = ColorUtils.getFloatComponents(mixedColor);
 			// Render the health bar texture with scaling based on health percentage
-			RenderHelper.renderTextureInWorld(context, armorStand.getCameraPosVec(tickDelta).add(0, 0.25 - height, 0), width, height, 1f, 1f, new Vec3d(width * -0.5f, 0, 0), HEALTH_BAR_BACKGROUND_TEXTURE, components, 1f, true);
 			RenderHelper.renderTextureInWorld(context, armorStand.getCameraPosVec(tickDelta).add(0, 0.25 - height, 0), width * health, height, health, 1f, new Vec3d(width * -0.5f, 0, 0.003f), HEALTH_BAR_TEXTURE, components, 1f, true);
+			RenderHelper.renderTextureInWorld(context, armorStand.getCameraPosVec(tickDelta).add(0, 0.25 - height, 0), width, height, 1f, 1f, new Vec3d(width * -0.5f, 0, 0), HEALTH_BAR_BACKGROUND_TEXTURE, components, 1f, true);
+
 		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/render/RenderHelper.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/RenderHelper.java
@@ -14,7 +14,6 @@ import net.fabricmc.fabric.api.event.Event;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gl.ShaderProgramKeys;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.VertexFormat.DrawMode;
@@ -127,29 +126,18 @@ public class RenderHelper {
         if (FrustumUtils.isVisible(minX, minY, minZ, maxX, maxY, maxZ)) {
             MatrixStack matrices = context.matrixStack();
             Vec3d camera = context.camera().getPos();
-            Tessellator tessellator = RenderSystem.renderThreadTesselator();
-
-            RenderSystem.setShader(ShaderProgramKeys.RENDERTYPE_LINES);
-            RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-            RenderSystem.enableBlend();
-            RenderSystem.lineWidth(lineWidth);
-            RenderSystem.disableCull();
-            RenderSystem.enableDepthTest();
-            RenderSystem.depthFunc(throughWalls ? GL11.GL_ALWAYS : GL11.GL_LEQUAL);
 
             matrices.push();
             matrices.translate(-camera.getX(), -camera.getY(), -camera.getZ());
 
-            BufferBuilder buffer = tessellator.begin(DrawMode.LINES, VertexFormats.LINES);
+            VertexConsumerProvider.Immediate consumers = (VertexConsumerProvider.Immediate) context.consumers();
+            RenderLayer layer = throughWalls ? SkyblockerRenderLayers.getLinesThroughWalls(lineWidth) : SkyblockerRenderLayers.getLines(lineWidth);
+            VertexConsumer buffer = consumers.getBuffer(layer);
+
             VertexRendering.drawBox(matrices, buffer, minX, minY, minZ, maxX, maxY, maxZ, colorComponents[0], colorComponents[1], colorComponents[2], alpha);
-            BufferRenderer.drawWithGlobalProgram(buffer.end());
+            consumers.draw(layer);
 
             matrices.pop();
-            RenderSystem.lineWidth(1f);
-            RenderSystem.enableCull();
-            RenderSystem.disableBlend();
-            RenderSystem.disableDepthTest();
-            RenderSystem.depthFunc(GL11.GL_LEQUAL);
         }
     }
 
@@ -174,22 +162,11 @@ public class RenderHelper {
         matrices.push();
         matrices.translate(-camera.x, -camera.y, -camera.z);
 
-        Tessellator tessellator = RenderSystem.renderThreadTesselator();
         MatrixStack.Entry entry = matrices.peek();
 
-        GL11.glEnable(GL11.GL_LINE_SMOOTH);
-        GL11.glHint(GL11.GL_LINE_SMOOTH_HINT, GL11.GL_NICEST);
-
-        RenderSystem.setShader(ShaderProgramKeys.RENDERTYPE_LINES);
-        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-        RenderSystem.lineWidth(lineWidth);
-        RenderSystem.enableBlend();
-        RenderSystem.defaultBlendFunc();
-        RenderSystem.disableCull();
-        RenderSystem.enableDepthTest();
-        RenderSystem.depthFunc(throughWalls ? GL11.GL_ALWAYS : GL11.GL_LEQUAL);
-
-        BufferBuilder buffer = tessellator.begin(DrawMode.LINE_STRIP, VertexFormats.LINES);
+        VertexConsumerProvider.Immediate consumers = (VertexConsumerProvider.Immediate) context.consumers();
+        RenderLayer layer = throughWalls ? SkyblockerRenderLayers.getLinesThroughWalls(lineWidth) : SkyblockerRenderLayers.getLines(lineWidth);
+        VertexConsumer buffer = consumers.getBuffer(layer);
 
         for (int i = 0; i < points.length; i++) {
             Vec3d nextPoint = points[i + 1 == points.length ? i - 1 : i + 1];
@@ -206,14 +183,8 @@ public class RenderHelper {
                     .normal(entry, normalVec);
         }
 
-        BufferRenderer.drawWithGlobalProgram(buffer.end());
-
+        consumers.draw(layer);
         matrices.pop();
-        GL11.glDisable(GL11.GL_LINE_SMOOTH);
-        RenderSystem.lineWidth(1f);
-        RenderSystem.enableCull();
-        RenderSystem.depthFunc(GL11.GL_LEQUAL);
-        RenderSystem.disableDepthTest();
     }
 
     public static void renderLineFromCursor(WorldRenderContext context, Vec3d point, float[] colorComponents, float alpha, float lineWidth) {
@@ -223,27 +194,16 @@ public class RenderHelper {
         matrices.push();
         matrices.translate(-camera.x, -camera.y, -camera.z);
 
-        Tessellator tessellator = RenderSystem.renderThreadTesselator();
         MatrixStack.Entry entry = matrices.peek();
 
-        GL11.glEnable(GL11.GL_LINE_SMOOTH);
-        GL11.glHint(GL11.GL_LINE_SMOOTH_HINT, GL11.GL_NICEST);
-
-        RenderSystem.setShader(ShaderProgramKeys.RENDERTYPE_LINES);
-        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-        RenderSystem.lineWidth(lineWidth);
-        RenderSystem.enableBlend();
-        RenderSystem.defaultBlendFunc();
-        RenderSystem.disableCull();
-        RenderSystem.enableDepthTest();
-        RenderSystem.depthFunc(GL11.GL_ALWAYS);
+        VertexConsumerProvider.Immediate consumers = (VertexConsumerProvider.Immediate) context.consumers();
+        RenderLayer layer = SkyblockerRenderLayers.getLines(lineWidth);
+        VertexConsumer buffer = consumers.getBuffer(layer);
 
         // Start drawing the line from a point slightly in front of the camera
         Vec3d cameraPoint = camera.add(Vec3d.fromPolar(context.camera().getPitch(), context.camera().getYaw()));
-
-        BufferBuilder buffer = tessellator.begin(DrawMode.LINES, VertexFormats.LINES);
-
         Vector3f normal = point.toVector3f().sub((float) cameraPoint.x, (float) cameraPoint.y, (float) cameraPoint.z).normalize();
+
         buffer
                 .vertex(entry, (float) cameraPoint.x, (float) cameraPoint.y, (float) cameraPoint.z)
                 .color(colorComponents[0], colorComponents[1], colorComponents[2], alpha)
@@ -254,15 +214,8 @@ public class RenderHelper {
                 .color(colorComponents[0], colorComponents[1], colorComponents[2], alpha)
                 .normal(entry, normal);
 
-
-        BufferRenderer.drawWithGlobalProgram(buffer.end());
-
+        consumers.draw(layer);
         matrices.pop();
-        GL11.glDisable(GL11.GL_LINE_SMOOTH);
-        RenderSystem.lineWidth(1f);
-        RenderSystem.enableCull();
-        RenderSystem.depthFunc(GL11.GL_LEQUAL);
-        RenderSystem.disableDepthTest();
     }
 
     public static void renderQuad(WorldRenderContext context, Vec3d[] points, float[] colorComponents, float alpha, boolean throughWalls) {
@@ -271,25 +224,15 @@ public class RenderHelper {
 
         positionMatrix.translate((float) -camera.x, (float) -camera.y, (float) -camera.z);
 
-        Tessellator tessellator = RenderSystem.renderThreadTesselator();
+        VertexConsumerProvider.Immediate consumers = (VertexConsumerProvider.Immediate) context.consumers();
+        RenderLayer layer = throughWalls ? SkyblockerRenderLayers.QUAD_THROUGH_WALLS : SkyblockerRenderLayers.QUAD;
+        VertexConsumer buffer = consumers.getBuffer(layer);
 
-        RenderSystem.setShader(ShaderProgramKeys.POSITION_COLOR);
-        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-        RenderSystem.enableBlend();
-        RenderSystem.defaultBlendFunc();
-        RenderSystem.disableCull();
-        RenderSystem.enableDepthTest();
-        RenderSystem.depthFunc(throughWalls ? GL11.GL_ALWAYS : GL11.GL_LEQUAL);
-
-        BufferBuilder buffer = tessellator.begin(DrawMode.QUADS, VertexFormats.POSITION_COLOR);
         for (int i = 0; i < 4; i++) {
             buffer.vertex(positionMatrix, (float) points[i].getX(), (float) points[i].getY(), (float) points[i].getZ()).color(colorComponents[0], colorComponents[1], colorComponents[2], alpha);
         }
-        BufferRenderer.drawWithGlobalProgram(buffer.end());
 
-        RenderSystem.enableCull();
-        RenderSystem.depthFunc(GL11.GL_LEQUAL);
-        RenderSystem.disableDepthTest();
+        consumers.draw(layer);
     }
 
 	/**
@@ -302,7 +245,7 @@ public class RenderHelper {
 	 * @param textureHeight amount of texture rendered height
 	 * @param renderOffset offset once it's been placed in the world facing the player
 	 * @param texture reference to texture to render
-	 * @param shaderColor color to apply to the texture
+	 * @param shaderColor color to apply to the texture (use white if none)
 	 * @param throughWalls if it should render though walls
 	 */
 	public static void renderTextureInWorld(WorldRenderContext context, Vec3d pos, float width, float height, float textureWidth, float textureHeight, Vec3d renderOffset, Identifier texture, float[] shaderColor, float alpha, boolean throughWalls) {
@@ -314,28 +257,18 @@ public class RenderHelper {
 				.translate((float) (pos.getX() - cameraPos.getX()), (float) (pos.getY() - cameraPos.getY()), (float) (pos.getZ() - cameraPos.getZ()))
 				.rotate(camera.getRotation());
 
-		Tessellator tessellator = RenderSystem.renderThreadTesselator();
+		VertexConsumerProvider.Immediate consumers = (VertexConsumerProvider.Immediate) context.consumers();
+		RenderLayer layer = throughWalls ? SkyblockerRenderLayers.getTextureThroughWalls(texture) : SkyblockerRenderLayers.getTexture(texture);
+		VertexConsumer buffer = consumers.getBuffer(layer);
 
-		RenderSystem.setShader(ShaderProgramKeys.POSITION_TEX);
-		RenderSystem.setShaderTexture(0, texture);
-		RenderSystem.setShaderColor(shaderColor[0], shaderColor[1], shaderColor[2], alpha);
-		RenderSystem.enableBlend();
-		RenderSystem.defaultBlendFunc();
-		RenderSystem.disableCull();
-		RenderSystem.depthFunc(throughWalls ? GL11.GL_ALWAYS : GL11.GL_LEQUAL);
-		BufferBuilder buffer = tessellator.begin(DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
+		int color = ColorHelper.fromFloats(alpha, shaderColor[0], shaderColor[1], shaderColor[2]);
 
-		buffer.vertex(positionMatrix, (float) renderOffset.getX(), (float) renderOffset.getY(), (float) renderOffset.getZ()).texture(1, 1 - textureHeight);
-		buffer.vertex(positionMatrix, (float) renderOffset.getX(), (float) renderOffset.getY() + height, (float) renderOffset.getZ()).texture(1, 1);
-		buffer.vertex(positionMatrix, (float) renderOffset.getX() + width, (float) renderOffset.getY() + height	, (float) renderOffset.getZ()).texture(1 - textureWidth, 1);
-		buffer.vertex(positionMatrix, (float) renderOffset.getX() + width, (float) renderOffset.getY(), (float) renderOffset.getZ()).texture(1 - textureWidth, 1 - textureHeight);
+		buffer.vertex(positionMatrix, (float) renderOffset.getX(), (float) renderOffset.getY(), (float) renderOffset.getZ()).texture(1, 1 - textureHeight).color(color);
+		buffer.vertex(positionMatrix, (float) renderOffset.getX(), (float) renderOffset.getY() + height, (float) renderOffset.getZ()).texture(1, 1).color(color);
+		buffer.vertex(positionMatrix, (float) renderOffset.getX() + width, (float) renderOffset.getY() + height	, (float) renderOffset.getZ()).texture(1 - textureWidth, 1).color(color);
+		buffer.vertex(positionMatrix, (float) renderOffset.getX() + width, (float) renderOffset.getY(), (float) renderOffset.getZ()).texture(1 - textureWidth, 1 - textureHeight).color(color);
 
-		BufferRenderer.drawWithGlobalProgram(buffer.end());
-
-		RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-		RenderSystem.enableCull();
-		RenderSystem.depthFunc(GL11.GL_LEQUAL);
-		RenderSystem.disableDepthTest();
+		consumers.draw(layer);
 	}
 
     public static void renderText(WorldRenderContext context, Text text, Vec3d pos, boolean throughWalls) {

--- a/src/main/java/de/hysky/skyblocker/utils/render/SkyblockerRenderLayers.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/SkyblockerRenderLayers.java
@@ -1,29 +1,114 @@
 package de.hysky.skyblocker.utils.render;
 
+import java.util.OptionalDouble;
+import java.util.function.DoubleFunction;
+import java.util.function.Function;
+
 import org.lwjgl.opengl.GL11;
 
+import it.unimi.dsi.fastutil.doubles.Double2ObjectMap;
+import it.unimi.dsi.fastutil.doubles.Double2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderLayer.MultiPhase;
 import net.minecraft.client.render.RenderLayer.MultiPhaseParameters;
 import net.minecraft.client.render.RenderPhase;
 import net.minecraft.client.render.RenderPhase.DepthTest;
+import net.minecraft.client.render.RenderPhase.LineWidth;
 import net.minecraft.client.render.VertexFormat.DrawMode;
 import net.minecraft.client.render.VertexFormats;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.TriState;
 
 public class SkyblockerRenderLayers {
 	public static final DepthTest OUTLINE_ALWAYS = new DepthTest("outline_always", GL11.GL_ALWAYS);
+	private static final Double2ObjectMap<MultiPhase> LINES_LAYERS = new Double2ObjectOpenHashMap<>();
+	private static final Double2ObjectMap<MultiPhase> LINES_THROUGH_WALLS_LAYERS = new Double2ObjectOpenHashMap<>();
+	private static final Object2ObjectMap<Identifier, MultiPhase> TEXTURE_LAYERS = new Object2ObjectOpenHashMap<>();
+	private static final Object2ObjectMap<Identifier, MultiPhase> TEXTURE_THROUGH_WALLS_LAYERS = new Object2ObjectOpenHashMap<>();
 
 	public static final MultiPhase FILLED = RenderLayer.of("filled", VertexFormats.POSITION_COLOR, DrawMode.TRIANGLE_STRIP, RenderLayer.CUTOUT_BUFFER_SIZE, false, true, MultiPhaseParameters.builder()
 			.program(RenderPhase.POSITION_COLOR_PROGRAM)
 			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
 			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
-			.depthTest(DepthTest.LEQUAL_DEPTH_TEST)
+			.depthTest(RenderPhase.LEQUAL_DEPTH_TEST)
 			.build(false));
 
 	public static final MultiPhase FILLED_THROUGH_WALLS = RenderLayer.of("filled_through_walls", VertexFormats.POSITION_COLOR, DrawMode.TRIANGLE_STRIP, RenderLayer.CUTOUT_BUFFER_SIZE, false, true, MultiPhaseParameters.builder()
 			.program(RenderPhase.POSITION_COLOR_PROGRAM)
 			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
 			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
-			.depthTest(DepthTest.ALWAYS_DEPTH_TEST)
+			.depthTest(RenderPhase.ALWAYS_DEPTH_TEST)
 			.build(false));
+
+	private static final DoubleFunction<MultiPhase> LINES = lineWidth -> RenderLayer.of("lines", VertexFormats.LINES, DrawMode.LINES, RenderLayer.DEFAULT_BUFFER_SIZE, false, false, MultiPhaseParameters.builder()
+			.program(RenderPhase.LINES_PROGRAM)
+			.lineWidth(new LineWidth(OptionalDouble.of(lineWidth)))
+			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
+			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+			.writeMaskState(RenderPhase.ALL_MASK)
+			.cull(RenderPhase.DISABLE_CULLING)
+			.depthTest(RenderPhase.LEQUAL_DEPTH_TEST)
+			.build(false));
+
+	private static final DoubleFunction<MultiPhase> LINES_THROUGH_WALLS = lineWidth -> RenderLayer.of("lines_through_walls", VertexFormats.LINES, DrawMode.LINES, RenderLayer.DEFAULT_BUFFER_SIZE, false, false, MultiPhaseParameters.builder()
+			.program(RenderPhase.LINES_PROGRAM)
+			.lineWidth(new LineWidth(OptionalDouble.of(lineWidth)))
+			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
+			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+			.writeMaskState(RenderPhase.ALL_MASK)
+			.cull(RenderPhase.DISABLE_CULLING)
+			.depthTest(RenderPhase.ALWAYS_DEPTH_TEST)
+			.build(false));
+
+	public static final MultiPhase QUAD = RenderLayer.of("quad", VertexFormats.POSITION_COLOR, DrawMode.QUADS, RenderLayer.DEFAULT_BUFFER_SIZE, false, true, MultiPhaseParameters.builder()
+			.program(RenderPhase.POSITION_COLOR_PROGRAM)
+			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
+			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+			.cull(RenderPhase.DISABLE_CULLING)
+			.depthTest(RenderPhase.LEQUAL_DEPTH_TEST)
+			.build(false));
+
+	public static final MultiPhase QUAD_THROUGH_WALLS = RenderLayer.of("quad_through_walls", VertexFormats.POSITION_COLOR, DrawMode.QUADS, RenderLayer.DEFAULT_BUFFER_SIZE, false, true, MultiPhaseParameters.builder()
+			.program(RenderPhase.POSITION_COLOR_PROGRAM)
+			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
+			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+			.cull(RenderPhase.DISABLE_CULLING)
+			.depthTest(RenderPhase.ALWAYS_DEPTH_TEST)
+			.build(false));
+
+	private static final Function<Identifier, MultiPhase> TEXTURE = texture -> RenderLayer.of("texture", VertexFormats.POSITION_TEXTURE_COLOR, DrawMode.QUADS, RenderLayer.DEFAULT_BUFFER_SIZE, false, true, MultiPhaseParameters.builder()
+			.program(RenderPhase.POSITION_TEXTURE_COLOR_PROGRAM)
+			.texture(new RenderPhase.Texture(texture, TriState.FALSE, false))
+			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
+			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+			.cull(RenderPhase.DISABLE_CULLING)
+			.depthTest(RenderPhase.LEQUAL_DEPTH_TEST)
+			.build(false));
+
+	private static final Function<Identifier, MultiPhase> TEXTURE_THROUGH_WALLS = texture -> RenderLayer.of("texture_through_walls", VertexFormats.POSITION_TEXTURE_COLOR, DrawMode.QUADS, RenderLayer.DEFAULT_BUFFER_SIZE, false, true, MultiPhaseParameters.builder()
+			.program(RenderPhase.POSITION_TEXTURE_COLOR_PROGRAM)
+			.texture(new RenderPhase.Texture(texture, TriState.FALSE, false))
+			.layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
+			.transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+			.cull(RenderPhase.DISABLE_CULLING)
+			.depthTest(RenderPhase.ALWAYS_DEPTH_TEST)
+			.build(false));
+
+	public static MultiPhase getLines(double lineWidth) {
+		return LINES_LAYERS.computeIfAbsent(lineWidth, LINES);
+	}
+
+	public static MultiPhase getLinesThroughWalls(double lineWidth) {
+		return LINES_THROUGH_WALLS_LAYERS.computeIfAbsent(lineWidth, LINES_THROUGH_WALLS);
+	}
+
+	public static MultiPhase getTexture(Identifier texture) {
+		return TEXTURE_LAYERS.computeIfAbsent(texture, TEXTURE);
+	}
+
+	public static MultiPhase getTextureThroughWalls(Identifier texture) {
+		return TEXTURE_THROUGH_WALLS_LAYERS.computeIfAbsent(texture, TEXTURE_THROUGH_WALLS);
+	}
 }


### PR DESCRIPTION
Migrates all rendering over to render layers, everything has been tested and works the same as before. Lines strip for line rendering was replaced with lines and it seems to look the same with ice fill for example.

This also fixes ImmediatelyFast causing puzzle solver rendering to flicker (which was really annoying). This migration will also result in less of our rendering code being slaughtered in 1.21.5.