### PR TITLE
Visitor Helper fixes

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -290,7 +290,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 
 		switch (this.handler) {
 			case GenericContainerScreenHandler genericContainerScreenHandler when genericContainerScreenHandler.getRows() == 6 -> {
-				VisitorHelper.onSlotClick(slot, slotId, title);
+				VisitorHelper.onSlotClick(slot, slotId, title, genericContainerScreenHandler.getSlot(13));
 				// Prevent selling to NPC shops
 				ItemStack sellStack = this.handler.slots.get(49).getStack();
 				if (sellStack.getName().getString().equals("Sell Item") || ItemUtils.getLoreLineIf(sellStack, text -> text.contains("buyback")) != null) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
@@ -232,8 +232,11 @@ public class VisitorHelper {
 				}
 
 				if (isMouseOverText(mouseX, mouseY, copyTextX, yPosition, textRenderer.getWidth(" [Copy Amount]"), textRenderer.fontHeight)) {
-					MinecraftClient.getInstance().keyboard.setClipboard(String.valueOf(totalAmount));
-					MinecraftClient.getInstance().player.sendMessage(Constants.PREFIX.get().append("Copied amount successfully"), false);
+					MinecraftClient client = MinecraftClient.getInstance();
+					client.keyboard.setClipboard(String.valueOf(totalAmount));
+					if (client.player != null) {
+						client.player.sendMessage(Constants.PREFIX.get().append("Copied amount successfully"), false);
+					}
 					return;
 				}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
@@ -37,7 +37,7 @@ public class VisitorHelper {
 	private static final int LINE_HEIGHT = 3;
 	private static final ItemStack BARRIER = new ItemStack(Items.BARRIER);
 
-	private static boolean updateVistors = false;
+	private static boolean processVistors = false;
 
 	@Init
 	public static void initialize() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
@@ -45,7 +45,7 @@ public class VisitorHelper {
 		ScreenEvents.BEFORE_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
 			if (!(screen instanceof HandledScreen<?> handledScreen) || !shouldRender()) return;
 
-			updateVistors = true;
+			processVisitor = true;
 			ScreenEvents.afterTick(screen).register(_screen -> updateVisitors(handledScreen.getScreenHandler()));
 			ScreenEvents.afterRender(screen).register((_screen, context, _x, _y, _d) -> renderVisitorHelper(context, client.textRenderer));
 		});

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
@@ -38,7 +38,7 @@ public class VisitorHelper {
 	private static final ItemStack BARRIER = new ItemStack(Items.BARRIER);
 
 	// Used to prevent adding the visitor again after the player clicks accept or refuse.
-	private static boolean processVistor = false;
+	private static boolean processVisitor = false;
 
 	@Init
 	public static void initialize() {
@@ -61,7 +61,7 @@ public class VisitorHelper {
 	 * Updates the current visitors and their required items.
 	 */
 	private static void updateVisitors(ScreenHandler handler) {
-		if (!processVistor) return;
+		if (!processVisitor) return;
 		ItemStack visitorHead = handler.getSlot(13).getStack();
 		if (visitorHead == null || !visitorHead.contains(DataComponentTypes.LORE) || ItemUtils.getLoreLineIf(visitorHead, t -> t.contains("Times Visited")) == null) return;
 
@@ -251,7 +251,7 @@ public class VisitorHelper {
 		if ((slotId == 29 || slotId == 13 || slotId == 33) && slot.hasStack() &&
 				ItemUtils.getLoreLineIf(slot.getStack(), s -> s.equals("Click to give!") || s.equals("Click to refuse!")) != null) {
 			activeVisitors.removeIf(entry -> entry.name().getString().equals(title) && visitorHeadSlot.hasStack() && ItemUtils.getHeadTexture(visitorHeadSlot.getStack()).equals(ItemUtils.getHeadTexture(entry.head())));
-			processVistor = false;
+			processVisitor = false;
 		}
 
 		updateItems();

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
@@ -37,7 +37,8 @@ public class VisitorHelper {
 	private static final int LINE_HEIGHT = 3;
 	private static final ItemStack BARRIER = new ItemStack(Items.BARRIER);
 
-	private static boolean processVistors = false;
+	// Used to prevent adding the visitor again after the player clicks accept or refuse.
+	private static boolean processVistor = false;
 
 	@Init
 	public static void initialize() {
@@ -60,7 +61,7 @@ public class VisitorHelper {
 	 * Updates the current visitors and their required items.
 	 */
 	private static void updateVisitors(ScreenHandler handler) {
-		if (!updateVistors) return;
+		if (!processVistor) return;
 		ItemStack visitorHead = handler.getSlot(13).getStack();
 		if (visitorHead == null || !visitorHead.contains(DataComponentTypes.LORE) || ItemUtils.getLoreLineIf(visitorHead, t -> t.contains("Times Visited")) == null) return;
 
@@ -250,7 +251,7 @@ public class VisitorHelper {
 		if ((slotId == 29 || slotId == 13 || slotId == 33) && slot.hasStack() &&
 				ItemUtils.getLoreLineIf(slot.getStack(), s -> s.equals("Click to give!") || s.equals("Click to refuse!")) != null) {
 			activeVisitors.removeIf(entry -> entry.name().getString().equals(title) && visitorHeadSlot.hasStack() && ItemUtils.getHeadTexture(visitorHeadSlot.getStack()).equals(ItemUtils.getHeadTexture(entry.head())));
-			updateVistors = false;
+			processVistor = false;
 		}
 
 		updateItems();


### PR DESCRIPTION
- fix crash if the cachedStack is null
- put a non null value if the item isn't found in the repo for some reason to avoid going through it every single frame
- fix refusing not removing the visitor
- check that the head texture is the same before removing visitor (for those idiots with the same name)