### PR TITLE
Remove hover text on chat waypoint suggestion message

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/barn/TreasureHunter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/barn/TreasureHunter.java
@@ -6,11 +6,9 @@ import de.hysky.skyblocker.utils.chat.ChatFilterResult;
 import de.hysky.skyblocker.utils.chat.ChatPatternListener;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.ClickEvent;
-import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +41,6 @@ public class TreasureHunter extends ChatPatternListener {
 		String command = "/skyblocker waypoints individual " + location + " Treasure";
 		MutableText requestMessage = Constants.PREFIX.get().append(Text.translatable("skyblocker.config.chat.waypoints.display", java.util.Arrays.stream(location.split(" ")).mapToInt(Integer::parseInt).boxed().toArray()).formatted(Formatting.AQUA)
 				.styled(style -> style
-						.withHoverEvent(new HoverEvent.ShowText(Text.translatable("skyblocker.config.chat.waypoints.display")))
 						.withClickEvent(new ClickEvent.RunCommand(command.trim()))
 				)
 		);

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
@@ -12,7 +12,6 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.ClickEvent;
-import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -79,7 +78,6 @@ public class ChatPositionShare {
         String command = "/skyblocker waypoints individual " + x + " " + y + " " + z + " " + area;
         MutableText requestMessage = Constants.PREFIX.get().append(Text.translatable("skyblocker.config.chat.waypoints.display", x, y, z).formatted(Formatting.AQUA)
                 .styled(style -> style
-						.withHoverEvent(new HoverEvent.ShowText(Text.translatable("skyblocker.config.chat.waypoints.display")))
 						.withClickEvent(new ClickEvent.RunCommand(command.trim()))
 				)
         );

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -527,7 +527,7 @@
   "skyblocker.config.chat.chatRules.screen.ruleScreen.sounds.pling": "Pling",
   "skyblocker.config.chat.chatRules.screen.ruleScreen.sounds.zombie": "Zombie",
   "skyblocker.config.chat.chatRules.screen.ruleScreen.true": "True",
-  "skyblocker.config.chat.waypoints.display": "[Click to Display Waypoint at x: %d y: %d z: %d]",
+  "skyblocker.config.chat.waypoints.display": "Click to display waypoint at x: %d y: %d z: %d",
   "skyblocker.config.chat.waypoints.displayed": "Displayed temporary waypoint at x: %d y: %d z: %d %s",
 
   "skyblocker.config.chat.confirmationPromptHelper": "Chat Confirmation Prompt Helper",


### PR DESCRIPTION
Hello, I was looking to fix the placeholders in the chat waypoint suggestion message not being filled. However, I believe it would look nicer to entirely remove the hover text and to remove the brackets in the translation string.

Before with /skyblocker sharePosition:
![image](https://github.com/user-attachments/assets/e2c30971-3f6b-4dbc-baf9-2bbc4a8937c8)

After (this PR):
![image](https://github.com/user-attachments/assets/4df28220-1a13-4e93-9b2c-c07ef0b66185)
