### PR TITLE
Add waypoints to forest nodes

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/ForagingCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/ForagingCategory.java
@@ -1,7 +1,10 @@
 package de.hysky.skyblocker.config.categories;
 
+import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import dev.isxander.yacl3.api.ConfigCategory;
+import dev.isxander.yacl3.api.Option;
+import dev.isxander.yacl3.api.OptionGroup;
 import net.minecraft.text.Text;
 
 public class ForagingCategory {
@@ -9,8 +12,20 @@ public class ForagingCategory {
 	public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
 		return ConfigCategory.createBuilder()
 				.name(Text.translatable("skyblocker.config.foraging"))
-
 				//Modern Foraging island
+
+				//Galatea
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.foraging.galatea"))
+						.collapsed(false)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.foraging.galatea.enableForestNodeHelper"))
+								.binding(defaults.foraging.galatea.enableForestNodeHelper,
+										() -> config.foraging.galatea.enableForestNodeHelper,
+										newValue -> config.foraging.galatea.enableForestNodeHelper = newValue)
+								.controller(ConfigUtils::createBooleanController)
+								.build())
+						.build())
 
 				//Hunting - YACL doesn't like empty option groups
 				/*.group(OptionGroup.createBuilder()

--- a/src/main/java/de/hysky/skyblocker/config/configs/ForagingConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/ForagingConfig.java
@@ -5,7 +5,15 @@ import dev.isxander.yacl3.config.v2.api.SerialEntry;
 public class ForagingConfig {
 
 	@SerialEntry
+	public Galatea galatea = new Galatea();
+
+	@SerialEntry
 	public Hunting hunting = new Hunting();
+
+	public static class Galatea {
+		@SerialEntry
+		public boolean enableForestNodeHelper = true;
+	}
 
 	public static class Hunting {
 		

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
@@ -24,6 +24,7 @@ import de.hysky.skyblocker.skyblock.end.TheEnd;
 import de.hysky.skyblocker.skyblock.fishing.FishingHelper;
 import de.hysky.skyblocker.skyblock.fishing.FishingHookDisplayHelper;
 import de.hysky.skyblocker.skyblock.fishing.SeaCreatureTracker;
+import de.hysky.skyblocker.skyblock.galatea.ForestNodes;
 import de.hysky.skyblocker.skyblock.slayers.SlayerManager;
 import de.hysky.skyblocker.skyblock.slayers.boss.demonlord.FirePillarAnnouncer;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListManager;
@@ -186,6 +187,7 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 		DojoManager.onParticle(packet);
 		CrystalsChestHighlighter.onParticle(packet);
 		EnderNodes.onParticle(packet);
+		ForestNodes.onParticle(packet);
 		WishingCompassSolver.onParticle(packet);
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
@@ -117,7 +117,12 @@ public class ForestNodes {
 	public static class ForestNode extends Waypoint {
 
 		private ForestNode(BlockPos pos) {
-			super(pos, () -> SkyblockerConfigManager.get().uiAndVisuals.waypoints.waypointType, ColorUtils.getFloatComponents(DyeColor.LIME));
+			super(pos,
+					() -> Type.HIGHLIGHT,
+					ColorUtils.getFloatComponents(DyeColor.ORANGE),
+					DEFAULT_HIGHLIGHT_ALPHA,
+					DEFAULT_LINE_WIDTH,
+					false);
 		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
@@ -1,0 +1,117 @@
+package de.hysky.skyblocker.skyblock.galatea;
+
+import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.ColorUtils;
+import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.waypoint.Waypoint;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.decoration.DisplayEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.network.packet.s2c.play.ParticleS2CPacket;
+import net.minecraft.particle.ParticleType;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.DyeColor;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ForestNodes {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ForestNodes.class);
+	private static final MinecraftClient client = MinecraftClient.getInstance();
+	private static final Map<BlockPos, ForestNode> forestNodes = new HashMap<>();
+
+	@Init
+	public static void init() {
+		WorldRenderEvents.AFTER_TRANSLUCENT.register(ForestNodes::render);
+		AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+			forestNodes.remove(pos);
+			return ActionResult.PASS;
+		});
+		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> reset());
+	}
+
+	public static void onParticle(ParticleS2CPacket packet) {
+		if (!shouldProcess()) {
+			return;
+		}
+
+		ParticleType<?> particleType = packet.getParameters().getType();
+		if (!ParticleTypes.HAPPY_VILLAGER.getType().equals(particleType)) {
+			return;
+		}
+
+		double x = packet.getX();
+		double y = packet.getY() - 1;
+		double z = packet.getZ();
+		BlockPos pos = BlockPos.ofFloored(x, y, z);
+
+		// Check for three ItemDisplayEntity with minecraft:string in the same block
+		if (client.world != null) {
+			int stringItemCount = countStringItemDisplays(pos);
+			if (stringItemCount == 3) {
+				forestNodes.computeIfAbsent(pos, ForestNode::new);
+			}
+		}
+	}
+
+	private static int countStringItemDisplays(BlockPos pos) {
+		ClientWorld world = client.world;
+		if (world == null) {
+			return 0;
+		}
+
+		// Get all ItemDisplayEntity within the same block
+		List<DisplayEntity.ItemDisplayEntity> entities = world.getEntitiesByClass(
+				DisplayEntity.ItemDisplayEntity.class,
+				new Box(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1),
+				entity -> true
+		);
+
+		// Count those with minecraft:string
+		return (int) entities.stream()
+				.filter(entity -> {
+					ItemStack stack = entity.getItemStack();
+					return !stack.isEmpty() && stack.getItem().equals(Items.STRING);
+				})
+				.count();
+	}
+
+	private static void render(WorldRenderContext context) {
+		if (!shouldProcess()) {
+			return;
+		}
+		for (ForestNode forestNode : forestNodes.values()) {
+			if (forestNode.shouldRender()) {
+				forestNode.render(context);
+			}
+		}
+	}
+
+	private static boolean shouldProcess() {
+		return SkyblockerConfigManager.get().foraging.galatea.enableForestNodeHelper && Utils.isInGalatea();
+	}
+
+	private static void reset() {
+		forestNodes.clear();
+	}
+
+	public static class ForestNode extends Waypoint {
+
+		private ForestNode(BlockPos pos) {
+			super(pos, () -> SkyblockerConfigManager.get().uiAndVisuals.waypoints.waypointType, ColorUtils.getFloatComponents(DyeColor.LIME));
+		}
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
@@ -9,6 +9,7 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.decoration.DisplayEntity;
@@ -37,6 +38,11 @@ public class ForestNodes {
 	public static void init() {
 		WorldRenderEvents.AFTER_TRANSLUCENT.register(ForestNodes::render);
 		AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+			forestNodes.remove(pos);
+			return ActionResult.PASS;
+		});
+		UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
+			BlockPos pos = hitResult.getBlockPos();
 			forestNodes.remove(pos);
 			return ActionResult.PASS;
 		});

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -258,6 +258,9 @@
   "skyblocker.config.farming.visitorHelper.showStacksInVisitorHelper.@Tooltip": "Show's the required items as (5 stacks + 45) rather than just a total number especially useful for ironman players.",
 
   "skyblocker.config.foraging": "Foraging",
+  "skyblocker.config.foraging.galatea": "Galatea",
+  "skyblocker.config.foraging.galatea.enableForestNodeHelper": "Enable Forest Node Helper",
+
   "skyblocker.config.foraging.hunting": "Hunting",
 
   "skyblocker.config.general": "General",


### PR DESCRIPTION
On the new foraging island there are certain spots you can dig at to receive various items. These spots are denoted by the presence of the happy_villager particle and 3 item display entities all containing string.

![Screenshot 2025-06-08 003509](https://github.com/user-attachments/assets/2ea745df-1ff3-472e-ab60-f5f9c303ba3a)
![Screenshot 2025-06-08 003529](https://github.com/user-attachments/assets/ef74a9da-1325-4187-909a-d3c65dadf936)
