### PR TITLE
Profile viewer update

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
@@ -61,7 +61,7 @@ public class ChestValue {
 								addValueToContainer(genericContainerScreen, dungeonChestProfit, title);
 						});
 					}
-				} else if (SkyblockerConfigManager.get().uiAndVisuals.chestValue.enableChestValue && !titleString.equals("SkyBlock Menu")) {
+				} else if (SkyblockerConfigManager.get().uiAndVisuals.chestValue.enableChestValue && !titleString.equals("SkyBlock Menu") && !titleString.endsWith("'s Profile")) {
 					boolean minion = MINION_PATTERN.matcher(title.getString().trim()).find();
 					Screens.getButtons(screen).add(ButtonWidget
 							.builder(Text.literal("$"), buttonWidget -> {

--- a/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerScreen.java
@@ -1,14 +1,13 @@
 package de.hysky.skyblocker.skyblock.profileviewer;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.util.UndashedUuid;
-
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.mixins.accessors.HandledScreenAccessor;
 import de.hysky.skyblocker.skyblock.profileviewer.collections.CollectionsPage;
 import de.hysky.skyblocker.skyblock.profileviewer.dungeons.DungeonsPage;
 import de.hysky.skyblocker.skyblock.profileviewer.inventory.InventoryPage;
@@ -24,10 +23,16 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.minecraft.block.entity.SkullBlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ChatScreen;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.ClickableWidget;
 import net.minecraft.client.network.OtherClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
@@ -37,244 +42,301 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerModelPart;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.*;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 
 import static net.minecraft.client.gui.screen.ingame.InventoryScreen.drawEntity;
 
 public class ProfileViewerScreen extends Screen {
-    public static final Logger LOGGER = LoggerFactory.getLogger(ProfileViewerScreen.class);
-    private static final Text TITLE = Text.of("Skyblocker Profile Viewer");
-    private static final String HYPIXEL_COLLECTIONS = "https://api.hypixel.net/v2/resources/skyblock/collections";
-    private static final Identifier TEXTURE = Identifier.of(SkyblockerMod.NAMESPACE, "textures/gui/profile_viewer/base_plate.png");
-    private static final int GUI_WIDTH = 322;
-    private static final int GUI_HEIGHT = 180;
-    private static Map<String, String[]> COLLECTIONS;
-    private static Map<String, IntList> TIER_REQUIREMENTS;
+	public static final Logger LOGGER = LoggerFactory.getLogger(ProfileViewerScreen.class);
+	private static final Text TITLE = Text.of("Skyblocker Profile Viewer");
+	private static final String HYPIXEL_COLLECTIONS = "https://api.hypixel.net/v2/resources/skyblock/collections";
+	private static final Identifier TEXTURE = Identifier.of(SkyblockerMod.NAMESPACE, "textures/gui/profile_viewer/base_plate.png");
+	private static final int GUI_WIDTH = 322;
+	private static final int GUI_HEIGHT = 180;
+	private static Map<String, String[]> COLLECTIONS;
+	private static Map<String, IntList> TIER_REQUIREMENTS;
 
-    private String playerName;
-    private JsonObject hypixelProfile;
-    private JsonObject playerProfile;
-    private boolean profileNotFound = false;
+	private String playerName;
+	private JsonObject hypixelProfile;
+	private JsonObject playerProfile;
+	private boolean profileNotFound = false;
 	private String errorMessage = "No Profile";
 
-    private int activePage = 0;
-    private static final String[] PAGE_NAMES = {"Skills", "Slayers", "Dungeons", "Inventories", "Collections"};
-    private final ProfileViewerPage[] profileViewerPages = new ProfileViewerPage[PAGE_NAMES.length];
-    private final List<ProfileViewerNavButton> profileViewerNavButtons = new ArrayList<>();
-    private OtherClientPlayerEntity entity;
-    private ProfileViewerTextWidget textWidget;
+	private int activePage = 0;
+	private static final String[] PAGE_NAMES = {"Skills", "Slayers", "Dungeons", "Inventories", "Collections"};
+	private final ProfileViewerPage[] profileViewerPages = new ProfileViewerPage[PAGE_NAMES.length];
+	private final List<ProfileViewerNavButton> profileViewerNavButtons = new ArrayList<>();
+	private OtherClientPlayerEntity entity;
+	private ProfileViewerTextWidget textWidget;
+	private final List<JsonObject> collectedProfiles = new ArrayList<>();
+	private int currentProfileIndex = 0;
+	private int nameBoxX, nameBoxY, nameBoxW, nameBoxH;
 
-    public ProfileViewerScreen(String username) {
-        super(TITLE);
-        fetchPlayerData(username).thenRun(this::initialisePagesAndWidgets);
+	public ProfileViewerScreen(String username) {
+		super(TITLE);
+		fetchPlayerData(username).thenRun(this::initialisePagesAndWidgets);
 
-        for (int i = 0; i < PAGE_NAMES.length; i++) {
-            profileViewerNavButtons.add(new ProfileViewerNavButton(this, PAGE_NAMES[i], i, i == 0));
-        }
-    }
+		for (int i = 0; i < PAGE_NAMES.length; i++) {
+			profileViewerNavButtons.add(new ProfileViewerNavButton(this, PAGE_NAMES[i], i, i == 0));
+		}
+	}
 
-    private void initialisePagesAndWidgets() {
-        if (profileNotFound) return;
+	private void initialisePagesAndWidgets() {
+		if (profileNotFound) return;
 
-        textWidget = new ProfileViewerTextWidget(hypixelProfile, playerProfile);
+		textWidget = new ProfileViewerTextWidget(collectedProfiles, currentProfileIndex, hypixelProfile, playerProfile);
 
-        CompletableFuture<Void> skillsFuture = CompletableFuture.runAsync(() -> profileViewerPages[0] = new SkillsPage(hypixelProfile, playerProfile));
-        CompletableFuture<Void> slayersFuture = CompletableFuture.runAsync(() -> profileViewerPages[1] = new SlayersPage(playerProfile));
-        CompletableFuture<Void> dungeonsFuture = CompletableFuture.runAsync(() -> profileViewerPages[2] = new DungeonsPage(playerProfile));
-        CompletableFuture<Void> inventoriesFuture = CompletableFuture.runAsync(() -> profileViewerPages[3] = new InventoryPage(playerProfile));
-        CompletableFuture<Void> collectionsFuture = CompletableFuture.runAsync(() -> profileViewerPages[4] = new CollectionsPage(hypixelProfile, playerProfile));
+		CompletableFuture<Void> skillsFuture = CompletableFuture.runAsync(() -> profileViewerPages[0] = new SkillsPage(hypixelProfile, playerProfile));
+		CompletableFuture<Void> slayersFuture = CompletableFuture.runAsync(() -> profileViewerPages[1] = new SlayersPage(playerProfile));
+		CompletableFuture<Void> dungeonsFuture = CompletableFuture.runAsync(() -> profileViewerPages[2] = new DungeonsPage(playerProfile));
+		CompletableFuture<Void> inventoriesFuture = CompletableFuture.runAsync(() -> profileViewerPages[3] = new InventoryPage(playerProfile));
+		CompletableFuture<Void> collectionsFuture = CompletableFuture.runAsync(() -> profileViewerPages[4] = new CollectionsPage(hypixelProfile, playerProfile));
 
-        CompletableFuture.allOf(skillsFuture, slayersFuture, dungeonsFuture, inventoriesFuture, collectionsFuture)
-                .thenRun(() -> {
-                    synchronized (this) {
-                        clearAndInit();
-                    }
-                });
-    }
+		CompletableFuture.allOf(skillsFuture, slayersFuture, dungeonsFuture, inventoriesFuture, collectionsFuture)
+				.thenRun(() -> {
+					synchronized (this) {
+						clearAndInit();
+					}
+				});
+	}
 
-    @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        synchronized (this) {
-            super.render(context, mouseX, mouseY, delta);
-        }
+	@Override
+	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+		synchronized (this) {
+			super.render(context, mouseX, mouseY, delta);
+		}
 
-        int rootX = width / 2 - GUI_WIDTH / 2;
-        int rootY = height / 2 - GUI_HEIGHT / 2 + 5;
+		int rootX = width / 2 - GUI_WIDTH / 2;
+		int rootY = height / 2 - GUI_HEIGHT / 2 + 5;
 
-        context.drawTexture(RenderLayer::getGuiTextured, TEXTURE, rootX, rootY, 0, 0, GUI_WIDTH, GUI_HEIGHT, GUI_WIDTH, GUI_HEIGHT);
-        for (ProfileViewerNavButton button : profileViewerNavButtons) {
-            button.setX(rootX + button.getIndex() * 28 + 4);
-            button.setY(rootY - 28);
-            button.render(context, mouseX, mouseY, delta);
-        }
+		context.drawTexture(RenderLayer::getGuiTextured, TEXTURE, rootX, rootY, 0, 0, GUI_WIDTH, GUI_HEIGHT, GUI_WIDTH, GUI_HEIGHT);
+		for (ProfileViewerNavButton button : profileViewerNavButtons) {
+			button.setX(rootX + button.getIndex() * 28 + 4);
+			button.setY(rootY - 28);
+			button.render(context, mouseX, mouseY, delta);
+		}
 
+		if (textWidget != null) textWidget.render(context, textRenderer, rootX + 8, rootY + 120, this, mouseX, mouseY);
+		drawPlayerEntity(context, playerName != null ? playerName : "Loading...", rootX, rootY, mouseX, mouseY);
 
-        if (textWidget != null) textWidget.render(context, textRenderer, rootX + 8, rootY + 120);
-        drawPlayerEntity(context, playerName != null ? playerName : "Loading...", rootX, rootY, mouseX, mouseY);
+		if (profileViewerPages[activePage] != null) {
+			profileViewerPages[activePage].markWidgetsAsVisible();
+			profileViewerPages[activePage].render(context, mouseX, mouseY, delta, rootX + 93, rootY + 7);
+		} else {
+			context.drawCenteredTextWithShadow(textRenderer, profileNotFound ? errorMessage : "Loading...", rootX + 200, rootY + 80, Color.WHITE.getRGB());
+		}
+	}
 
-        if (profileViewerPages[activePage] != null) {
-            profileViewerPages[activePage].markWidgetsAsVisible();
-            profileViewerPages[activePage].render(context, mouseX, mouseY, delta, rootX + 93, rootY + 7);
-        } else {
-            context.drawCenteredTextWithShadow(textRenderer, profileNotFound ? errorMessage : "Loading...", rootX + 200, rootY + 80, Color.WHITE.getRGB());
-        }
-    }
+	private void drawPlayerEntity(DrawContext context, String username, int rootX, int rootY, int mouseX, int mouseY) {
+		if (entity != null)
+			drawEntity(context, rootX + 9, rootY + 16, rootX + 89, rootY + 124, 42, 0.0625F, mouseX, mouseY, entity);
+		String base = username.length() > 15 ? username.substring(0, 15) : username;
+		int cx = rootX + 47;
+		int cy = rootY + 14;
+		int w = textRenderer.getWidth(base);
+		nameBoxX = cx - w / 2;
+		nameBoxY = cy;
+		nameBoxW = w;
+		nameBoxH = textRenderer.fontHeight;
+		boolean hover = mouseX >= nameBoxX && mouseX <= nameBoxX + nameBoxW
+				&& mouseY >= nameBoxY && mouseY <= nameBoxY + nameBoxH;
+		String display = hover
+				? Formatting.UNDERLINE + base + Formatting.RESET
+				: base;
+		context.drawCenteredTextWithShadow(textRenderer, display, cx, cy, 0xFFFFFF);
+	}
 
-    private void drawPlayerEntity(DrawContext context, String username, int rootX, int rootY, int mouseX, int mouseY) {
-        if (entity != null)
-            drawEntity(context, rootX + 9, rootY + 16, rootX + 89, rootY + 124, 42, 0.0625F, mouseX, mouseY, entity);
-        context.drawCenteredTextWithShadow(textRenderer, username.length() > 15 ? username.substring(0, 15) : username, rootX + 47, rootY + 14, Color.WHITE.getRGB());
-    }
+	private CompletableFuture<Void> fetchPlayerData(String username) {
+		CompletableFuture<Void> profileFuture = ProfileUtils.fetchFullProfile(username).thenAccept(profiles -> {
+			try {
+				profiles.getAsJsonArray("profiles").forEach(elem -> collectedProfiles.add(elem.getAsJsonObject()));
+				if (collectedProfiles.isEmpty()) throw new IllegalStateException();
+				currentProfileIndex = IntStream.range(0, collectedProfiles.size()).filter(i -> collectedProfiles.get(i).getAsJsonPrimitive("selected").getAsBoolean()).findFirst().orElse(0);
+				hypixelProfile = collectedProfiles.get(currentProfileIndex);
+				playerProfile = hypixelProfile.getAsJsonObject("members").get(ApiUtils.name2Uuid(username)).getAsJsonObject();
 
-    private CompletableFuture<Void> fetchPlayerData(String username) {
-        CompletableFuture<Void> profileFuture = ProfileUtils.fetchFullProfile(username).thenAccept(profiles -> {
-            try {
-                Optional<JsonObject> selectedProfile = profiles.getAsJsonArray("profiles").asList().stream()
-                        .map(JsonElement::getAsJsonObject)
-                        .filter(profile -> profile.getAsJsonPrimitive("selected").getAsBoolean())
-                        .findFirst();
-
-                if (selectedProfile.isPresent()) {
-                    this.hypixelProfile = selectedProfile.get();
-                    this.playerProfile = hypixelProfile.getAsJsonObject("members").get(ApiUtils.name2Uuid(username)).getAsJsonObject();
-                }
-            } catch (Exception e) {
+			} catch (Exception e) {
 				this.errorMessage = ApiAuthentication.getToken() == null ? "Invalid Skyblocker token" : "Skyblock profile not found";
-                this.profileNotFound = true;
-                LOGGER.warn("[Skyblocker Profile Viewer] Error while looking for profile", e);
-            }
-        });
+				this.profileNotFound = true;
+				LOGGER.warn("[Skyblocker Profile Viewer] Error while looking for profile", e);
+			}
+		});
 
-        CompletableFuture<Void> playerFuture = CompletableFuture.runAsync(() -> {
-    		String stringifiedUuid = ApiUtils.name2Uuid(username);
+		CompletableFuture<Void> playerFuture = CompletableFuture.runAsync(() -> {
+			String stringifiedUuid = ApiUtils.name2Uuid(username);
 
-    		if (stringifiedUuid.isEmpty()) {
+			if (stringifiedUuid.isEmpty()) {
 				// "Player not found" doesn't fit on the screen lol
-                this.playerName = "User not found";
+				this.playerName = "User not found";
 				this.errorMessage = "Player UUID not found";
-                this.profileNotFound = true;
-    		}
+				this.profileNotFound = true;
+			}
 
-    		UUID uuid = UndashedUuid.fromStringLenient(stringifiedUuid);
+			UUID uuid = UndashedUuid.fromStringLenient(stringifiedUuid);
 
-    		//The fetch by name method can sometimes fail in weird cases and return a fake offline player
-    		SkullBlockEntity.fetchProfileByUuid(uuid).thenAccept(profile -> {
-                this.playerName = profile.get().getName();
-                entity = new OtherClientPlayerEntity(MinecraftClient.getInstance().world, profile.get()) {
-                    @Override
-                    public SkinTextures getSkinTextures() {
-                        PlayerListEntry playerListEntry = new PlayerListEntry(profile.get(), false);
-                        return playerListEntry.getSkinTextures();
-                    }
+			//The fetch by name method can sometimes fail in weird cases and return a fake offline player
+			SkullBlockEntity.fetchProfileByUuid(uuid).thenAccept(profile -> {
+				this.playerName = profile.get().getName();
+				entity = new OtherClientPlayerEntity(MinecraftClient.getInstance().world, profile.get()) {
+					@Override
+					public SkinTextures getSkinTextures() {
+						PlayerListEntry playerListEntry = new PlayerListEntry(profile.get(), false);
+						return playerListEntry.getSkinTextures();
+					}
 
-                    @Override
-                    public boolean isPartVisible(PlayerModelPart modelPart) {
-                        return !(modelPart.getName().equals(PlayerModelPart.CAPE.getName()));
-                    }
+					@Override
+					public boolean isPartVisible(PlayerModelPart modelPart) {
+						return !(modelPart.getName().equals(PlayerModelPart.CAPE.getName()));
+					}
 
-                    @Override
-                    public boolean isInvisibleTo(PlayerEntity player) {
-                        return true;
-                    }
-                };
-                entity.setCustomNameVisible(false);
-    		}).exceptionally(ex -> {
+					@Override
+					public boolean isInvisibleTo(PlayerEntity player) {
+						return true;
+					}
+				};
+				entity.setCustomNameVisible(false);
+			}).exceptionally(ex -> {
 				// "Player not found" doesn't fit on the screen lol
-                this.playerName = "User not found";
+				this.playerName = "User not found";
 				this.errorMessage = "Player skin not found";
-                this.profileNotFound = true;
-                return null;
-            }).join();
-    	});
+				this.profileNotFound = true;
+				return null;
+			}).join();
+		});
 
-        return CompletableFuture.allOf(profileFuture, playerFuture);
-    }
+		return CompletableFuture.allOf(profileFuture, playerFuture);
+	}
 
-    public void onNavButtonClick(ProfileViewerNavButton clickedButton) {
-        if (profileViewerPages[activePage] != null) profileViewerPages[activePage].markWidgetsAsInvisible();
-        for (ProfileViewerNavButton button : profileViewerNavButtons) {
-            button.setToggled(false);
-        }
-        activePage = clickedButton.getIndex();
-        clickedButton.setToggled(true);
-    }
+	public void onNavButtonClick(ProfileViewerNavButton clickedButton) {
+		if (profileViewerPages[activePage] != null) profileViewerPages[activePage].markWidgetsAsInvisible();
+		for (ProfileViewerNavButton button : profileViewerNavButtons) {
+			button.setToggled(false);
+		}
+		activePage = clickedButton.getIndex();
+		clickedButton.setToggled(true);
+	}
 
-    @Override
-    public void init() {
-        profileViewerNavButtons.forEach(this::addDrawableChild);
-        for (ProfileViewerPage profileViewerPage : profileViewerPages) {
-            if (profileViewerPage != null && profileViewerPage.getButtons() != null) {
-                for (ClickableWidget button : profileViewerPage.getButtons()) {
-                    if (button != null) addDrawableChild(button);
-                }
-            }
-        }
-    }
+	@Override
+	public void init() {
+		profileViewerNavButtons.forEach(this::addDrawableChild);
+		for (ProfileViewerPage profileViewerPage : profileViewerPages) {
+			if (profileViewerPage != null && profileViewerPage.getButtons() != null) {
+				for (ClickableWidget button : profileViewerPage.getButtons()) {
+					if (button != null) addDrawableChild(button);
+				}
+			}
+		}
+	}
 
-    @Init
-    public static void initClass() {
-        fetchCollectionsData(); // caching on launch
+	@Init
+	public static void initClass() {
+		fetchCollectionsData(); // caching on launch
 
-        ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {
-            LiteralArgumentBuilder<FabricClientCommandSource> literalArgumentBuilder = ClientCommandManager.literal("pv")
-                    .then(ClientCommandManager.argument("username", StringArgumentType.string())
-                            .suggests((source, builder) -> CommandSource.suggestMatching(getPlayerSuggestions(source.getSource()), builder))
-                            .executes(Scheduler.queueOpenScreenFactoryCommand(context -> new ProfileViewerScreen(StringArgumentType.getString(context, "username"))))
-                    )
-                    .executes(Scheduler.queueOpenScreenCommand(() -> new ProfileViewerScreen(MinecraftClient.getInstance().getSession().getUsername())));
-            dispatcher.register(literalArgumentBuilder);
-            dispatcher.register(ClientCommandManager.literal(SkyblockerMod.NAMESPACE).then(literalArgumentBuilder));
-        });
-    }
+		ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {
+			LiteralArgumentBuilder<FabricClientCommandSource> literalArgumentBuilder = ClientCommandManager.literal("pv")
+					.then(ClientCommandManager.argument("username", StringArgumentType.string())
+							.suggests((source, builder) -> CommandSource.suggestMatching(getPlayerSuggestions(source.getSource()), builder))
+							.executes(Scheduler.queueOpenScreenFactoryCommand(context -> new ProfileViewerScreen(StringArgumentType.getString(context, "username"))))
+					)
+					.executes(Scheduler.queueOpenScreenCommand(() -> new ProfileViewerScreen(MinecraftClient.getInstance().getSession().getUsername())));
+			dispatcher.register(literalArgumentBuilder);
+			dispatcher.register(ClientCommandManager.literal(SkyblockerMod.NAMESPACE).then(literalArgumentBuilder));
+		});
+		ScreenEvents.AFTER_INIT.register((client, screen, sw, sh) -> {
+			if (screen instanceof GenericContainerScreen gcs && screen.getTitle().getString().endsWith("'s Profile")) {
+				String title = screen.getTitle().getString();
+				String suffix = "'s Profile";
+				final String name = title.substring(0, title.length() - suffix.length()).trim();
 
-    private static void fetchCollectionsData() {
-        CompletableFuture.runAsync(() -> {
-            try {
-                JsonObject jsonObject = JsonParser.parseString(Http.sendGetRequest(HYPIXEL_COLLECTIONS)).getAsJsonObject();
-                if (jsonObject.get("success").getAsBoolean()) {
-                    Map<String, String[]> collectionsMap = new HashMap<>();
-                    Map<String, IntList> tierRequirementsMap = new HashMap<>();
-                    JsonObject collections = jsonObject.getAsJsonObject("collections");
-                    collections.entrySet().forEach(entry -> {
-                        String category = entry.getKey();
-                        JsonObject itemsObject = entry.getValue().getAsJsonObject().getAsJsonObject("items");
-                        String[] items = itemsObject.keySet().toArray(new String[0]);
-                        collectionsMap.put(category, items);
-                        itemsObject.entrySet().forEach(itemEntry -> {
-                            IntImmutableList tierReqs = IntImmutableList.toList(itemEntry.getValue().getAsJsonObject().getAsJsonArray("tiers").asList().stream()
-                                    .mapToInt(tier -> tier.getAsJsonObject().get("amountRequired").getAsInt())
-                            );
-                            tierRequirementsMap.put(itemEntry.getKey(), tierReqs);
-                        });
-                    });
-                    COLLECTIONS = collectionsMap;
-                    TIER_REQUIREMENTS = tierRequirementsMap;
-                }
-            } catch (Exception e) {
-                LOGGER.error("[Skyblocker Profile Viewer] Failed to fetch collections data", e);
-            }
-        });
-    }
+				ButtonWidget btn = ButtonWidget.builder(
+								Text.literal("\uD83D\uDD0D"),
+								b -> {
+									MinecraftClient mc = MinecraftClient.getInstance();
+									if (mc.player != null) {
+										mc.player.networkHandler.sendChatCommand("pv " + name);
+									}
+								}).dimensions(
+								((HandledScreenAccessor) gcs).getX() + ((HandledScreenAccessor) gcs).getBackgroundWidth() - 16,
+								((HandledScreenAccessor) gcs).getY() + 4,
+								12, 12)
+						.tooltip(Tooltip.of(Text.translatable("skyblocker.profileviewer.title", name)))
+						.build();
 
-    public static Map<String, String[]> getCollections() {
-        return COLLECTIONS;
-    }
+				Screens.getButtons(screen).add(btn);
+			}
+		});
+	}
 
-    public static Map<String, IntList> getTierRequirements() {
-        return TIER_REQUIREMENTS;
-    }
+	private static void fetchCollectionsData() {
+		CompletableFuture.runAsync(() -> {
+			try {
+				JsonObject jsonObject = JsonParser.parseString(Http.sendGetRequest(HYPIXEL_COLLECTIONS)).getAsJsonObject();
+				if (jsonObject.get("success").getAsBoolean()) {
+					Map<String, String[]> collectionsMap = new HashMap<>();
+					Map<String, IntList> tierRequirementsMap = new HashMap<>();
+					JsonObject collections = jsonObject.getAsJsonObject("collections");
+					collections.entrySet().forEach(entry -> {
+						String category = entry.getKey();
+						JsonObject itemsObject = entry.getValue().getAsJsonObject().getAsJsonObject("items");
+						String[] items = itemsObject.keySet().toArray(new String[0]);
+						collectionsMap.put(category, items);
+						itemsObject.entrySet().forEach(itemEntry -> {
+							IntImmutableList tierReqs = IntImmutableList.toList(itemEntry.getValue().getAsJsonObject().getAsJsonArray("tiers").asList().stream()
+									.mapToInt(tier -> tier.getAsJsonObject().get("amountRequired").getAsInt())
+							);
+							tierRequirementsMap.put(itemEntry.getKey(), tierReqs);
+						});
+					});
+					COLLECTIONS = collectionsMap;
+					TIER_REQUIREMENTS = tierRequirementsMap;
+				}
+			} catch (Exception e) {
+				LOGGER.error("[Skyblocker Profile Viewer] Failed to fetch collections data", e);
+			}
+		});
+	}
 
-    /**
-     * Ensures that "dummy" players aren't included in command suggestions
-     */
-    private static String[] getPlayerSuggestions(FabricClientCommandSource source) {
-        return source.getPlayerNames().stream().filter(playerName -> playerName.matches("[A-Za-z0-9_]+")).toArray(String[]::new);
-    }
+	public static Map<String, String[]> getCollections() {
+		return COLLECTIONS;
+	}
+
+	public static Map<String, IntList> getTierRequirements() {
+		return TIER_REQUIREMENTS;
+	}
+
+	public void selectProfile(int newIndex) {
+		currentProfileIndex = newIndex;
+		hypixelProfile = collectedProfiles.get(currentProfileIndex);
+		playerProfile = hypixelProfile.getAsJsonObject("members").get(ApiUtils.name2Uuid(playerName)).getAsJsonObject();
+		initialisePagesAndWidgets();
+	}
+
+	@Override
+	public boolean mouseClicked(double mx, double my, int btn) {
+		if (textWidget != null && textWidget.mouseClicked(mx, my, btn, this)) return true;
+		if (btn == 0) {
+			if (mx >= nameBoxX && mx <= nameBoxX + nameBoxW && my >= nameBoxY && my <= nameBoxY + nameBoxH) {
+				MinecraftClient mc = MinecraftClient.getInstance();
+				mc.setScreen(new ChatScreen("/pv "));
+				return true;
+			}
+		}
+		return super.mouseClicked(mx, my, btn);
+	}
+
+	/**
+	 * Ensures that "dummy" players aren't included in command suggestions
+	 */
+	private static String[] getPlayerSuggestions(FabricClientCommandSource source) {
+		return source.getPlayerNames().stream().filter(playerName -> playerName.matches("[A-Za-z0-9_]+")).toArray(String[]::new);
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerTextWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerTextWidget.java
@@ -6,39 +6,154 @@ import de.hysky.skyblocker.skyblock.tabhud.util.Ico;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.util.Colors;
+import net.minecraft.util.Formatting;
+
+import java.util.List;
 
 public class ProfileViewerTextWidget {
-    private static final int ROW_GAP = 9;
+	private static final int ROW_GAP = 9;
 
-    private String PROFILE_NAME = "UNKNOWN";
-    private int SKYBLOCK_LEVEL = 0;
-    private double PURSE = 0;
-    private double BANK = 0;
+	private String PROFILE_NAME = "UNKNOWN";
+	private int SKYBLOCK_LEVEL = 0;
+	private double PURSE = 0;
+	private double BANK = 0;
+	private List<String> cuteNames;
+	private boolean dropOpen = false;
+	private int boxX, boxY, boxW, boxH;
+	private List<JsonObject> profiles;
+	private List<ItemStack> modeIcons;
 
-    public ProfileViewerTextWidget(JsonObject hypixelProfile, JsonObject playerProfile){
-        try {
-            this.PROFILE_NAME = hypixelProfile.get("cute_name").getAsString();
-            this.SKYBLOCK_LEVEL = playerProfile.getAsJsonObject("leveling").get("experience").getAsInt() / 100;
-            this.PURSE = playerProfile.getAsJsonObject("currencies").get("coin_purse").getAsDouble();
-            this.BANK = hypixelProfile.getAsJsonObject("banking").get("balance").getAsDouble();
-        } catch (Exception ignored) {}
-    }
+	public ProfileViewerTextWidget(List<JsonObject> allProfiles, int currentIndex, JsonObject hypixelProfile, JsonObject playerProfile) {
+		try {
+			this.profiles = allProfiles;
+			this.cuteNames = allProfiles.stream().map(p -> p.get("cute_name").getAsString()).toList();
+			this.modeIcons = allProfiles.stream().map(p -> {
+				String gm = p.has("game_mode") ? p.get("game_mode").getAsString() : "";
+				return switch (gm) {
+					case "bingo" -> new ItemStack(Items.FILLED_MAP);
+					case "island" -> new ItemStack(Items.GRASS_BLOCK);
+					case "ironman" -> new ItemStack(Items.IRON_INGOT);
+					default -> ItemStack.EMPTY;
+				};
+			}).toList();
+			this.PROFILE_NAME = cuteNames.get(currentIndex);
+			this.SKYBLOCK_LEVEL = playerProfile.getAsJsonObject("leveling").get("experience").getAsInt() / 100;
+			this.PURSE = playerProfile.getAsJsonObject("currencies").get("coin_purse").getAsDouble();
+			this.BANK = hypixelProfile.getAsJsonObject("banking").get("balance").getAsDouble();
+		} catch (Exception ignored) {}
+	}
 
-    public void render(DrawContext context, TextRenderer textRenderer, int root_x, int root_y){
-        // Profile Icon
-        MatrixStack matrices = context.getMatrices();
-        matrices.push();
-        matrices.scale(0.75f, 0.75f, 1);
-        int rootAdjustedX = (int) ((root_x) / 0.75f);
-        int rootAdjustedY = (int) ((root_y) / 0.75f);
-        context.drawItem(Ico.PAINTING, rootAdjustedX, rootAdjustedY);
-        matrices.pop();
+	public void render(DrawContext context, TextRenderer textRenderer, int root_x, int root_y, ProfileViewerScreen screen, int mouseX, int mouseY) {
+		// Profile Icon
+		MatrixStack matrices = context.getMatrices();
+		matrices.push();
+		matrices.scale(0.75f, 0.75f, 1);
+		int rootAdjustedX = (int) ((root_x) / 0.75f);
+		int rootAdjustedY = (int) ((root_y) / 0.75f);
+		context.drawItem(Ico.PAINTING, rootAdjustedX, rootAdjustedY);
+		matrices.pop();
 
-        context.drawText(textRenderer, "§n"+PROFILE_NAME, root_x + 14, root_y + 3, Colors.WHITE, true);
-        context.drawText(textRenderer, "§aLevel:§r " + SKYBLOCK_LEVEL, root_x + 2, root_y + 6 + ROW_GAP, Colors.WHITE, true);
-        context.drawText(textRenderer, "§6Purse:§r " + ProfileViewerUtils.numLetterFormat(PURSE), root_x + 2, root_y + 6 + ROW_GAP * 2, Colors.WHITE, true);
-        context.drawText(textRenderer, "§6Bank:§r " + ProfileViewerUtils.numLetterFormat(BANK), root_x + 2, root_y + 6 + ROW_GAP * 3, Colors.WHITE, true);
-        context.drawText(textRenderer, "§6NW:§r " + "Soon™", root_x + 2, root_y + 6 + ROW_GAP * 4, Colors.WHITE, true );
-    }
+		int widest = 0;
+		for (int i = 0; i < cuteNames.size(); i++) {
+			boolean sel = profiles.get(i).getAsJsonPrimitive("selected").getAsBoolean();
+			ItemStack ico = modeIcons.get(i);
+
+			int txtW = textRenderer.getWidth((sel ? "★ " : "") + cuteNames.get(i));
+			int fullW = txtW + (ico.isEmpty() ? 0 : 14);
+			widest = Math.max(widest, fullW);
+		}
+		int dropWidth = widest + 2;
+
+		boxX = root_x + 14;
+		boxY = root_y + 2;
+		boxW = textRenderer.getWidth(PROFILE_NAME) + 4;
+		boxH = textRenderer.fontHeight + 2;
+
+		boolean hoverName = mouseX >= boxX && mouseX <= boxX + boxW && mouseY >= boxY && mouseY <= boxY + boxH;
+		String color = dropOpen ? Formatting.YELLOW.toString() : Formatting.WHITE.toString();
+		String display = color + (hoverName ? Formatting.UNDERLINE.toString() : "") + PROFILE_NAME + Formatting.RESET;
+
+		context.fill(boxX - 1, boxY - 1, boxX + boxW + 1, boxY + boxH + 1, 0x55000000);
+		context.drawText(textRenderer, display, boxX + 2, boxY + 1, Colors.WHITE, true);
+
+		if (dropOpen && cuteNames.size() > 1) {
+			MatrixStack stack = context.getMatrices();
+			stack.push();
+			stack.translate(0, 0, 300);
+
+			int x0 = boxX;
+			int y0 = boxY + boxH + 2;
+			int totalH = cuteNames.size() * (boxH + 2) - 2;
+
+			context.fill(x0 - 1, y0 - 1, x0 + dropWidth + 1, y0 + totalH + 1, 0xAA080808);
+			context.fill(x0 - 1, y0 - 1, x0 + dropWidth + 1, y0, 0xFFFFFFFF);
+			context.fill(x0 - 1, y0 + totalH, x0 + dropWidth + 1, y0 + totalH + 1, 0xFFFFFFFF);
+			context.fill(x0 - 1, y0 - 1, x0, y0 + totalH + 1, 0xFFFFFFFF);
+			context.fill(x0 + dropWidth, y0 - 1, x0 + dropWidth + 1, y0 + totalH + 1, 0xFFFFFFFF);
+
+			int y = y0;
+			int i = 0;
+			for (String name : cuteNames) {
+				boolean sel = profiles.get(i).getAsJsonPrimitive("selected").getAsBoolean();
+				ItemStack ico = modeIcons.get(i);
+				String label = (sel ? "★ " : "") + cuteNames.get(i);
+
+				boolean hover = mouseX >= x0 && mouseX <= x0 + dropWidth && mouseY >= y && mouseY <= y + boxH;
+				if (hover) context.fill(x0, y, x0 + dropWidth, y + boxH, 0x33FFFFFF);
+
+				int col = sel ? Colors.YELLOW : Colors.WHITE;
+
+				int textX = x0 + 4;
+				if (!ico.isEmpty()) {
+					float scale = textRenderer.fontHeight / 16.0f;
+
+					MatrixStack m = context.getMatrices();
+					m.push();
+					m.translate(x0 + 3, y + 1, 300);
+					m.scale(scale, scale, 1.0f);
+					context.drawItem(ico, 0, 0);
+					m.pop();
+					textX += (int) (14 * scale) + 4;
+				}
+
+				context.drawText(textRenderer, label, textX, y + 1, col, false);
+				y += boxH + 2;
+				i++;
+			}
+			stack.pop();
+		}
+		int baseY = root_y + 6;
+		context.drawText(textRenderer, "§aLevel:§r " + SKYBLOCK_LEVEL, root_x + 2, baseY + ROW_GAP, Colors.WHITE, true);
+		context.drawText(textRenderer, "§6Purse:§r " + ProfileViewerUtils.numLetterFormat(PURSE), root_x + 2, baseY + ROW_GAP * 2, Colors.WHITE, true);
+		context.drawText(textRenderer, "§6Bank:§r " + ProfileViewerUtils.numLetterFormat(BANK), root_x + 2, baseY + ROW_GAP * 3, Colors.WHITE, true);
+		context.drawText(textRenderer, "§6NW:§r " + "Soon™", root_x + 2, baseY + ROW_GAP * 4, Colors.WHITE, true);
+	}
+
+	public boolean mouseClicked(double mx, double my, int btn, ProfileViewerScreen screen) {
+		if (btn != 0) return false;
+
+		if (mx >= boxX && mx <= boxX + boxW && my >= boxY && my <= boxY + boxH) {
+			dropOpen = !dropOpen;
+			return true;
+		}
+
+		if (!dropOpen) return false;
+
+		int y = boxY + boxH + 2;
+		for (int i = 0; i < cuteNames.size(); i++, y += boxH + 2) {
+			if (mx >= boxX && mx <= boxX + boxW && my >= y && my <= y + boxH) {
+				if (!cuteNames.get(i).equals(PROFILE_NAME)) {
+					screen.selectProfile(i);
+				}
+				dropOpen = false;
+				return true;
+			}
+		}
+
+		dropOpen = false;
+		return false;
+	}
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1380,6 +1380,7 @@
   "skyblocker.profileviewer.inventory.inactive": "Locked Slot",
   "skyblocker.profileviewer.inventory.inactive.description.backpack": "The selected backpack",
   "skyblocker.profileviewer.inventory.inactive.description.general": "does not contain this slot",
+  "skyblocker.profileviewer.title": "View Profile of: %s",
 
   "skyblocker.chat.confirmationPromptNotification": "Click anywhere on screen within 60 seconds to accept the prompt.",
 


### PR DESCRIPTION

- Added the ability to switch **profile** and **user** directly from the viewer
- Added game mode icons:
  - **Bingo** → Filled Map
  - **Island** → Grass Block
  - **Ironman** → Iron Block
  - **Normal** → No icon
- Main profile (currently used profile) is now marked with a ⭐ star icon
- Added a button (top-right corner) to open the skyblocker Profile Viewer from the SkyBlock Profile Viewer

![Bildschirmfoto vom 2025-05-12 00-08-35](https://github.com/user-attachments/assets/e3b33caf-9ee2-49e7-8978-8e48017ac8fe)

![Bildschirmfoto vom 2025-05-12 00-08-12](https://github.com/user-attachments/assets/c0cd5f94-ea81-4893-a180-0c84436195a0)

![Bildschirmfoto vom 2025-05-12 00-14-13](https://github.com/user-attachments/assets/bd620bb9-ea50-45f1-a366-c2e32286c537)