### PR TITLE
visitor helper: dont display "x0 stacks" text

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
@@ -179,7 +179,7 @@ public class VisitorHelper {
 			}
 
 			MutableText name = cachedStack != null ? cachedStack.getName().copy() : itemName.copy();
-			Text itemText = SkyblockerConfigManager.get().farming.visitorHelper.showStacksInVisitorHelper
+			Text itemText = SkyblockerConfigManager.get().farming.visitorHelper.showStacksInVisitorHelper && totalAmount >= 64
 					? name
 					.append(" x" + (totalAmount / 64) + " stacks + " + (totalAmount % 64))
 					: name
@@ -222,7 +222,7 @@ public class VisitorHelper {
 				int yPosition = Y_OFFSET + index * (LINE_HEIGHT + textRenderer.fontHeight) -
 						(int) ((float) textRenderer.fontHeight / 2 - ICON_SIZE * 0.95f / 2) + yOffsetAdjustment;
 
-				Text itemText = SkyblockerConfigManager.get().farming.visitorHelper.showStacksInVisitorHelper
+				Text itemText = SkyblockerConfigManager.get().farming.visitorHelper.showStacksInVisitorHelper && totalAmount >= 64
 						? itemName.copy()
 						.append(" x" + (totalAmount / 64) + " stacks + " + (totalAmount % 64))
 						: itemName.copy()


### PR DESCRIPTION
Removed useless information from the Visitor Helper UI: "x0 stacks" when a Visitor asks for less than a stack of items.

<sub>I had to resubmit it. Messed up my branches. Git is complicated and everybody gets to see your mistakes</sub>