### PR TITLE
fix wishing compass solver distance

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CrystalsChestHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CrystalsChestHighlighter.java
@@ -127,7 +127,7 @@ public class CrystalsChestHighlighter {
 				activeParticles.clear();
 			}
 			//lock pick fail sound
-		} else if (sound.id().equals(SoundEvents.BLOCK_CHEST_LOCKED.id())) {
+		} else if (sound.id().equals(SoundEvents.ENTITY_VILLAGER_NO.id())) {
 			currentLockCount = 0;
 			activeParticles.clear();
 			//lock pick finish sound

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
@@ -53,9 +53,9 @@ public class WishingCompassSolver {
      */
     private static final double PARTICLES_MAX_DISTANCE = 0.9;
     /**
-     * the distance squared the player has to be from where they used the first compass to where they use the second
+     * the distance the player has to be from where they used the first compass to where they use the second
      */
-    private static final long DISTANCE_BETWEEN_USES = 64;
+    private static final long DISTANCE_BETWEEN_USES = 8;
 	/**
 	 * Arbitrary distance below which skyblocker will consider two compass trails to be intersecting
 	 */


### PR DESCRIPTION
fix bugs introduced in #1040. 
 - fix sound crystals chest highlighters  `lock pick fail sound` being the wrong sound
 - fix wishing compass solver `DISTANCE_BETWEEN_USES` being squared twice