### PR TITLE
update cooldown for new axe throw ability

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemCooldowns.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemCooldowns.java
@@ -22,6 +22,8 @@ import java.util.Map;
 public class ItemCooldowns {
     private static final String JUNGLE_AXE_ID = "JUNGLE_AXE";
     private static final String TREECAPITATOR_ID = "TREECAPITATOR_AXE";
+	private static final String FIG_AXE_ID = "FIG_AXE";
+	private static final String FIGSTONE_ID = "FIGSTONE_AXE";
     private static final String GRAPPLING_HOOK_ID = "GRAPPLING_HOOK";
 	private static final String ROGUE_SWORD_ID = "ROGUE_SWORD";
 	private static final String LEAPING_SWORD_ID = "LEAPING_SWORD";
@@ -35,66 +37,10 @@ public class ItemCooldowns {
 
     private static final List<String> BAT_ARMOR_IDS = List.of("BAT_PERSON_HELMET", "BAT_PERSON_CHESTPLATE", "BAT_PERSON_LEGGINGS", "BAT_PERSON_BOOTS");
     private static final Map<String, CooldownEntry> ITEM_COOLDOWNS = new HashMap<>();
-    private static final int[] EXPERIENCE_LEVELS = {
-            0, 660, 730, 800, 880, 960, 1050, 1150, 1260, 1380, 1510, 1650, 1800, 1960, 2130,
-            2310, 2500, 2700, 2920, 3160, 3420, 3700, 4000, 4350, 4750, 5200, 5700, 6300, 7000,
-            7800, 8700, 9700, 10800, 12000, 13300, 14700, 16200, 17800, 19500, 21300, 23200,
-            25200, 27400, 29800, 32400, 35200, 38200, 41400, 44800, 48400, 52200, 56200, 60400,
-            64800, 69400, 74200, 79200, 84700, 90700, 97200, 104200, 111700, 119700, 128200,
-            137200, 147700, 156700, 167700, 179700, 192700, 206700, 221700, 237700, 254700,
-            272700, 291700, 311700, 333700, 357700, 383700, 411700, 441700, 476700, 516700,
-            561700, 611700, 666700, 726700, 791700, 861700, 936700, 1016700, 1101700, 1191700,
-            1286700, 1386700, 1496700, 1616700, 1746700, 1886700
-    };
-    private static int monkeyLevel = 1;
-    private static double monkeyExp = 0;
 
     @Init
     public static void init() {
-        ClientPlayerBlockBreakEvents.AFTER.register(ItemCooldowns::afterBlockBreak);
         UseItemCallback.EVENT.register(ItemCooldowns::onItemInteract);
-    }
-
-    public static void updateCooldown() {
-        PetInfo pet = PetCache.getCurrentPet();
-
-        if (pet != null && pet.tier().equals(SkyblockItemRarity.LEGENDARY)) {
-            monkeyExp = pet.exp();
-
-            monkeyLevel = 0;
-            for (int xpLevel : EXPERIENCE_LEVELS) {
-                if (monkeyExp < xpLevel) {
-                    break;
-                } else {
-                    monkeyExp -= xpLevel;
-                    monkeyLevel++;
-                }
-            }
-        }
-    }
-
-    private static int getCooldown4Foraging() {
-        int baseCooldown = 2000;
-        int monkeyPetCooldownReduction = baseCooldown * monkeyLevel / 200;
-        return baseCooldown - monkeyPetCooldownReduction;
-    }
-
-    public static void afterBlockBreak(World world, PlayerEntity player, BlockPos pos, BlockState state) {
-        if (!SkyblockerConfigManager.get().uiAndVisuals.itemCooldown.enableItemCooldowns) return;
-        String usedItemId = ItemUtils.getItemId(player.getMainHandStack());
-        if (usedItemId.isEmpty()) return;
-        if (state.isIn(BlockTags.LOGS)) {
-            if (usedItemId.equals(JUNGLE_AXE_ID) && !isOnCooldown(JUNGLE_AXE_ID)) {
-                updateCooldown();
-                ITEM_COOLDOWNS.put(usedItemId, new CooldownEntry(getCooldown4Foraging()));
-                return;
-            }
-            if (usedItemId.equals(TREECAPITATOR_ID) && !isOnCooldown(TREECAPITATOR_ID)) {
-                updateCooldown();
-                ITEM_COOLDOWNS.put(usedItemId, new CooldownEntry(getCooldown4Foraging()));
-                return;
-            }
-        }
     }
 
     private static ActionResult onItemInteract(PlayerEntity player, World world, Hand hand) {
@@ -102,6 +48,7 @@ public class ItemCooldowns {
 			return ActionResult.PASS;
 		String usedItemId = ItemUtils.getItemId(player.getMainHandStack());
 		switch (usedItemId) {
+			case FIG_AXE_ID, FIGSTONE_ID, JUNGLE_AXE_ID, TREECAPITATOR_ID -> handleItemCooldown(usedItemId, 1000);
 			case SILK_EDGE_SWORD_ID, LEAPING_SWORD_ID -> handleItemCooldown(usedItemId, 1000);
 			case GRAPPLING_HOOK_ID -> handleItemCooldown(GRAPPLING_HOOK_ID, 2000, player.fishHook != null && !isWearingBatArmor(player));
 			case ROGUE_SWORD_ID, SPIRIT_LEAP_ID, LIVID_DAGGER_ID -> handleItemCooldown(usedItemId, 5000);


### PR DESCRIPTION
With the sweep stat most axes now have the treecapitator ability with no cooldown. treecapitator, jungle axe, and the new axes now have the ability to be thrown at a 1 second cooldown. The monkey pet no longer reduces this cooldown. 

Can delay merge till after update officially releases.