### PR TITLE
Fix catacombs level adder showing incorrect levels

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CatacombsLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CatacombsLevelAdder.java
@@ -1,13 +1,12 @@
 package de.hysky.skyblocker.skyblock.item.slottext.adders;
 
-import de.hysky.skyblocker.skyblock.item.slottext.SlotText;
 import de.hysky.skyblocker.skyblock.item.slottext.SimpleSlotTextAdder;
+import de.hysky.skyblocker.skyblock.item.slottext.SlotText;
 import de.hysky.skyblocker.utils.RomanNumerals;
 import de.hysky.skyblocker.utils.container.SlotTextAdder;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,8 +15,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-//This class is split into 3 inner classes as there are multiple screens for showing catacombs levels, each with different slot ids or different style of showing the level.
-//It's still kept in 1 main class for organization purposes.
+// This class is split into 3 inner classes as there are multiple screens for showing catacombs levels, each with different slot ids or different style of showing the level.
+// It's still kept in 1 main class for the shared config information.
 public class CatacombsLevelAdder {
 
 	private static final SlotTextAdder.ConfigInformation CONFIG_INFORMATION = new SlotTextAdder.ConfigInformation(
@@ -28,7 +27,7 @@ public class CatacombsLevelAdder {
 	}
 
 	public static class Dungeoneering extends SimpleSlotTextAdder {
-		private static final Pattern LEVEL_PATTERN = Pattern.compile(".*?(?:(?<arabic>\\d+)|(?<roman>\\S+))? ?✯?");
+		private static final Pattern LEVEL_PATTERN = Pattern.compile(".*?(?:(?: (?<arabic>\\d+)| (?<roman>[IVXLC]+))(?: ✯)?)?");
 		public Dungeoneering() {
 			super("^Dungeoneering", CONFIG_INFORMATION);
 		}
@@ -41,7 +40,7 @@ public class CatacombsLevelAdder {
 					if (!matcher.matches()) return List.of();
 					String arabic = matcher.group("arabic");
 					String roman = matcher.group("roman");
-					if (arabic == null && roman == null) return SlotText.bottomLeftList(Text.literal("0").formatted(Formatting.RED));
+					if (arabic == null && roman == null) return SlotText.bottomLeftList(Text.literal("0").withColor(SlotText.CREAM));
 					String level;
 					if (arabic != null) {
 						if (!NumberUtils.isDigits(arabic)) return List.of(); //Sanity check

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/PotionLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/PotionLevelAdder.java
@@ -22,19 +22,14 @@ public class PotionLevelAdder extends SimpleSlotTextAdder {
 		super(CONFIG_INFORMATION);
 	}
 
-    @Override
-    public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
-        NbtCompound customData = ItemUtils.getCustomData(stack);
-        String title = stack.getName().getString();
-        if (customData.contains("potion_level", NbtElement.INT_TYPE) && !title.contains("Healer Class") && !title.contains("Class Passives")) {
-            if (title.contains("Healer Level ")){
-                String level = title.replaceAll("\\D", "");
-                return SlotText.bottomRightList(Text.literal(level).withColor(SlotText.WHITE));
-            } else {
-                int level = customData.getInt("potion_level");
-                return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
-            }
-        }
-        return List.of();
-    }
+	@Override
+	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
+		NbtCompound customData = ItemUtils.getCustomData(stack);
+		String title = stack.getName().getString();
+		if (customData.contains("potion_level", NbtElement.INT_TYPE) && !title.contains("Healer") && !title.contains("Class Passives")) {
+			int level = customData.getInt("potion_level");
+			return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
+		}
+		return List.of();
+	}
 }


### PR DESCRIPTION
There were 3 issues:
1. The potion item on the healer class was showing the potion level for some reason, and it was done through `PotionLevelAdder` with a different positioning. Now it doesn't show the potion level on the healer item.
2. The regex for the `Dungeoneering` screen didn't match level 0, now it does. It now doesn't match a few incorrect patterns as well. *The regex might look a bit complicated but believe me it's not.*
3. Level 0 in the `Dungeoneering` screen (which wasn't even shown) had a red color. Now it matches others with the `SlotText.CREAM` color.