### PR TITLE
Item cooldown for most items Also changed the logic

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemCooldowns.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemCooldowns.java
@@ -1,179 +1,281 @@
 package de.hysky.skyblocker.skyblock.item;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.PetCache;
 import de.hysky.skyblocker.utils.ItemUtils;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.event.client.player.ClientPlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ItemCooldowns {
-    private static final String JUNGLE_AXE_ID = "JUNGLE_AXE";
-    private static final String TREECAPITATOR_ID = "TREECAPITATOR_AXE";
-    private static final String GRAPPLING_HOOK_ID = "GRAPPLING_HOOK";
-	private static final String ROGUE_SWORD_ID = "ROGUE_SWORD";
-	private static final String LEAPING_SWORD_ID = "LEAPING_SWORD";
-	private static final String SILK_EDGE_SWORD_ID = "SILK_EDGE_SWORD";
-	private static final String GREAT_SPOOK_STAFF_ID = "GREAT_SPOOK_STAFF";
-	private static final String SPIRIT_LEAP_ID = "SPIRIT_LEAP";
-	private static final String GIANTS_SWORD_ID = "GIANTS_SWORD";
-	private static final String SHADOW_FURY_ID = "SHADOW_FURY";
-	private static final String LIVID_DAGGER_ID = "LIVID_DAGGER";
-	private static final String INK_WAND_ID = "INK_WAND";
+	private static final Logger LOGGER = LoggerFactory.getLogger(ItemCooldowns.class);
+	private static final List<String> BAT_ARMOR_IDS = List.of("BAT_PERSON_HELMET", "BAT_PERSON_CHESTPLATE", "BAT_PERSON_LEGGINGS", "BAT_PERSON_BOOTS");
+	private static final Map<String, CooldownConfigEntry> ITEM_CONFIGS = new HashMap<>();
+	private static final Map<String, CooldownEntry> ITEM_COOLDOWNS = new HashMap<>();
 
-    private static final List<String> BAT_ARMOR_IDS = List.of("BAT_PERSON_HELMET", "BAT_PERSON_CHESTPLATE", "BAT_PERSON_LEGGINGS", "BAT_PERSON_BOOTS");
-    private static final Map<String, CooldownEntry> ITEM_COOLDOWNS = new HashMap<>();
-    private static final int[] EXPERIENCE_LEVELS = {
-            0, 660, 730, 800, 880, 960, 1050, 1150, 1260, 1380, 1510, 1650, 1800, 1960, 2130,
-            2310, 2500, 2700, 2920, 3160, 3420, 3700, 4000, 4350, 4750, 5200, 5700, 6300, 7000,
-            7800, 8700, 9700, 10800, 12000, 13300, 14700, 16200, 17800, 19500, 21300, 23200,
-            25200, 27400, 29800, 32400, 35200, 38200, 41400, 44800, 48400, 52200, 56200, 60400,
-            64800, 69400, 74200, 79200, 84700, 90700, 97200, 104200, 111700, 119700, 128200,
-            137200, 147700, 156700, 167700, 179700, 192700, 206700, 221700, 237700, 254700,
-            272700, 291700, 311700, 333700, 357700, 383700, 411700, 441700, 476700, 516700,
-            561700, 611700, 666700, 726700, 791700, 861700, 936700, 1016700, 1101700, 1191700,
-            1286700, 1386700, 1496700, 1616700, 1746700, 1886700
-    };
-    private static int monkeyLevel = 1;
-    private static double monkeyExp = 0;
+	private static final int[] EXPERIENCE_LEVELS = {
+			0, 660, 730, 800, 880, 960, 1050, 1150, 1260, 1380, 1510, 1650, 1800, 1960, 2130,
+			2310, 2500, 2700, 2920, 3160, 3420, 3700, 4000, 4350, 4750, 5200, 5700, 6300, 7000,
+			7800, 8700, 9700, 10800, 12000, 13300, 14700, 16200, 17800, 19500, 21300, 23200,
+			25200, 27400, 29800, 32400, 35200, 38200, 41400, 44800, 48400, 52200, 56200, 60400,
+			64800, 69400, 74200, 79200, 84700, 90700, 97200, 104200, 111700, 119700, 128200,
+			137200, 147700, 156700, 167700, 179700, 192700, 206700, 221700, 237700, 254700,
+			272700, 291700, 311700, 333700, 357700, 383700, 411700, 441700, 476700, 516700,
+			561700, 611700, 666700, 726700, 791700, 861700, 936700, 1016700, 1101700, 1191700,
+			1286700, 1386700, 1496700, 1616700, 1746700, 1886700
+	};
+	private static int monkeyLevel = 1;
+	private static double monkeyExp = 0;
+	private static boolean wasPressed = false;
 
-    @Init
-    public static void init() {
-        ClientPlayerBlockBreakEvents.AFTER.register(ItemCooldowns::afterBlockBreak);
-        UseItemCallback.EVENT.register(ItemCooldowns::onItemInteract);
-    }
+	@Init
+	public static void init() {
+		ClientLifecycleEvents.CLIENT_STARTED.register(ItemCooldowns::loadCooldownConfig);
+		UseItemCallback.EVENT.register((player, world, hand) -> applyCooldownIfConfigured(player, world, "right_click") ? ActionResult.SUCCESS : ActionResult.PASS);
+		ClientTickEvents.END_CLIENT_TICK.register(client -> {
+			if (client.player == null || client.world == null) return;
+			boolean currentlyPressed = client.options.attackKey.isPressed();
+			if (currentlyPressed && !wasPressed) {
+				applyCooldownIfConfigured(client.player, client.world, "left_click");
+			}
+			wasPressed = currentlyPressed;
+		});
+		ClientPlayerBlockBreakEvents.AFTER.register(ItemCooldowns::afterBlockBreak);
+	}
 
-    public static void updateCooldown() {
-        PetInfo pet = PetCache.getCurrentPet();
+	public static void updateCooldown() {
+		PetInfo pet = PetCache.getCurrentPet();
 
-        if (pet != null && pet.tier().equals(SkyblockItemRarity.LEGENDARY)) {
-            monkeyExp = pet.exp();
+		if (pet != null && pet.tier().equals(SkyblockItemRarity.LEGENDARY)) {
+			monkeyExp = pet.exp();
 
-            monkeyLevel = 0;
-            for (int xpLevel : EXPERIENCE_LEVELS) {
-                if (monkeyExp < xpLevel) {
-                    break;
-                } else {
-                    monkeyExp -= xpLevel;
-                    monkeyLevel++;
-                }
-            }
-        }
-    }
-
-    private static int getCooldown4Foraging() {
-        int baseCooldown = 2000;
-        int monkeyPetCooldownReduction = baseCooldown * monkeyLevel / 200;
-        return baseCooldown - monkeyPetCooldownReduction;
-    }
-
-    public static void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state) {
-        if (!SkyblockerConfigManager.get().uiAndVisuals.itemCooldown.enableItemCooldowns) return;
-        String usedItemId = ItemUtils.getItemId(player.getMainHandStack());
-        if (usedItemId.isEmpty()) return;
-        if (state.isIn(BlockTags.LOGS)) {
-            if (usedItemId.equals(JUNGLE_AXE_ID) && !isOnCooldown(JUNGLE_AXE_ID)) {
-                updateCooldown();
-                ITEM_COOLDOWNS.put(usedItemId, new CooldownEntry(getCooldown4Foraging()));
-                return;
-            }
-            if (usedItemId.equals(TREECAPITATOR_ID) && !isOnCooldown(TREECAPITATOR_ID)) {
-                updateCooldown();
-                ITEM_COOLDOWNS.put(usedItemId, new CooldownEntry(getCooldown4Foraging()));
-                return;
-            }
-        }
-    }
-
-    private static ActionResult onItemInteract(PlayerEntity player, World world, Hand hand) {
-		if (!SkyblockerConfigManager.get().uiAndVisuals.itemCooldown.enableItemCooldowns)
-			return ActionResult.PASS;
-		String usedItemId = ItemUtils.getItemId(player.getMainHandStack());
-		switch (usedItemId) {
-			case SILK_EDGE_SWORD_ID, LEAPING_SWORD_ID -> handleItemCooldown(usedItemId, 1000);
-			case GRAPPLING_HOOK_ID -> handleItemCooldown(GRAPPLING_HOOK_ID, 2000, player.fishHook != null && !isWearingBatArmor(player));
-			case ROGUE_SWORD_ID, SPIRIT_LEAP_ID, LIVID_DAGGER_ID -> handleItemCooldown(usedItemId, 5000);
-			case SHADOW_FURY_ID -> handleItemCooldown(SHADOW_FURY_ID, 15000);
-			case INK_WAND_ID, GIANTS_SWORD_ID -> handleItemCooldown(usedItemId, 30000);
-			case GREAT_SPOOK_STAFF_ID -> handleItemCooldown(GREAT_SPOOK_STAFF_ID, 60000);
-			// Handle any unlisted items if necessary
-			default -> {}
-		}
-        return ActionResult.PASS;
-    }
-
-	// Method to handle item cooldowns with optional condition
-	private static void handleItemCooldown(String itemId, int cooldownTime, boolean additionalCondition) {
-		if (!isOnCooldown(itemId) && additionalCondition) {
-			ITEM_COOLDOWNS.put(itemId, new CooldownEntry(cooldownTime));
+			monkeyLevel = 0;
+			for (int xpLevel : EXPERIENCE_LEVELS) {
+				if (monkeyExp < xpLevel) {
+					break;
+				} else {
+					monkeyExp -= xpLevel;
+					monkeyLevel++;
+				}
+			}
 		}
 	}
 
-	// Overloaded method for cases without additional conditions
-	private static void handleItemCooldown(String itemId, int cooldownTime) {
-		handleItemCooldown(itemId, cooldownTime, true);
+	private static int getCooldown4Foraging(CooldownConfigEntry config) {
+		int baseCooldown = config.cooldown;
+		int monkeyPetCooldownReduction = baseCooldown * monkeyLevel / 200;
+		return baseCooldown - monkeyPetCooldownReduction;
 	}
 
-    public static boolean isOnCooldown(ItemStack itemStack) {
-        return isOnCooldown(ItemUtils.getItemId(itemStack));
-    }
+	//	"ITEM_ID": {
+	//		"cooldown": 1000,                // Cooldown duration in milliseconds
+	//		"cooldown_type": "foraging",     // Optional: defines dynamic cooldown logic
+	//		"trigger": "right_click",        // Action that triggers the ability (e.g. "right_click", "left_click", "block_break")
+	//		"condition": "someCondition",    // Optional: name of a special condition to check before triggering
+	//		"block_tag": "minecraft:logs",   // Optional: required block tag for block_break triggers
+	//		"toggle": true,                  // If true, item can be toggled on/off with one click (logic not implemented yet)
+	//		"requires_sneak": true,          // If true, player must be sneaking to trigger the item
+	//		"cooldown_group": "GROUP_ID"     // Optional: group of items that share the same cooldown (e.g. jungle axe and treecapitator)
+	//	}
+	private static void loadCooldownConfig(MinecraftClient client) {
+		try (BufferedReader reader = client.getResourceManager().openAsReader(Identifier.of(SkyblockerMod.NAMESPACE, "cooldown/item_cooldown.json"))) {
+			JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+			for (Map.Entry<String, JsonElement> entry : root.entrySet()) {
+				JsonObject obj = entry.getValue().getAsJsonObject();
+				CooldownConfigEntry cfg = new CooldownConfigEntry();
+				cfg.trigger = obj.get("trigger").getAsString();
+				cfg.cooldown = obj.has("cooldown") && obj.get("cooldown").isJsonPrimitive() && obj.get("cooldown").getAsJsonPrimitive().isNumber() ? obj.get("cooldown").getAsInt() : 0;
+				cfg.cooldownType = obj.has("cooldown_type") ? obj.get("cooldown_type").getAsString() : null;
+				cfg.condition = obj.has("condition") ? obj.get("condition").getAsString() : null;
+				cfg.block_tag = obj.has("block_tag") ? obj.get("block_tag").getAsString() : null;
+				cfg.toggle = obj.has("toggle") && obj.get("toggle").getAsBoolean();
+				cfg.requiresSneak = obj.has("requires_sneak") && obj.get("requires_sneak").getAsBoolean();
+				cfg.cooldownGroup = obj.has("cooldown_group") ? obj.get("cooldown_group").getAsString() : null;
+				ITEM_CONFIGS.put(entry.getKey(), cfg);
+			}
+			LOGGER.info("[Skyblocker] Loaded item cooldown");
+		} catch (IOException e) {
+			LOGGER.error("[Skyblocker] Failed to load item cooldown", e);
+		}
+	}
 
-    private static boolean isOnCooldown(String itemId) {
-        if (ITEM_COOLDOWNS.containsKey(itemId)) {
-            CooldownEntry cooldownEntry = ITEM_COOLDOWNS.get(itemId);
-            if (cooldownEntry.isOnCooldown()) {
-                return true;
-            } else {
-                ITEM_COOLDOWNS.remove(itemId);
-                return false;
-            }
-        }
+	private static boolean applyCooldownIfConfigured(PlayerEntity player, World world, String triggerType) {
+		if (!SkyblockerConfigManager.get().uiAndVisuals.itemCooldown.enableItemCooldowns) return false;
+		String itemId = ItemUtils.getItemId(player.getMainHandStack());
+		CooldownConfigEntry config = ITEM_CONFIGS.get(itemId);
 
-        return false;
-    }
+		if (config == null || !triggerType.equals(config.trigger)) return false;
+		if (config.requiresSneak && !player.isSneaking()) return false;
 
-    public static CooldownEntry getItemCooldownEntry(ItemStack itemStack) {
-        return ITEM_COOLDOWNS.get(ItemUtils.getItemId(itemStack));
-    }
+		if (isOnCooldown(itemId)) return false;
+		if (config.condition != null && !checkCondition(config.condition, player)) return false;
 
-    private static boolean isWearingBatArmor(PlayerEntity player) {
-        for (ItemStack stack : ItemUtils.getArmor(player)) {
-            String itemId = ItemUtils.getItemId(stack);
-            if (!BAT_ARMOR_IDS.contains(itemId)) {
-                return false;
-            }
-        }
-        return true;
-    }
+		int cooldown = resolveCooldown(config);
+		ITEM_COOLDOWNS.put(itemId, new CooldownEntry(cooldown));
 
-    public record CooldownEntry(int cooldown, long startTime) {
-        public CooldownEntry(int cooldown) {
-            this(cooldown, System.currentTimeMillis());
-        }
+		if (config.cooldownGroup != null) {
+			for (Map.Entry<String, CooldownConfigEntry> e : ITEM_CONFIGS.entrySet()) {
+				if (config.cooldownGroup.equals(e.getValue().cooldownGroup)) {
+					ITEM_COOLDOWNS.put(e.getKey(), new CooldownEntry(cooldown));
+				}
+			}
+		}
+		return true;
+	}
 
-        public boolean isOnCooldown() {
-            return (this.startTime + this.cooldown) > System.currentTimeMillis();
-        }
+	public static void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state) {
+		if (!SkyblockerConfigManager.get().uiAndVisuals.itemCooldown.enableItemCooldowns) return;
 
-        public long getRemainingCooldown() {
-            long time = (this.startTime + this.cooldown) - System.currentTimeMillis();
-            return Math.max(time, 0);
-        }
+		String itemId = ItemUtils.getItemId(player.getMainHandStack());
+		CooldownConfigEntry config = ITEM_CONFIGS.get(itemId);
+		if (config == null || !"block_break".equals(config.trigger) || isOnCooldown(itemId)) return;
 
-        public float getRemainingCooldownPercent() {
-            return this.isOnCooldown() ? (float) this.getRemainingCooldown() / cooldown : 0.0f;
-        }
-    }
+		if (config.block_tag != null) {
+			TagKey<Block> tag = TagKey.of(Registries.BLOCK.getKey(), Identifier.of(config.block_tag));
+			if (!state.isIn(tag)) return;
+		}
+
+		ITEM_COOLDOWNS.put(itemId, new CooldownEntry(resolveCooldown(config)));
+	}
+
+	public static boolean isOnCooldown(ItemStack itemStack) {
+		String itemId = ItemUtils.getItemId(itemStack);
+		CooldownConfigEntry config = ITEM_CONFIGS.get(itemId);
+
+		if (config == null) return false;
+
+		if (isOnCooldown(itemId)) return true;
+
+		if (config.cooldownGroup != null) {
+			for (Map.Entry<String, CooldownConfigEntry> e : ITEM_CONFIGS.entrySet()) {
+				if (config.cooldownGroup.equals(e.getValue().cooldownGroup)) {
+					if (isOnCooldown(e.getKey())) return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static int resolveCooldown(CooldownConfigEntry config) {
+		if ("foraging".equals(config.cooldownType)) {
+			updateCooldown();
+			return getCooldown4Foraging(config);
+		}
+		return config.cooldown;
+	}
+
+	public static boolean isOnCooldown(String itemId) {
+		CooldownConfigEntry config = ITEM_CONFIGS.get(itemId);
+
+		if (ITEM_COOLDOWNS.containsKey(itemId)) {
+			CooldownEntry entry = ITEM_COOLDOWNS.get(itemId);
+			if (entry.isOnCooldown()) return true;
+			ITEM_COOLDOWNS.remove(itemId);
+		}
+
+		if (config != null && config.cooldownGroup != null) {
+			for (Map.Entry<String, CooldownEntry> e : ITEM_COOLDOWNS.entrySet()) {
+				CooldownConfigEntry otherConfig = ITEM_CONFIGS.get(e.getKey());
+				if (otherConfig != null && config.cooldownGroup.equals(otherConfig.cooldownGroup)) {
+					if (e.getValue().isOnCooldown()) return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public static CooldownEntry getItemCooldownEntry(ItemStack itemStack) {
+		String itemId = ItemUtils.getItemId(itemStack);
+		CooldownConfigEntry config = ITEM_CONFIGS.get(itemId);
+
+		if (config == null) return null;
+
+		CooldownEntry entry = ITEM_COOLDOWNS.get(itemId);
+		if (entry != null && entry.isOnCooldown()) return entry;
+
+		if (config.cooldownGroup != null) {
+			for (Map.Entry<String, CooldownEntry> e : ITEM_COOLDOWNS.entrySet()) {
+				CooldownConfigEntry otherConfig = ITEM_CONFIGS.get(e.getKey());
+				if (otherConfig != null && config.cooldownGroup.equals(otherConfig.cooldownGroup)) {
+					if (e.getValue().isOnCooldown()) return e.getValue();
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static boolean checkCondition(String condition, PlayerEntity player) {
+		return switch (condition) {
+			case "hasFishingHookAndNotBatArmor" -> player.fishHook != null && !isWearingBatArmor(player);
+			default -> true;
+		};
+	}
+
+	private static boolean isWearingBatArmor(PlayerEntity player) {
+		for (ItemStack stack : ItemUtils.getArmor(player)) {
+			String itemId = ItemUtils.getItemId(stack);
+			if (!BAT_ARMOR_IDS.contains(itemId)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public record CooldownEntry(int cooldown, long startTime) {
+		public CooldownEntry(int cooldown) {
+			this(cooldown, System.currentTimeMillis());
+		}
+
+		public boolean isOnCooldown() {
+			return (this.startTime + this.cooldown) > System.currentTimeMillis();
+		}
+
+		public long getRemainingCooldown() {
+			long time = (this.startTime + this.cooldown) - System.currentTimeMillis();
+			return Math.max(time, 0);
+		}
+
+		public float getRemainingCooldownPercent() {
+			return this.isOnCooldown() ? (float) this.getRemainingCooldown() / cooldown : 0.0f;
+		}
+	}
+
+	private static class CooldownConfigEntry {
+		public String trigger;
+		public Integer cooldown;
+		public String condition;
+		public String cooldownType;
+		public String block_tag;
+		public boolean toggle;
+		public boolean requiresSneak;
+		public String cooldownGroup;
+	}
 }

--- a/src/main/resources/assets/skyblocker/cooldown/item_cooldown.json
+++ b/src/main/resources/assets/skyblocker/cooldown/item_cooldown.json
@@ -1,0 +1,334 @@
+{
+  "SILK_EDGE_SWORD": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "LEAPING_SWORD": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "GRAPPLING_HOOK": {
+    "cooldown": 2000,
+    "trigger": "right_click",
+    "condition": "hasFishingHookAndNotBatArmor"
+  },
+  "ROGUE_SWORD": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "SPIRIT_LEAP": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "INFINITE_SPIRIT_LEAP": {
+    "cooldown": 2000,
+    "trigger": "right_click"
+  },
+  "LIVID_DAGGER": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "SHADOW_FURY": {
+    "cooldown": 15000,
+    "trigger": "right_click"
+  },
+  "STARRED_SHADOW_FURY": {
+    "cooldown": 15000,
+    "trigger": "right_click"
+  },
+  "INK_WAND": {
+    "cooldown": 30000,
+    "trigger": "right_click"
+  },
+  "GIANTS_SWORD": {
+    "cooldown": 30000,
+    "trigger": "right_click"
+  },
+  "GREAT_SPOOK_STAFF": {
+    "cooldown": 60000,
+    "trigger": "right_click"
+  },
+  "JUNGLE_AXE": {
+    "cooldown": 2000,
+    "cooldown_type": "foraging",
+    "trigger": "block_break",
+    "block_tag": "minecraft:logs",
+    "cooldown_group": "jungle_axe"
+  },
+  "TREECAPITATOR_AXE": {
+    "cooldown": 2000,
+    "cooldown_type": "foraging",
+    "trigger": "block_break",
+    "block_tag": "minecraft:logs",
+    "cooldown_group": "jungle_axe"
+  },
+  "WITHER_CLOAK": {
+    "cooldown": 10000,
+    "trigger": "right_click",
+    "toggle": true
+  },
+  "GOLEM_SWORD": {
+    "cooldown": 3000,
+    "trigger": "right_click"
+  },
+  "ASPECT_OF_THE_JERRY": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "SWORD_OF_BAD_HEALTH": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "PIGMAN_SWORD": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "YETI_SWORD": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "STARRED_YETI_SWORD": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "RAGNAROCK_AXE": {
+    "cooldown": 20000,
+    "trigger": "right_click"
+  },
+  "FIRE_FREEZE_STAFF": {
+    "cooldown": 10000,
+    "trigger": "right_click"
+  },
+  "RUNIC_STAFF": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "MIDAS_STAFF": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "STARRED_MIDAS_STAFF": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "ENRAGER": {
+    "cooldown": 20000,
+    "trigger": "right_click"
+  },
+  "EMBER_ROD": {
+    "cooldown": 30000,
+    "trigger": "right_click"
+  },
+  "ASPECT_OF_THE_JERRY_SIGNATURE": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "REAPER_SCYTHE": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "ATOMSPLIT_KATANA": {
+    "cooldown": 4000,
+    "trigger": "right_click"
+  },
+  "VORPAL_KATANA": {
+    "cooldown": 4000,
+    "trigger": "right_click"
+  },
+  "VOIDEDGE_KATANA": {
+    "cooldown": 4000,
+    "trigger": "right_click"
+  },
+  "ICE_SPRAY_WAND": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "STARRED_ICE_SPRAY_WAND": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "FLOWER_OF_TRUTH": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "BOUQUET_OF_LIES": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "SPIRIT_SWORD": {
+    "cooldown": 10000,
+    "trigger": "right_click"
+  },
+  "NECROMANCER_SWORD": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "ENDER_BOW": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "MACHINE_GUN_BOW": {
+    "cooldown": 100000,
+    "trigger": "right_click"
+  },
+  "VOODOO_DOLL": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "VOODOO_DOLL_WILTED": {
+    "cooldown": 3000,
+    "trigger": "right_click"
+  },
+  "STARLIGHT_WAND": {
+    "cooldown": 2000,
+    "trigger": "right_click"
+  },
+  "STAFF_OF_THE_VOLCANO": {
+    "cooldown": 30000,
+    "trigger": "right_click"
+  },
+  "FIRE_FURY_STAFF": {
+    "cooldown": 20000,
+    "trigger": "right_click"
+  },
+  "BINGO_BLASTER": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "SILENT_DEATH": {
+    "cooldown": 60000,
+    "trigger": "right_click"
+  },
+  "SKYMART_VACUUM": {
+    "cooldown": 1000,
+    "trigger": "left_click"
+  },
+  "SKYMART_TURBO_VACUUM": {
+    "cooldown": 1000,
+    "trigger": "left_click"
+  },
+  "SKYMART_HYPER_VACUUM": {
+    "cooldown": 1000,
+    "trigger": "left_click"
+  },
+  "INFINI_VACUUM": {
+    "cooldown": 1000,
+    "trigger": "left_click"
+  },
+  "INFINI_VACUUM_HOOVERIUS": {
+    "cooldown": 1000,
+    "trigger": "left_click"
+  },
+  "FIRE_VEIL_WAND": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "WAND_OF_STRENGTH": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "WAND_OF_HEALING": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "WAND_OF_MENDING": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "WAND_OF_RESTORATION": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "WAND_OF_ATONEMENT": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "GYROKINETIC_WAND": {
+    "cooldown": 30000,
+    "trigger": "right_click"
+  },
+  "WEIRD_TUBA": {
+    "cooldown": 20000,
+    "trigger": "right_click"
+  },
+  "WEIRDER_TUBA": {
+    "cooldown": 20000,
+    "trigger": "right_click"
+  },
+  "SPRAYONATOR": {
+    "cooldown": 3000,
+    "trigger": "right_click"
+  },
+  "GLOOMLOCK_GRIMOIRE": {
+    "cooldown": 1000,
+    "trigger": "left_click"
+  },
+  "TACTICAL_INSERTION": {
+    "cooldown": 20000,
+    "trigger": "right_click"
+  },
+  "SUMMONING_RING": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "HOLY_ICE": {
+    "cooldown": 4000,
+    "trigger": "right_click"
+  },
+  "ANCESTRAL_SPADE": {
+    "cooldown": 3000,
+    "trigger": "right_click"
+  },
+  "MOODY_GRAPPLESHOT": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "INFINITE_SUPERBOOM_TNT": {
+    "cooldown": 2000,
+    "trigger": "right_click"
+  },
+  "ROYAL_COMPASS": {
+    "cooldown": 3000,
+    "trigger": "right_click"
+  },
+  "SECRET_TRACKER": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "FAKE_SHURIKEN": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "DEAD_CAT_DETECTOR": {
+    "cooldown": 9000,
+    "trigger": "right_click"
+  },
+  "HOTSPOT_RADAR": {
+    "cooldown": 2000,
+    "trigger": "right_click"
+  },
+  "TALBOTS_THEODOLITE": {
+    "cooldown": 10000,
+    "trigger": "right_click"
+  },
+  "EMMETT_POINTER": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "EGGLOCATOR": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  },
+  "DETECTIVE_SCANNER": {
+    "cooldown": 4000,
+    "trigger": "right_click"
+  },
+  "JINGLE_BELLS": {
+    "cooldown": 1000,
+    "trigger": "right_click"
+  },
+  "ROYAL_PIGEON": {
+    "cooldown": 5000,
+    "trigger": "right_click"
+  }
+}


### PR DESCRIPTION
### Summary

- Added support for all known Skyblock items with cooldowns  
  (some items might be missing)
- Added support for **left-click** triggered abilities
- Added handling for **sneak + left/right-click** combinations
- Moved all cooldown logic to an external JSON configuration file

---

### JSON Format

```json
"ITEM_ID": {
  "cooldown": 1000,                // Cooldown duration in milliseconds
  "cooldown_type": "foraging",     // Optional: dynamic cooldown logic (e.g. depends on monkey pet level)
  "trigger": "right_click",        // How the ability is triggered ("right_click", "left_click", "block_break")
  "condition": "someCondition",    // Optional: name of a condition to be checked before activation
  "block_tag": "minecraft:logs",   // Optional: required block tag for block_break abilities
  "toggle": true,                  // Optional: item can be toggled on/off ( different cooldown applies after early deactivation)
  "requires_sneak": true,          // Optional: only activates while sneaking
  "cooldown_group": "GROUP_ID"     // Optional: shared cooldown group (e.g. Jungle Axe & Treecapitator)
}
```
---
### Still missing:
* Full toggle logic (e.g. Wither Cloak: stays active for 10s, cooldown begins after deactivation, if deactivated early cooldown is 5s)