### PR TITLE
Bazaar Quick Quantities

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -6,7 +6,6 @@ import de.hysky.skyblocker.config.configs.UIAndVisualsConfig;
 import de.hysky.skyblocker.skyblock.ItemPickupWidget;
 import de.hysky.skyblocker.skyblock.TeleportOverlay;
 import de.hysky.skyblocker.skyblock.fancybars.StatusBarsConfigScreen;
-import de.hysky.skyblocker.skyblock.fishing.FishingHudWidget;
 import de.hysky.skyblocker.skyblock.item.slottext.SlotTextManager;
 import de.hysky.skyblocker.skyblock.item.slottext.SlotTextMode;
 import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
@@ -22,6 +21,7 @@ import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import dev.isxander.yacl3.api.*;
 import dev.isxander.yacl3.api.controller.ColorControllerBuilder;
 import dev.isxander.yacl3.api.controller.FloatFieldControllerBuilder;
+import dev.isxander.yacl3.api.controller.IntegerFieldControllerBuilder;
 import dev.isxander.yacl3.api.controller.IntegerSliderControllerBuilder;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
@@ -535,6 +535,48 @@ public class UIAndVisualsCategory {
                                 .controller(ConfigUtils::createBooleanController)
                                 .build())
                         .build())
+
+				// Bazaar Quick Quantities
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.bazaarQuickQuantities"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.bazaarQuickQuantities.enabled"))
+								.description(OptionDescription.of(Text.translatable("skyblocker.config.uiAndVisuals.bazaarQuickQuantities.enabled.@Tooltip")))
+								.binding(defaults.uiAndVisuals.bazaarQuickQuantities.enabled,
+										() -> config.uiAndVisuals.bazaarQuickQuantities.enabled,
+										newValue -> config.uiAndVisuals.bazaarQuickQuantities.enabled = newValue)
+								.controller(ConfigUtils::createBooleanController)
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.bazaarQuickQuantities.closeSignOnUse"))
+								.binding(defaults.uiAndVisuals.bazaarQuickQuantities.closeSignOnUse,
+										() -> config.uiAndVisuals.bazaarQuickQuantities.closeSignOnUse,
+										newValue -> config.uiAndVisuals.bazaarQuickQuantities.closeSignOnUse = newValue)
+								.controller(ConfigUtils::createBooleanController)
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.bazaarQuickQuantities.slotQuantity", 1))
+								.binding(defaults.uiAndVisuals.bazaarQuickQuantities.slot1Quantity,
+										() -> config.uiAndVisuals.bazaarQuickQuantities.slot1Quantity,
+										newValue -> config.uiAndVisuals.bazaarQuickQuantities.slot1Quantity = newValue)
+								.controller(opt -> IntegerFieldControllerBuilder.create(opt).range(0, 71680))
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.bazaarQuickQuantities.slotQuantity", 2))
+								.binding(defaults.uiAndVisuals.bazaarQuickQuantities.slot2Quantity,
+										() -> config.uiAndVisuals.bazaarQuickQuantities.slot2Quantity,
+										newValue -> config.uiAndVisuals.bazaarQuickQuantities.slot2Quantity = newValue)
+								.controller(opt -> IntegerFieldControllerBuilder.create(opt).range(0, 71680))
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.bazaarQuickQuantities.slotQuantity", 3))
+								.binding(defaults.uiAndVisuals.bazaarQuickQuantities.slot3Quantity,
+										() -> config.uiAndVisuals.bazaarQuickQuantities.slot3Quantity,
+										newValue -> config.uiAndVisuals.bazaarQuickQuantities.slot3Quantity = newValue)
+								.controller(opt -> IntegerFieldControllerBuilder.create(opt).range(0, 71680))
+								.build())
+						.build())
 
                 //Input Calculator
                 .group(OptionGroup.createBuilder()

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -80,6 +80,9 @@ public class UIAndVisualsConfig {
     @SerialEntry
     public SearchOverlay searchOverlay = new SearchOverlay();
 
+	@SerialEntry
+	public BazaarQuickQuantities bazaarQuickQuantities = new BazaarQuickQuantities();
+
     @SerialEntry
     public InputCalculator inputCalculator = new InputCalculator();
 
@@ -399,6 +402,23 @@ public class UIAndVisualsConfig {
         @SerialEntry
         public List<String> auctionHistory = new ArrayList<>();
     }
+
+	public static class BazaarQuickQuantities {
+		@SerialEntry
+		public boolean enabled = false;
+
+		@SerialEntry
+		public boolean closeSignOnUse = false;
+
+		@SerialEntry
+		public int slot1Quantity = 28;
+
+		@SerialEntry
+		public int slot2Quantity = 2240;
+
+		@SerialEntry
+		public int slot3Quantity = 256;
+	}
 
     public static class InputCalculator {
         @SerialEntry

--- a/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
@@ -3,12 +3,14 @@ package de.hysky.skyblocker.mixins;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.BazaarQuickQuantities;
 import de.hysky.skyblocker.skyblock.calculators.SignCalculator;
 import de.hysky.skyblocker.skyblock.speedPreset.SpeedPresets;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.AbstractSignEditScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -33,6 +35,17 @@ public abstract class SignEditScreenMixin extends Screen {
 
 	protected SignEditScreenMixin(Text title) {
 		super(title);
+	}
+
+	@Inject(method = "init", at = @At("TAIL"))
+	private void skyblocker$init(CallbackInfo ci) {
+		if (Utils.isOnSkyblock()) {
+			var config = SkyblockerConfigManager.get();
+			if (isInputSign() && messages[3].equals("to order") && config.uiAndVisuals.bazaarQuickQuantities.enabled) {
+				ButtonWidget[] buttons = BazaarQuickQuantities.getButtons(this.width, messages);
+				for (ButtonWidget button : buttons) addDrawableChild(button);
+			}
+		}
 	}
 
 	@Inject(method = "render", at = @At("HEAD"))

--- a/src/main/java/de/hysky/skyblocker/skyblock/BazaarQuickQuantities.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/BazaarQuickQuantities.java
@@ -1,0 +1,33 @@
+package de.hysky.skyblocker.skyblock;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.UIAndVisualsConfig;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+
+public class BazaarQuickQuantities {
+	private static final MinecraftClient client = MinecraftClient.getInstance();
+
+	public static ButtonWidget[] getButtons(int width, String[] messages) {
+		ButtonWidget[] buttons = new ButtonWidget[3];
+		UIAndVisualsConfig.BazaarQuickQuantities config = SkyblockerConfigManager.get().uiAndVisuals.bazaarQuickQuantities;
+
+		int x = width / 2 + 50;
+		int y = 45;
+
+		buttons[0] = ButtonWidget.builder(Text.of(String.valueOf(config.slot1Quantity)), button -> {
+			messages[0] = String.valueOf(config.slot1Quantity);
+			if (config.closeSignOnUse) client.setScreen(null);
+		}).dimensions(x, y += 20, 50, 20).build();
+		buttons[1] = ButtonWidget.builder(Text.of(String.valueOf(config.slot2Quantity)), button -> {
+			messages[0] = String.valueOf(config.slot2Quantity);
+			if (config.closeSignOnUse) client.setScreen(null);
+		}).dimensions(x, y += 20, 50, 20).build();
+		buttons[2] = ButtonWidget.builder(Text.of(String.valueOf(config.slot3Quantity)), button -> {
+			messages[0] = String.valueOf(config.slot3Quantity);
+			if (config.closeSignOnUse) client.setScreen(null);
+		}).dimensions(x, y + 20, 50, 20).build();
+		return buttons;
+	}
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -913,6 +913,12 @@
   "skyblocker.config.uiAndVisuals.healthBars.emptyBarColor": "Empty Health Bar Color",
   "skyblocker.config.uiAndVisuals.healthBars.emptyBarColor.@Tooltip": "Color of health bar when mob is at full hp",
 
+  "skyblocker.config.uiAndVisuals.bazaarQuickQuantities": "Bazaar Quick Quantities",
+  "skyblocker.config.uiAndVisuals.bazaarQuickQuantities.enabled": "Enabled",
+  "skyblocker.config.uiAndVisuals.bazaarQuickQuantities.enabled.@Tooltip": "Adds 3 buttons to quickly fill out Bazaar buy order amounts",
+  "skyblocker.config.uiAndVisuals.bazaarQuickQuantities.closeSignOnUse": "Close Sign on Use",
+  "skyblocker.config.uiAndVisuals.bazaarQuickQuantities.slotQuantity": "Slot #%s Quantity",
+
   "skyblocker.config.uiAndVisuals.inputCalculator": "Input Calculator",
   "skyblocker.config.uiAndVisuals.inputCalculator.enabled": "Enable Sign Calculator",
   "skyblocker.config.uiAndVisuals.inputCalculator.enabled.@Tooltip": "Enables the ability for you to do calculations when inputting values such as price for the ah.\n Key:\n  S = 64\n  E = 160\n  K = 1,000\n  M = 1,000,000\n  B = 1,000,000,000\n\n purse/P = current purse value",


### PR DESCRIPTION
Adds 3 customizable presets onto the Bazaar "enter amount to order" sign to make creating buy orders/insta-buying quicker.  

Config Tab
![image](https://github.com/user-attachments/assets/41b7bad6-4428-4afd-9a71-551eecb7aba8)

Sign
![image](https://github.com/user-attachments/assets/2067d88e-047e-44d9-a47f-1abeae43cd66)
