### PR TITLE
Fix chest value not accounting for item count in sacks & stashes

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
@@ -176,6 +176,7 @@ public class ChestValue {
 			List<Slot> slots = switch (screenType) {
 				case MINION -> getMinionSlots(handler);
 				case SACK -> handler.slots.subList(10, (handler.getRows() * 9) - 10); // Skip the glass pane rows so we don't have to iterate over them
+				case STASH -> handler.slots.subList(0, (handler.getRows() - 1) * 9); // Stash uses the bottom row for the menu, so we skip it
 				case OTHER -> handler.slots.subList(0, handler.getRows() * 9);
 			};
 
@@ -201,6 +202,7 @@ public class ChestValue {
 						List<Text> lines = ItemUtils.getLore(stack);
 						yield ItemUtils.getItemCountInSack(stack, lines, true).orElse(0); // If this is in a sack and the item is not a stored item, we can just skip it
 					}
+					case STASH -> ItemUtils.getItemCountInStash(stack).orElse(0);
 					case OTHER, MINION -> stack.getCount();
 				};
 
@@ -276,6 +278,7 @@ public class ChestValue {
 	private static ScreenType determineScreenType(String rawTitleString) {
 		if (StringUtils.containsIgnoreCase(rawTitleString, "sack")) return ScreenType.SACK;
 		if (MINION_PATTERN.matcher(rawTitleString.trim()).find()) return ScreenType.MINION;
+		if (StringUtils.equalsIgnoreCase(rawTitleString, "View Stash")) return ScreenType.STASH;
 		return ScreenType.OTHER;
 	}
 
@@ -283,6 +286,7 @@ public class ChestValue {
 		return switch (screenType) {
 			case MINION -> Text.translatable("skyblocker.config.general.minionValue.@Tooltip");
 			case OTHER -> Text.translatable("skyblocker.config.general.chestValue.@Tooltip");
+			case STASH -> Text.translatable("skyblocker.config.general.stashValue.@Tooltip");
 			case SACK -> Text.translatable("skyblocker.config.general.sackValue.@Tooltip");
 		};
 	}
@@ -322,6 +326,7 @@ public class ChestValue {
 	private enum ScreenType {
 		MINION,
 		SACK,
+		STASH,
 		OTHER
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
@@ -25,6 +25,7 @@ import net.minecraft.screen.GenericContainerScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.MathHelper;
 import org.apache.commons.lang3.StringUtils;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Set;
@@ -43,7 +45,7 @@ import java.util.regex.Pattern;
 public class ChestValue {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ChestValue.class);
 	private static final Set<String> DUNGEON_CHESTS = Set.of("Wood Chest", "Gold Chest", "Diamond Chest", "Emerald Chest", "Obsidian Chest", "Bedrock Chest");
-	private static final Pattern ESSENCE_PATTERN = Pattern.compile("(?<type>[A-Za-z]+) Essence x(?<amount>[0-9]+)");
+	private static final Pattern ESSENCE_PATTERN = Pattern.compile("(?<type>[A-Za-z]+) Essence x(?<amount>\\d+)");
 	private static final Pattern MINION_PATTERN = Pattern.compile("Minion (I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII)$");
 	private static final DecimalFormat FORMATTER = new DecimalFormat("#,###");
 
@@ -53,6 +55,7 @@ public class ChestValue {
 			if (Utils.isOnSkyblock() && screen instanceof GenericContainerScreen genericContainerScreen) {
 				Text title = screen.getTitle();
 				String titleString = title.getString();
+
 				if (DUNGEON_CHESTS.contains(titleString)) {
 					if (SkyblockerConfigManager.get().dungeons.dungeonChestProfit.enableProfitCalculator) {
 						ScreenEvents.afterTick(screen).register(ignored -> {
@@ -62,20 +65,19 @@ public class ChestValue {
 						});
 					}
 				} else if (SkyblockerConfigManager.get().uiAndVisuals.chestValue.enableChestValue && !titleString.equals("SkyBlock Menu")) {
-					boolean minion = MINION_PATTERN.matcher(title.getString().trim()).find();
+					ScreenType screenType = determineScreenType(titleString);
 					Screens.getButtons(screen).add(ButtonWidget
 							.builder(Text.literal("$"), buttonWidget -> {
 								Screens.getButtons(screen).remove(buttonWidget);
 								ScreenEvents.afterTick(screen).register(ignored -> {
-									Text chestValue = getChestValue(genericContainerScreen.getScreenHandler(), minion);
+									Text chestValue = getChestValue(genericContainerScreen.getScreenHandler(), screenType);
 									if (chestValue != null) {
 										addValueToContainer(genericContainerScreen, chestValue, title);
 									}
 								});
-
 							})
 							.dimensions(((HandledScreenAccessor) genericContainerScreen).getX() + ((HandledScreenAccessor) genericContainerScreen).getBackgroundWidth() - 16, ((HandledScreenAccessor) genericContainerScreen).getY() + 4, 12, 12)
-							.tooltip(minion ? Tooltip.of(Text.translatable("skyblocker.config.general.minionValue.@Tooltip")) : Tooltip.of(Text.translatable("skyblocker.config.general.chestValue.@Tooltip")))
+							.tooltip(Tooltip.of(getButtonTooltipText(screenType)))
 							.build()
 					);
 				}
@@ -138,7 +140,7 @@ public class ChestValue {
 
 					//Incase we're searching the free chest
 					if (!StringUtils.isBlank(foundString)) {
-						profit -= Integer.parseInt(foundString.replaceAll("[^0-9]", ""));
+						profit -= Integer.parseInt(foundString.replaceAll("\\D", ""));
 					}
 
 					continue;
@@ -166,36 +168,50 @@ public class ChestValue {
 		return null;
 	}
 
-	private static @Nullable Text getChestValue(GenericContainerScreenHandler handler, boolean minion) {
+	private static @Nullable Text getChestValue(GenericContainerScreenHandler handler, @NotNull ScreenType screenType) {
 		try {
 			double value = 0;
 			boolean hasIncompleteData = false;
-			List<Slot> slots = minion ? getMinionSlots(handler) : handler.slots.subList(0, handler.getRows() * 9);
+
+			List<Slot> slots = switch (screenType) {
+				case MINION -> getMinionSlots(handler);
+				case SACK -> handler.slots.subList(10, (handler.getRows() * 9) - 10); // Skip the glass pane rows so we don't have to iterate over them
+				case OTHER -> handler.slots.subList(0, handler.getRows() * 9);
+			};
 
 			for (Slot slot : slots) {
 				ItemStack stack = slot.getStack();
-				if (stack.isEmpty()) {
-					continue;
-				}
+				if (stack.isEmpty()) continue;
+
 				String coinsLine;
-				if (minion && slot.id == 28 && stack.isOf(Items.HOPPER) && (coinsLine = ItemUtils.getLoreLineIf(stack, s -> s.contains("Held Coins:"))) != null) {
+				if (screenType == ScreenType.MINION && slot.id == 28 && stack.isOf(Items.HOPPER) && (coinsLine = ItemUtils.getLoreLineIf(stack, s -> s.contains("Held Coins:"))) != null) {
 					String source = coinsLine.split(":")[1];
 					try {
-						value += DecimalFormat.getNumberInstance(java.util.Locale.US).parse(source.trim()).doubleValue();
+						value += NumberFormat.getNumberInstance(java.util.Locale.US).parse(source.trim()).doubleValue();
 					} catch (ParseException e) {
-						LOGGER.warn("[Skyblocker] Failed to parse {}", source);
+						LOGGER.warn("[Skyblocker] Failed to parse `{}`", source);
 					}
 					continue;
 				}
 
 				String id = stack.getSkyblockApiId();
 
+				int count = switch (screenType) {
+					case SACK -> {
+						List<Text> lines = ItemUtils.getLore(stack);
+						yield ItemUtils.getItemCountInSack(stack, lines, true).orElse(0); // If this is in a sack and the item is not a stored item, we can just skip it
+					}
+					case OTHER, MINION -> stack.getCount();
+				};
+
+				if (count == 0) continue;
+
 				if (!id.isEmpty()) {
 					DoubleBooleanPair priceData = ItemUtils.getItemPrice(id);
 
 					if (!priceData.rightBoolean()) hasIncompleteData = true;
 
-					value += NetworthCalculator.getItemNetworth(stack).price();
+					value += NetworthCalculator.getItemNetworth(stack, count).price();
 				}
 			}
 
@@ -223,8 +239,15 @@ public class ChestValue {
 	}
 
 	static Text getProfitText(long profit, boolean hasIncompleteData) {
+		return Text.literal((profit > 0 ? " +" : ' ') + FORMATTER.format(profit) + " Coins").formatted(getProfitColor(hasIncompleteData, profit));
+	}
+
+	static Formatting getProfitColor(boolean hasIncompleteData, long profit) {
 		DungeonsConfig.DungeonChestProfit config = SkyblockerConfigManager.get().dungeons.dungeonChestProfit;
-		return Text.literal((profit > 0 ? " +" : ' ') + FORMATTER.format(profit) + " Coins").formatted(hasIncompleteData ? config.incompleteColor : (Math.abs(profit) < config.neutralThreshold) ? config.neutralColor : (profit > 0) ? config.profitColor : config.lossColor);
+		if (hasIncompleteData) return config.incompleteColor;
+		if (Math.abs(profit) < config.neutralThreshold) return config.neutralColor;
+		if (profit > 0) return config.profitColor;
+		return config.lossColor;
 	}
 
 	static Text getValueText(long value, boolean hasIncompleteData) {
@@ -233,7 +256,7 @@ public class ChestValue {
 	}
 
 	private static void addValueToContainer(GenericContainerScreen genericContainerScreen, Text chestValue, Text title) {
-		Screens.getButtons(genericContainerScreen).removeIf(clickableWidget -> clickableWidget instanceof ChestValueTextWidget);
+		Screens.getButtons(genericContainerScreen).removeIf(ChestValueTextWidget.class::isInstance);
 		int backgroundWidth = ((HandledScreenAccessor) genericContainerScreen).getBackgroundWidth();
 		int y = ((HandledScreenAccessor) genericContainerScreen).getY();
 		int x = ((HandledScreenAccessor) genericContainerScreen).getX();
@@ -250,6 +273,20 @@ public class ChestValue {
 		Screens.getButtons(genericContainerScreen).add(chestTitleWidget);
 	}
 
+	private static ScreenType determineScreenType(String rawTitleString) {
+		if (StringUtils.containsIgnoreCase(rawTitleString, "sack")) return ScreenType.SACK;
+		if (MINION_PATTERN.matcher(rawTitleString.trim()).find()) return ScreenType.MINION;
+		return ScreenType.OTHER;
+	}
+
+	private static Text getButtonTooltipText(ScreenType screenType) {
+		return switch (screenType) {
+			case MINION -> Text.translatable("skyblocker.config.general.minionValue.@Tooltip");
+			case OTHER -> Text.translatable("skyblocker.config.general.chestValue.@Tooltip");
+			case SACK -> Text.translatable("skyblocker.config.general.sackValue.@Tooltip");
+		};
+	}
+
 	private static class ChestValueTextWidget extends TextWidget {
 		public boolean shadow = false;
 
@@ -264,15 +301,13 @@ public class ChestValue {
 		}
 
 		// Yoinked from ClickableWidget
-		protected void draw(
-				DrawContext context, TextRenderer textRenderer, Text text, int startX, int endX
-		) {
+		protected void draw(DrawContext context, TextRenderer textRenderer, Text text, int startX, int endX) {
 			int i = textRenderer.getWidth(text);
 			int k = endX - startX;
 			if (i > k) {
 				int l = i - k;
-				double d = (double) Util.getMeasuringTimeMs() / 600.0;
-				double e = Math.max((double) l * 0.5, 3.0);
+				double d = Util.getMeasuringTimeMs() / 600.0;
+				double e = Math.max(l * 0.5, 3.0);
 				double f = Math.sin((Math.PI / 2) * Math.cos((Math.PI * 2) * d / e)) / 2.0 + 0.5;
 				double g = MathHelper.lerp(f, 0.0, l);
 				context.enableScissor(startX, getY(), endX, getY() + textRenderer.fontHeight);
@@ -282,5 +317,11 @@ public class ChestValue {
 				context.drawText(textRenderer, text, startX, getY(), -1, shadow);
 			}
 		}
+	}
+
+	private enum ScreenType {
+		MINION,
+		SACK,
+		OTHER
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
@@ -23,7 +23,7 @@ public class BazaarPriceTooltip extends SimpleTooltipAdder {
 		String skyblockApiId = stack.getSkyblockApiId();
 
 		if (TooltipInfoType.BAZAAR.hasOrNullWarning(skyblockApiId)) {
-			int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(stack.getCount()), 1);
+			int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
 
 			BazaarProduct product = TooltipInfoType.BAZAAR.getData().get(skyblockApiId);
 			lines.add(Text.literal(String.format("%-18s", "Bazaar buy Price:"))

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
@@ -12,7 +12,6 @@ import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.OptionalInt;
 
 public class BazaarPriceTooltip extends SimpleTooltipAdder {
 	public BazaarPriceTooltip(int priority) {
@@ -24,9 +23,7 @@ public class BazaarPriceTooltip extends SimpleTooltipAdder {
 		String skyblockApiId = stack.getSkyblockApiId();
 
 		if (TooltipInfoType.BAZAAR.hasOrNullWarning(skyblockApiId)) {
-			OptionalInt optCount = ItemUtils.getItemCountInSack(stack, lines);
-			// This clamp is here to ensure that the tooltip doesn't show a useless price of 0 coins if the item count is 0.
-			int count = optCount.isPresent() ? Math.max(optCount.getAsInt(), 1) : stack.getCount();
+			int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(stack.getCount()), 1);
 
 			BazaarProduct product = TooltipInfoType.BAZAAR.getData().get(skyblockApiId);
 			lines.add(Text.literal(String.format("%-18s", "Bazaar buy Price:"))

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CraftPriceTooltip extends SimpleTooltipAdder {
@@ -53,9 +52,7 @@ public class CraftPriceTooltip extends SimpleTooltipAdder {
 
 			if (totalCraftCost == 0) return;
 
-			OptionalInt optCount = ItemUtils.getItemCountInSack(stack, lines);
-			// This clamp is here to ensure that the tooltip doesn't show a useless price of 0 coins if the item count is 0.
-			int count = optCount.isPresent() ? Math.max(optCount.getAsInt(), 1) : stack.getCount();
+			int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(stack.getCount()), 1);
 
 			neuRecipes.getFirst().getAllOutputs().stream().findFirst().ifPresent(outputIngredient ->
 					lines.add(Text.literal(String.format("%-20s", "Crafting Price:")).formatted(Formatting.GOLD)

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
@@ -52,7 +52,7 @@ public class CraftPriceTooltip extends SimpleTooltipAdder {
 
 			if (totalCraftCost == 0) return;
 
-			int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(stack.getCount()), 1);
+			int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
 
 			neuRecipes.getFirst().getAllOutputs().stream().findFirst().ifPresent(outputIngredient ->
 					lines.add(Text.literal(String.format("%-20s", "Crafting Price:")).formatted(Formatting.GOLD)

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
@@ -1,9 +1,5 @@
 package de.hysky.skyblocker.skyblock.item.tooltip.adders;
 
-import java.util.List;
-
-import org.jetbrains.annotations.Nullable;
-
 import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
@@ -14,6 +10,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class EstimatedItemValueTooltip extends SimpleTooltipAdder {
 
@@ -23,7 +22,7 @@ public class EstimatedItemValueTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(stack.getCount()), 1);
+		int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
 
 		NetworthResult result = NetworthCalculator.getItemNetworth(stack, count);
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
@@ -11,7 +11,6 @@ import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.OptionalInt;
 
 public class NpcPriceTooltip extends SimpleTooltipAdder {
 
@@ -35,9 +34,7 @@ public class NpcPriceTooltip extends SimpleTooltipAdder {
 		double price = TooltipInfoType.NPC.getData().getOrDefault(internalID, -1); // The original default return value of 0 can be an actual price, so we use a value that can't be a price
 		if (price < 0) return;
 
-		OptionalInt optCount = ItemUtils.getItemCountInSack(stack, lines);
-		// This clamp is here to ensure that the tooltip doesn't show a useless price of 0 coins if the item count is 0.
-		int count = optCount.isPresent() ? Math.max(optCount.getAsInt(), 1) : stack.getCount();
+		int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
 
 		lines.add(Text.literal(String.format("%-21s", "NPC Sell Price:"))
 					  .formatted(Formatting.YELLOW)

--- a/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
@@ -65,6 +65,7 @@ public final class ItemUtils {
     ).apply(instance, ItemStack::new)));
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemUtils.class);
     private static final Pattern STORED_PATTERN = Pattern.compile("Stored: ([\\d,]+)/\\S+");
+    private static final Pattern STASH_COUNT_PATTERN = Pattern.compile("x([\\d,]+)$"); // This is used with Matcher#find, not #matches
     private static final short LOG_INTERVAL = 1000;
 	private static long lastLog = Util.getMeasuringTimeMs();
 
@@ -510,5 +511,23 @@ public final class ItemUtils {
 			} else return RegexUtils.parseOptionalIntFromMatcher(matcher, 1);
 		}
 		return OptionalInt.empty();
+    }
+
+    /**
+     * Finds the number of items stored in a stash based on item's name.
+     * @param itemStack The item stack.
+     * @return An {@link OptionalInt} containing the number of items stored in the stash, or an empty {@link OptionalInt} if the item is not a stash or the amount could not be found.
+     */
+    public static OptionalInt getItemCountInStash(@NotNull ItemStack itemStack) {
+        return getItemCountInStash(itemStack.getName());
+    }
+
+    /**
+     * Finds the number of items stored in a stash based on item's name.
+     * @param itemName The name of the item to look in.
+     * @return An {@link OptionalInt} containing the number of items stored in the stash, or an empty {@link OptionalInt} if the item is not a stash or the amount could not be found.
+     */
+    public static OptionalInt getItemCountInStash(@NotNull Text itemName) {
+        return RegexUtils.findIntFromMatcher(STASH_COUNT_PATTERN.matcher(itemName.getString()));
     }
 }

--- a/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
@@ -485,7 +485,18 @@ public final class ItemUtils {
      * @return An {@link OptionalInt} containing the number of items stored in the sack, or an empty {@link OptionalInt} if the item is not a sack or the amount could not be found.
      */
     public static OptionalInt getItemCountInSack(@NotNull ItemStack itemStack, @NotNull List<Text> lines) {
-        if (lines.size() >= 2 && lines.get(1).getString().endsWith("Sack")) {
+        return getItemCountInSack(itemStack, lines, false);
+    }
+
+    /**
+     * Finds the number of items stored in a sack from a list of texts.
+     * @param itemStack The item stack this list of texts belong to. This is used for logging purposes.
+     * @param lines A list of text lines that represent the tooltip of the item stack.
+     * @param isLore Whether the lines are from the item's lore or not. This is useful to figure out which line to look at, as lore and tooltip lines are different due to the first line being the item's name.
+     * @return An {@link OptionalInt} containing the number of items stored in the sack, or an empty {@link OptionalInt} if the item is not a sack or the amount could not be found.
+     */
+    public static OptionalInt getItemCountInSack(@NotNull ItemStack itemStack, @NotNull List<Text> lines, boolean isLore) {
+		if (lines.size() >= 2 && lines.get(isLore ? 0 : 1).getString().endsWith("Sack")) {
 			// Example line: empty[style={color=dark_purple,!italic}, siblings=[literal{Stored: }[style={color=gray}], literal{0}[style={color=dark_gray}], literal{/20k}[style={color=gray}]]
             // Which equals: `Stored: 0/20k`
 			Matcher matcher = TextUtils.matchInList(lines, STORED_PATTERN);

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -264,6 +264,7 @@
 
   "skyblocker.config.general.chestValue.@Tooltip": "Calculate the value of this container.",
   "skyblocker.config.general.minionValue.@Tooltip": "Calculate the value of this minion's generated resources.",
+  "skyblocker.config.general.sackValue.@Tooltip": "Calculate the value of the items in this sack.",
 
   "skyblocker.config.general.enableTips": "Enable Tips",
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -265,6 +265,7 @@
   "skyblocker.config.general.chestValue.@Tooltip": "Calculate the value of this container.",
   "skyblocker.config.general.minionValue.@Tooltip": "Calculate the value of this minion's generated resources.",
   "skyblocker.config.general.sackValue.@Tooltip": "Calculate the value of the items in this sack.",
+  "skyblocker.config.general.stashValue.@Tooltip": "Calculate the value of the items in this stash.",
 
   "skyblocker.config.general.enableTips": "Enable Tips",
 


### PR DESCRIPTION
The stash fix is also applied to the various tooltip adders we have. 

**Sack:**
![image](https://cdn.discordapp.com/attachments/1381690997322420406/1381703452215873779/image.png?ex=68487b1d&is=6847299d&hm=be3c836451634b795e50cc81eb81596bcaf027adf4356d18f3c336d085e5f9cc&)
**`/viewstash material`:**
![image](https://cdn.discordapp.com/attachments/1381690997322420406/1381706954023637124/image.png?ex=68487e60&is=68472ce0&hm=b8632e27a5e8fe121139416529ee7e8c3c45afe009b5a4fc4a5bbd9a25eaf1f5&)

I also did some small code cleanups here and there in the relevant files.

The only untested part of this is `/viewstash item`. I've never had any items in that stash, nor do I know how they get in there.