### PR TITLE
Update Ordered Waypoints Tooltip

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/Tips.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/Tips.java
@@ -48,7 +48,7 @@ public class Tips {
             getTipFactory("skyblocker.tips.fairySoulsEnigmaSoulsRelics", ClickEvent.Action.SUGGEST_COMMAND, "/skyblocker fairySouls"),
             getTipFactory("skyblocker.tips.quickNav", ClickEvent.Action.SUGGEST_COMMAND, "/skyblocker config"),
             getTipFactory("skyblocker.tips.waypoints", ClickEvent.Action.SUGGEST_COMMAND, "/skyblocker waypoint"),
-            getTipFactory("skyblocker.tips.orderedWaypoints", ClickEvent.Action.SUGGEST_COMMAND, "/skyblocker waypoint ordered"),
+            getTipFactory("skyblocker.tips.orderedWaypoints", ClickEvent.Action.SUGGEST_COMMAND, "/skyblocker waypoints"),
             getTipFactory("skyblocker.tips.visitorHelper"),
             getTipFactory("skyblocker.tips.slotText"),
             getTipFactory("skyblocker.tips.profileViewer", ClickEvent.Action.SUGGEST_COMMAND, "/pv"),

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1240,7 +1240,7 @@
   "skyblocker.tips.fairySoulsEnigmaSoulsRelics": "Don't know where to find Fairy Souls, Enigma Souls, or Relics? Enable the helpers to aid your exploration; they'll remember which souls you've already found.",
   "skyblocker.tips.quickNav": "You can customize the QuickNav buttons in the config.",
   "skyblocker.tips.waypoints": "You can import (including from skytils), add, remove, and toggle waypoints on any island with /skyblocker waypoints.",
-  "skyblocker.tips.orderedWaypoints": "You can import (including from coleweight), add, remove, and toggle ordered waypoints with /skyblocker waypoints ordered.",
+  "skyblocker.tips.orderedWaypoints": "You can import (including from Coleweight), add, remove, and toggle ordered waypoints with /skyblocker waypoints. When importing from Coleweight you must go to Share → Import Waypoints (Soopy). Make sure to import them under the desired island.",
   "skyblocker.tips.visitorHelper": "Click on the item name in the visitor helper to buy from the bazaar or click on [Copy Amount] to copy the amount to your clipboard.",
   "skyblocker.tips.slotText": "Slot text shows you the attribute shard info, catacombs level, collection level, enchantment book level, minion level, pet level, potion level, prehistoric egg blocks walked, rancher's boots speed cap, skill level, skyblock level in the slot.",
   "skyblocker.tips.profileViewer": "You can view other players' profiles with /pv.",


### PR DESCRIPTION
On top of being outdated, the tip previously linked to a command that didn't even exist.

Fixes #1140 