### PR TITLE
Fix customize button not moving when recipe book is toggled + refactor

### DIFF
--- a/src/main/java/de/hysky/skyblocker/injected/RecipeBookHolder.java
+++ b/src/main/java/de/hysky/skyblocker/injected/RecipeBookHolder.java
@@ -1,0 +1,12 @@
+package de.hysky.skyblocker.injected;
+
+public interface RecipeBookHolder {
+
+	/**
+	 * Register a callback that gets called when the recipe book button is toggled.
+	 * The callback list is emptied after each init, so this needs to be registered everytime in {@link net.fabricmc.fabric.api.client.screen.v1.ScreenEvents.AfterInit}
+	 * @implNote {@code BEFORE_INIT} may be called before the callback list is emptied.
+	 * @param callback the callback
+	 */
+	void registerRecipeBookToggleCallback(Runnable callback);
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
@@ -7,18 +7,23 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.events.SkyblockEvents;
+import de.hysky.skyblocker.injected.RecipeBookHolder;
+import de.hysky.skyblocker.mixins.accessors.HandledScreenAccessor;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListManager;
+import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.gui.ItemButtonWidget;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
 import it.unimi.dsi.fastutil.ints.*;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
+import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.widget.ContainerWidget;
 import net.minecraft.client.render.RenderLayer;
@@ -102,6 +107,16 @@ public class GardenPlotsWidget extends ContainerWidget {
 					}
 
 				});
+			} else if (screen instanceof InventoryScreen inventoryScreen && Utils.getLocation().equals(Location.GARDEN) && SkyblockerConfigManager.get().farming.garden.gardenPlotsWidget) {
+				GardenPlotsWidget widget = new GardenPlotsWidget(
+						((HandledScreenAccessor) inventoryScreen).getX() + ((HandledScreenAccessor) inventoryScreen).getBackgroundWidth() + 4,
+						((HandledScreenAccessor) inventoryScreen).getY());
+				Screens.getButtons(inventoryScreen).add(widget);
+
+				((RecipeBookHolder) inventoryScreen).registerRecipeBookToggleCallback(() -> widget.setPosition(
+						((HandledScreenAccessor) inventoryScreen).getX() + ((HandledScreenAccessor) inventoryScreen).getBackgroundWidth() + 4,
+						((HandledScreenAccessor) inventoryScreen).getY()
+				));
 			}
 		});
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/CustomizeArmorScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/CustomizeArmorScreen.java
@@ -5,6 +5,7 @@ import com.mojang.logging.LogUtils;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.injected.RecipeBookHolder;
 import de.hysky.skyblocker.mixins.accessors.HandledScreenAccessor;
 import de.hysky.skyblocker.skyblock.item.custom.CustomArmorAnimatedDyes;
 import de.hysky.skyblocker.skyblock.item.custom.CustomArmorTrims;
@@ -71,7 +72,12 @@ public class CustomizeArmorScreen extends Screen {
 		));
 		ScreenEvents.AFTER_INIT.register((client1, screen, scaledWidth, scaledHeight) -> {
 			if (Utils.isOnSkyblock() && screen instanceof InventoryScreen inventoryScreen) {
-				Screens.getButtons(inventoryScreen).add(new CustomizeButton(
+				CustomizeButton button = new CustomizeButton(
+						((HandledScreenAccessor) inventoryScreen).getX() + 63,
+						((HandledScreenAccessor) inventoryScreen).getY() + 10
+				);
+				Screens.getButtons(inventoryScreen).add(button);
+				((RecipeBookHolder) inventoryScreen).registerRecipeBookToggleCallback(() -> button.setPosition(
 						((HandledScreenAccessor) inventoryScreen).getX() + 63,
 						((HandledScreenAccessor) inventoryScreen).getY() + 10
 				));


### PR DESCRIPTION
Fixes a bug where the little brush icon doesn't move when recipe book is toggled.

This also adds a basic callback system for recipe book toggles since 2 things depended on it.

This has been tested