### PR TITLE
Fix fossil solver again

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/fossil/FossilSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/fossil/FossilSolver.java
@@ -164,6 +164,12 @@ public class FossilSolver extends SimpleContainerSolver implements TooltipAdder 
 		return 0;
 	}
 
+	@Override
+	public void reset() {
+		chiselLeft = -1;
+		percentage = null;
+	}
+
 
 }
 


### PR DESCRIPTION
Reset values when the container is reset. This should stop only one type of fossil being possible after finding one.

