### PR TITLE
refactor: prevent possible mod incompatabilites due to conflicts

### DIFF
--- a/src/main/java/de/hysky/skyblocker/injected/RecipeBookHolder.java
+++ b/src/main/java/de/hysky/skyblocker/injected/RecipeBookHolder.java
@@ -8,5 +8,5 @@ public interface RecipeBookHolder {
 	 * @implNote {@code BEFORE_INIT} may be called before the callback list is emptied.
 	 * @param callback the callback
 	 */
-	void registerRecipeBookToggleCallback(Runnable callback);
+	void skyblocker$registerRecipeBookToggleCallback(Runnable callback);
 }

--- a/src/main/java/de/hysky/skyblocker/injected/SkyblockerStack.java
+++ b/src/main/java/de/hysky/skyblocker/injected/SkyblockerStack.java
@@ -6,27 +6,27 @@ import de.hysky.skyblocker.skyblock.item.PetInfo;
 
 public interface SkyblockerStack {
 	@NotNull
-	default String getSkyblockId() {
+	default String skyblocker$getSkyblockId() {
 		return "";
 	}
 
 	@NotNull
-	default String getSkyblockApiId() {
+	default String skyblocker$getSkyblockApiId() {
 		return "";
 	}
 
 	@NotNull
-	default String getNeuName() {
+	default String skyblocker$getNeuName() {
 		return "";
 	}
 
 	@NotNull
-	default String getUuid() {
+	default String skyblocker$getUuid() {
 		return "";
 	}
 
 	@NotNull
-	default PetInfo getPetInfo() {
+	default PetInfo skyblocker$getPetInfo() {
 		return PetInfo.EMPTY;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/CameraMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/CameraMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 public class CameraMixin {
 
     @ModifyReturnValue(method = "getPos", at = @At("RETURN"))
-    private Vec3d skyblocker$onCameraUpdate(Vec3d original) {
+    private Vec3d onCameraUpdate(Vec3d original) {
         Vec3d pos = SmoothAOTE.getInterpolatedPos();
         if (pos != null) {
             return pos;

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
@@ -71,7 +71,7 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 	}
 
 	@Inject(method = "onEntityTrackerUpdate", at = @At("TAIL"))
-	private void skyblocker$onEntityTrackerUpdate(EntityTrackerUpdateS2CPacket packet, CallbackInfo ci, @Local Entity entity) {
+	private void onEntityTrackerUpdate(EntityTrackerUpdateS2CPacket packet, CallbackInfo ci, @Local Entity entity) {
 		if (!(entity instanceof ArmorStandEntity armorStandEntity)) return;
 
 		SlayerManager.checkSlayerBoss(armorStandEntity);
@@ -93,19 +93,19 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 	}
 
 	@Inject(method = "method_64896", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;removeEntity(ILnet/minecraft/entity/Entity$RemovalReason;)V"))
-	private void skyblocker$onItemDestroy(int entityId, CallbackInfo ci) {
+	private void onItemDestroy(int entityId, CallbackInfo ci) {
 		if (world.getEntityById(entityId) instanceof ItemEntity itemEntity) {
 			DungeonManager.onItemPickup(itemEntity);
 		}
 	}
 
 	@Inject(method = "onPlayerPositionLook", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/util/thread/ThreadExecutor;)V", shift = At.Shift.AFTER))
-	private void skyblocker$beforeTeleport(PlayerPositionLookS2CPacket packet, CallbackInfo ci, @Share("playerBeforeTeleportBlockPos") LocalRef<BlockPos> beforeTeleport) {
+	private void beforeTeleport(PlayerPositionLookS2CPacket packet, CallbackInfo ci, @Share("playerBeforeTeleportBlockPos") LocalRef<BlockPos> beforeTeleport) {
 		beforeTeleport.set(client.player.getBlockPos().toImmutable());
 	}
 
 	@Inject(method = "onPlayerPositionLook", at = @At(value = "RETURN"))
-	private void skyblocker$onTeleport(PlayerPositionLookS2CPacket packet, CallbackInfo ci, @Share("playerBeforeTeleportBlockPos") LocalRef<BlockPos> beforeTeleport) {
+	private void onTeleport(PlayerPositionLookS2CPacket packet, CallbackInfo ci, @Share("playerBeforeTeleportBlockPos") LocalRef<BlockPos> beforeTeleport) {
 		//player has been teleported by the server, tell the smooth AOTE this
 		SmoothAOTE.playerTeleported();
 
@@ -113,18 +113,18 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 	}
 
 	@ModifyVariable(method = "onItemPickupAnimation", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;removeEntity(ILnet/minecraft/entity/Entity$RemovalReason;)V", ordinal = 0))
-	private ItemEntity skyblocker$onItemPickup(ItemEntity itemEntity) {
+	private ItemEntity onItemPickup(ItemEntity itemEntity) {
 		DungeonManager.onItemPickup(itemEntity);
 		return itemEntity;
 	}
 
 	@WrapWithCondition(method = "onEntityPassengersSet", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;)V", remap = false))
-	private boolean skyblocker$cancelEntityPassengersWarning(Logger instance, String msg) {
+	private boolean cancelEntityPassengersWarning(Logger instance, String msg) {
 		return !Utils.isOnHypixel();
 	}
 
 	@ModifyExpressionValue(method = "onEntityStatus", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/s2c/play/EntityStatusS2CPacket;getEntity(Lnet/minecraft/world/World;)Lnet/minecraft/entity/Entity;"))
-	private Entity skyblocker$onEntityDeath(Entity entity, @Local(argsOnly = true) EntityStatusS2CPacket packet) {
+	private Entity onEntityDeath(Entity entity, @Local(argsOnly = true) EntityStatusS2CPacket packet) {
 		if (packet.getStatus() == EntityStatuses.PLAY_DEATH_SOUND_OR_ADD_PROJECTILE_HIT_PARTICLES) {
 			DungeonScore.handleEntityDeath(entity);
 			TheEnd.onEntityDeath(entity);
@@ -133,23 +133,23 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 	}
 
 	@Inject(method = "onEntityEquipmentUpdate", at = @At(value = "TAIL"))
-	private void skyblocker$onEntityEquip(EntityEquipmentUpdateS2CPacket packet, CallbackInfo ci, @Local Entity entity) {
+	private void onEntityEquip(EntityEquipmentUpdateS2CPacket packet, CallbackInfo ci, @Local Entity entity) {
 		EggFinder.checkIfEgg(entity);
 		CorpseFinder.checkIfCorpse(entity);
 	}
 
 	@Inject(method = "onPlayerListHeader", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/PlayerListHud;setFooter(Lnet/minecraft/text/Text;)V"))
-	private void skyblocker$updatePlayerListFooter(PlayerListHeaderS2CPacket packet, CallbackInfo ci) {
+	private void updatePlayerListFooter(PlayerListHeaderS2CPacket packet, CallbackInfo ci) {
 		PlayerListManager.updateFooter(packet.footer());
 	}
 
 	@WrapWithCondition(method = "onPlayerList", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false))
-	private boolean skyblocker$cancelPlayerListWarning(Logger instance, String format, Object arg1, Object arg2) {
+	private boolean cancelPlayerListWarning(Logger instance, String format, Object arg1, Object arg2) {
 		return !Utils.isOnHypixel();
 	}
 
 	@Inject(method = "onPlaySound", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/util/thread/ThreadExecutor;)V", shift = At.Shift.AFTER), cancellable = true)
-	private void skyblocker$onPlaySound(PlaySoundS2CPacket packet, CallbackInfo ci) {
+	private void onPlaySound(PlaySoundS2CPacket packet, CallbackInfo ci) {
 		FishingHelper.onSound(packet);
 		CrystalsChestHighlighter.onSound(packet);
 		SoundEvent sound = packet.getSound().value();
@@ -167,22 +167,22 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 	}
 
 	@WrapWithCondition(method = "warnOnUnknownPayload", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;)V", remap = false))
-	private boolean skyblocker$dropBadlionPacketWarnings(Logger instance, String message, Object identifier) {
+	private boolean dropBadlionPacketWarnings(Logger instance, String message, Object identifier) {
 		return !(Utils.isOnHypixel() && ((Identifier) identifier).getNamespace().equals("badlion"));
 	}
 
 	@WrapWithCondition(method = {"onScoreboardScoreUpdate", "onScoreboardScoreReset"}, at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;)V", remap = false), require = 2)
-	private boolean skyblocker$cancelUnknownScoreboardObjectiveWarnings(Logger instance, String message, Object objectiveName) {
+	private boolean cancelUnknownScoreboardObjectiveWarnings(Logger instance, String message, Object objectiveName) {
 		return !Utils.isOnHypixel();
 	}
 
 	@WrapWithCondition(method = "onTeam", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;[Ljava/lang/Object;)V", remap = false))
-	private boolean skyblocker$cancelTeamWarning(Logger instance, String format, Object... arg) {
+	private boolean cancelTeamWarning(Logger instance, String format, Object... arg) {
 		return !Utils.isOnHypixel();
 	}
 
 	@Inject(method = "onParticle", at = @At("RETURN"))
-	private void skyblocker$onParticle(ParticleS2CPacket packet, CallbackInfo ci) {
+	private void onParticle(ParticleS2CPacket packet, CallbackInfo ci) {
 		MythologicalRitual.onParticle(packet);
 		DojoManager.onParticle(packet);
 		CrystalsChestHighlighter.onParticle(packet);

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerEntityMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerEntityMixin.java
@@ -36,7 +36,7 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
     }
 
     @Inject(method = "dropSelectedItem", at = @At("HEAD"), cancellable = true)
-    public void skyblocker$dropSelectedItem(CallbackInfoReturnable<Boolean> cir) {
+    public void dropSelectedItem(CallbackInfoReturnable<Boolean> cir) {
         if (Utils.isOnSkyblock() && (ItemProtection.isItemProtected(this.getMainHandStack()) || HotbarSlotLock.isLocked(this.getInventory().getSelectedSlot()))
                 && (!SkyblockerConfigManager.get().dungeons.allowDroppingProtectedItems || !Utils.isInDungeons())) {
             cir.setReturnValue(false);
@@ -44,12 +44,12 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
     }
 
     @Inject(method = "updateHealth", at = @At("RETURN"))
-    public void skyblocker$updateHealth(CallbackInfo ci) {
+    public void updateHealth(CallbackInfo ci) {
         HealingMelonIndicator.updateHealth();
     }
 
     @Inject(method = "openEditSignScreen", at = @At("HEAD"), cancellable = true)
-    public void skyblocker$redirectEditSignScreen(SignBlockEntity sign, boolean front, CallbackInfo ci) {
+    public void redirectEditSignScreen(SignBlockEntity sign, boolean front, CallbackInfo ci) {
         // Fancy Party Finder
         if (!PartyFinderScreen.isInKuudraPartyFinder && client.currentScreen instanceof PartyFinderScreen partyFinderScreen && !partyFinderScreen.isAborted() && sign.getText(front).getMessage(3, false).getString().toLowerCase().contains("level")) {
             partyFinderScreen.updateSign(sign, front);

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerInteractionManagerMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.network.packet.Packet;
 import net.minecraft.util.Hand;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Slice;
@@ -30,6 +31,7 @@ public class ClientPlayerInteractionManagerMixin {
 		}
 	}
 
+	@Unique
 	private void swingHandWithoutPackets(PlayerEntity playerEntity, Hand hand) {
 		playerEntity.swingHand(hand, false); // The playerEntity override for swingHand is the other method with just the hand parameter, this one isn't overridden and doesn't lead to sending packets.
 	}

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientWorldMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientWorldMixin.java
@@ -26,7 +26,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 public abstract class ClientWorldMixin implements BlockView {
 
 	@Inject(method = "handleBlockUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;II)Z"))
-	private void skyblocker$beforeBlockUpdate(CallbackInfo ci, @Local(argsOnly = true) BlockPos pos, @Share("old") LocalRef<@Nullable BlockState> oldState) {
+	private void beforeBlockUpdate(CallbackInfo ci, @Local(argsOnly = true) BlockPos pos, @Share("old") LocalRef<@Nullable BlockState> oldState) {
 		oldState.set(getBlockState(pos));
 	}
 
@@ -36,7 +36,7 @@ public abstract class ClientWorldMixin implements BlockView {
 	 */
 	//TODO might be worth creating an event for this
 	@Inject(method = "handleBlockUpdate", at = @At("RETURN"))
-	private void skyblocker$afterBlockUpdate(CallbackInfo ci, @Local(argsOnly = true) BlockPos pos, @Local(argsOnly = true) BlockState state, @Share("old") LocalRef<@Nullable BlockState> oldState) {
+	private void afterBlockUpdate(CallbackInfo ci, @Local(argsOnly = true) BlockPos pos, @Local(argsOnly = true) BlockState state, @Share("old") LocalRef<@Nullable BlockState> oldState) {
 		if (Utils.isInCrimson()) {
 			DojoManager.onBlockUpdate(pos.toImmutable(), state);
 		} else if (Utils.isInCrystalHollows()) {

--- a/src/main/java/de/hysky/skyblocker/mixins/ComponentHolderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ComponentHolderMixin.java
@@ -21,7 +21,7 @@ public interface ComponentHolderMixin {
 
 	@SuppressWarnings("unchecked")
 	@ModifyReturnValue(method = "get", at = @At("RETURN"))
-	private <T> T skyblocker$customArmorTrims(T original, ComponentType<? extends T> dataComponentType) {
+	private <T> T customArmorTrims(T original, ComponentType<? extends T> dataComponentType) {
 		if (Utils.isOnSkyblock() && ((Object) this) instanceof ItemStack stack) {
 			if (dataComponentType == DataComponentTypes.TRIM) {
 				Object2ObjectOpenHashMap<String, CustomArmorTrims.ArmorTrimId> customTrims = SkyblockerConfigManager.get().general.customArmorTrims;

--- a/src/main/java/de/hysky/skyblocker/mixins/DataTrackerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/DataTrackerMixin.java
@@ -31,7 +31,7 @@ public abstract class DataTrackerMixin {
 
     @SuppressWarnings("ConstantValue")
     @Inject(method = "writeUpdatedEntries", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/data/DataTracker;copyToFrom(Lnet/minecraft/entity/data/DataTracker$Entry;Lnet/minecraft/entity/data/DataTracker$SerializedEntry;)V"))
-    private <T> void skyblocker$onWriteUpdatedEntries(CallbackInfo ci, @Local DataTracker.Entry<T> entry, @Local DataTracker.SerializedEntry<T> serializedEntry) {
+    private <T> void onWriteUpdatedEntries(CallbackInfo ci, @Local DataTracker.Entry<T> entry, @Local DataTracker.SerializedEntry<T> serializedEntry) {
         if (Utils.isInTheEnd() && SkyblockerConfigManager.get().slayers.endermanSlayer.enableYangGlyphsNotification && entry.getData() == EndermanEntityAccessor.getCARRIED_BLOCK() && entry.get() instanceof Optional<?> value && value.isPresent() && value.get() instanceof BlockState state && state.isOf(Blocks.BEACON) && ((Optional<?>) serializedEntry.value()).isEmpty()) {
             MinecraftClient client = MinecraftClient.getInstance();
             if (trackedEntity instanceof Entity entity && MobGlow.getArmorStands(entity).stream().anyMatch(armorStand -> armorStand.getName().getString().contains(client.getSession().getUsername()))) {
@@ -43,7 +43,7 @@ public abstract class DataTrackerMixin {
     }
 
     @Inject(method = "copyToFrom", at = @At(value = "NEW", target = "Ljava/lang/IllegalStateException;"), cancellable = true)
-    public void skyblocker$ignoreInvalidDataExceptions(CallbackInfo ci) {
+    public void ignoreInvalidDataExceptions(CallbackInfo ci) {
         //These exceptions cause annoying small lag spikes for some reason
         if (Utils.isOnHypixel()) ci.cancel();
     }

--- a/src/main/java/de/hysky/skyblocker/mixins/DownloadingTerrainScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/DownloadingTerrainScreenMixin.java
@@ -12,7 +12,7 @@ import net.minecraft.client.gui.screen.DownloadingTerrainScreen;
 public class DownloadingTerrainScreenMixin {
 
 	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
-	private void skyblocker$hideWorldLoadingScreen(CallbackInfo ci) {
+	private void hideWorldLoadingScreen(CallbackInfo ci) {
 		if (Utils.isOnHypixel()) ci.cancel();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/DrawContextMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/DrawContextMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(DrawContext.class)
 public abstract class DrawContextMixin {
     @ModifyExpressionValue(method = "drawCooldownProgress", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/ItemCooldownManager;getCooldownProgress(Lnet/minecraft/item/ItemStack;F)F"))
-    private float skyblocker$modifyItemCooldown(float cooldownProgress, @Local(argsOnly = true) ItemStack stack) {
+    private float modifyItemCooldown(float cooldownProgress, @Local(argsOnly = true) ItemStack stack) {
         return Utils.isOnSkyblock() && ItemCooldowns.isOnCooldown(stack) ? ItemCooldowns.getItemCooldownEntry(stack).getRemainingCooldownPercent() : cooldownProgress;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/DyedColorComponentMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/DyedColorComponentMixin.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.At;
 public class DyedColorComponentMixin {
 
 	@ModifyReturnValue(method = "getColor", at = @At("RETURN"))
-	private static int skyblocker$customDyeColor(int originalColor, @Local(argsOnly = true) ItemStack stack) {
+	private static int customDyeColor(int originalColor, @Local(argsOnly = true) ItemStack stack) {
 		if (Utils.isOnSkyblock()) {
 			String itemUuid = ItemUtils.getItemUuid(stack);
 

--- a/src/main/java/de/hysky/skyblocker/mixins/EntityMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/EntityMixin.java
@@ -48,7 +48,7 @@ public abstract class EntityMixin {
 	public abstract boolean isInvisible();
 
 	@ModifyExpressionValue(method = "isInvisibleTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;isSpectator()Z"))
-	public boolean skyblocker$showInvisibleArmorStands(boolean isSpectator, PlayerEntity player) {
+	public boolean showInvisibleArmorStands(boolean isSpectator, PlayerEntity player) {
 		return isSpectator || (isInvisible() && Utils.isOnHypixel() && Debug.debugEnabled() && SkyblockerConfigManager.get().debug.showInvisibleArmorStands && type.equals(EntityType.ARMOR_STAND));
 	}
 

--- a/src/main/java/de/hysky/skyblocker/mixins/EntityRenderDispatcherMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/EntityRenderDispatcherMixin.java
@@ -20,7 +20,7 @@ public class EntityRenderDispatcherMixin {
 	private static final String skyblocker$SOULWEAVER_SKULL_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmYyNGVkNjg3NTMwNGZhNGExZjBjNzg1YjJjYjZhNmE3MjU2M2U5ZjNlMjRlYTU1ZTE4MTc4NDUyMTE5YWE2NiJ9fX0=";
 
 	@ModifyReturnValue(method = "shouldRender", at = @At("RETURN"))
-	private <E extends Entity> boolean skyblocker$dontRenderSoulweaverSkulls(boolean original, @Local(argsOnly = true) E entity) {
+	private <E extends Entity> boolean hideSoulWeaverSkulls(boolean original, @Local(argsOnly = true) E entity) {
 		return Utils.isInDungeons() && SkyblockerConfigManager.get().dungeons.hideSoulweaverSkulls && entity instanceof ArmorStandEntity armorStand && entity.isInvisible() && armorStand.hasStackEquipped(EquipmentSlot.HEAD) ? !ItemUtils.getHeadTexture(armorStand.getEquippedStack(EquipmentSlot.HEAD)).equals(skyblocker$SOULWEAVER_SKULL_TEXTURE) : original;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/EntityRenderDispatcherMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/EntityRenderDispatcherMixin.java
@@ -17,10 +17,10 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(EntityRenderDispatcher.class)
 public class EntityRenderDispatcherMixin {
 	@Unique
-	private static final String SOULWEAVER_SKULL_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmYyNGVkNjg3NTMwNGZhNGExZjBjNzg1YjJjYjZhNmE3MjU2M2U5ZjNlMjRlYTU1ZTE4MTc4NDUyMTE5YWE2NiJ9fX0=";
+	private static final String skyblocker$SOULWEAVER_SKULL_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmYyNGVkNjg3NTMwNGZhNGExZjBjNzg1YjJjYjZhNmE3MjU2M2U5ZjNlMjRlYTU1ZTE4MTc4NDUyMTE5YWE2NiJ9fX0=";
 
 	@ModifyReturnValue(method = "shouldRender", at = @At("RETURN"))
 	private <E extends Entity> boolean skyblocker$dontRenderSoulweaverSkulls(boolean original, @Local(argsOnly = true) E entity) {
-		return Utils.isInDungeons() && SkyblockerConfigManager.get().dungeons.hideSoulweaverSkulls && entity instanceof ArmorStandEntity armorStand && entity.isInvisible() && armorStand.hasStackEquipped(EquipmentSlot.HEAD) ? !ItemUtils.getHeadTexture(armorStand.getEquippedStack(EquipmentSlot.HEAD)).equals(SOULWEAVER_SKULL_TEXTURE) : original;
+		return Utils.isInDungeons() && SkyblockerConfigManager.get().dungeons.hideSoulweaverSkulls && entity instanceof ArmorStandEntity armorStand && entity.isInvisible() && armorStand.hasStackEquipped(EquipmentSlot.HEAD) ? !ItemUtils.getHeadTexture(armorStand.getEquippedStack(EquipmentSlot.HEAD)).equals(skyblocker$SOULWEAVER_SKULL_TEXTURE) : original;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/EntityRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/EntityRendererMixin.java
@@ -19,7 +19,7 @@ import net.minecraft.entity.decoration.ArmorStandEntity;
 public class EntityRendererMixin {
 
 	@ModifyExpressionValue(method = "updateRenderState", slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/EntityRenderDispatcher;shouldRenderHitboxes()Z")), at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/entity/state/EntityRenderState;invisible:Z", opcode = Opcodes.GETFIELD))
-	private <E extends Entity> boolean skyblocker$armorStandHitboxVisible(boolean invisible, @Local(argsOnly = true) E entity) {
+	private <E extends Entity> boolean visibleArmorStandHitBox(boolean invisible, @Local(argsOnly = true) E entity) {
 		return (!(entity instanceof ArmorStandEntity) || !Utils.isOnHypixel() || !Debug.debugEnabled() || !SkyblockerConfigManager.get().debug.showInvisibleArmorStands) && invisible;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/FarmlandBlockMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/FarmlandBlockMixin.java
@@ -17,14 +17,14 @@ import org.spongepowered.asm.mixin.injection.At;
 public abstract class FarmlandBlockMixin extends Block {
     @Shadow
     @Final
-    protected static VoxelShape SHAPE;
+	private static VoxelShape SHAPE;
 
     protected FarmlandBlockMixin(Settings settings) {
         super(settings);
     }
 
     @ModifyReturnValue(method = "getOutlineShape", at = @At("RETURN"))
-    private VoxelShape skyblocker$replaceOutlineShape(VoxelShape original) {
+    private VoxelShape replaceOutlineShape(VoxelShape original) {
         return Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.hitbox.oldFarmlandHitbox ? VoxelShapes.fullCube() : original;
     }
 

--- a/src/main/java/de/hysky/skyblocker/mixins/GlResourceManagerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/GlResourceManagerMixin.java
@@ -17,7 +17,7 @@ import net.minecraft.client.gl.GlResourceManager;
 public class GlResourceManagerMixin {
 
 	@WrapWithCondition(method = "writeToBuffer", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/opengl/GlStateManager;_glBufferSubData(IILjava/nio/ByteBuffer;)V", ordinal = 0))
-	private static boolean skyblocker$replaceBufferData(int target, int offset, ByteBuffer data, @Local(argsOnly = true) GpuBuffer gpuBuffer) {
+	private boolean replaceBufferData(int target, int offset, ByteBuffer data, @Local(argsOnly = true) GpuBuffer gpuBuffer) {
 		GlStateManager._glBufferData(target, data, GlConst.toGl(gpuBuffer.usage()));
 
 		return false;

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -104,7 +104,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	}
 
 	@Inject(method = "init", at = @At("RETURN"))
-	private void skyblocker$initQuickNav(CallbackInfo ci) {
+	private void initQuickNav(CallbackInfo ci) {
 		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().quickNav.enableQuickNav && client != null && client.player != null && !client.player.isCreative()) {
 			for (QuickNavButton quickNavButton : skyblocker$quickNavButtons = QuickNav.init(getTitle().getString().trim())) {
 				addSelectableChild(quickNavButton);
@@ -113,7 +113,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	}
 
 	@Inject(at = @At("HEAD"), method = "keyPressed")
-	public void skyblocker$keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+	public void keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
 		if (this.client != null && this.client.player != null && this.focusedSlot != null && keyCode != 256 && !this.client.options.inventoryKey.matchesKey(keyCode, scanCode) && Utils.isOnSkyblock()) {
 			SkyblockerConfig config = SkyblockerConfigManager.get();
 			//wiki lookup
@@ -140,7 +140,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	}
 
 	@ModifyExpressionValue(method = "mouseClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;mouseClicked(DDI)Z"))
-	public boolean skyblocker$passThroughSearchFieldUnfocusedClicks(boolean superClicked, double mouseX, double mouseY, int button) {
+	public boolean passThroughSearchFieldUnfocusedClicks(boolean superClicked, double mouseX, double mouseY, int button) {
 		//Handle Search Field clicks - as of 1.21.4 the game will only send clicks to the selected element rather than trying to send one to each and stopping when the first returns true (if any).
 		if (!superClicked) {
 			Optional<ClickableWidget> searchField = Screens.getButtons(this).stream()
@@ -159,7 +159,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 * Draws the unselected tabs in front of the background blur, but behind the main inventory, similar to creative inventory tabs
 	 */
 	@Inject(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawBackground(Lnet/minecraft/client/gui/DrawContext;FII)V"))
-	private void skyblocker$drawUnselectedQuickNavButtons(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+	private void drawUnselectedQuickNavButtons(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
 		if (skyblocker$quickNavButtons != null) for (QuickNavButton quickNavButton : skyblocker$quickNavButtons) {
 			// Render the button behind the main inventory background if it's not toggled or if it's still fading in
 			if (!quickNavButton.toggled() || quickNavButton.getAlpha() < 255) {
@@ -173,7 +173,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 * Draws the selected tab in front of the background blur and the main inventory, similar to creative inventory tabs
 	 */
 	@Inject(method = "renderBackground", at = @At("RETURN"))
-	private void skyblocker$drawSelectedQuickNavButtons(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+	private void drawSelectedQuickNavButtons(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
 		if (skyblocker$quickNavButtons != null) for (QuickNavButton quickNavButton : skyblocker$quickNavButtons) {
 			if (quickNavButton.toggled()) {
 				quickNavButton.setRenderInFront(true);
@@ -185,7 +185,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	@SuppressWarnings("DataFlowIssue")
 	// makes intellij be quiet about this.focusedSlot maybe being null. It's already null checked in mixined method.
 	@Inject(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;IILnet/minecraft/util/Identifier;)V"), cancellable = true)
-	public void skyblocker$drawMouseOverTooltip(DrawContext context, int x, int y, CallbackInfo ci, @Local(ordinal = 0) ItemStack stack) {
+	public void drawMouseOverTooltip(DrawContext context, int x, int y, CallbackInfo ci, @Local(ordinal = 0) ItemStack stack) {
 		if (!Utils.isOnSkyblock()) return;
 
 		// Hide Empty Tooltips
@@ -209,30 +209,30 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	}
 
 	@ModifyVariable(method = "drawMouseoverTooltip", at = @At(value = "STORE"))
-	private ItemStack skyblocker$experimentSolvers$replaceTooltipDisplayStack(ItemStack stack) {
-		return skyblocker$experimentSolvers$getStack(focusedSlot, stack);
+	private ItemStack modifyToolTipStackForExperimentSolver(ItemStack stack) {
+		return getExperimentSolverStack(focusedSlot, stack);
 	}
 
 	@ModifyVariable(method = "drawSlot", at = @At(value = "LOAD", ordinal = 3), ordinal = 0)
-	private ItemStack skyblocker$experimentSolvers$replaceDisplayStack(ItemStack stack, @Local(argsOnly = true) Slot slot) {
-		return skyblocker$experimentSolvers$getStack(slot, stack);
+	private ItemStack replaceDisplayStackForExperimentSolver(ItemStack stack, @Local(argsOnly = true) Slot slot) {
+		return getExperimentSolverStack(slot, stack);
 	}
 
 	/**
 	 * Avoids getting currentSolver again when it's already in the scope for some usages of this method.
 	 *
-	 * @see #skyblocker$experimentSolvers$getStack(Slot, ItemStack, ContainerSolver)
+	 * @see #getExperimentSolverStack(Slot, ItemStack, ContainerSolver)
 	 */
 	@Unique
-	private ItemStack skyblocker$experimentSolvers$getStack(Slot slot, @NotNull ItemStack stack) {
-		return skyblocker$experimentSolvers$getStack(slot, stack, ContainerSolverManager.getCurrentSolver());
+	private ItemStack getExperimentSolverStack(Slot slot, @NotNull ItemStack stack) {
+		return getExperimentSolverStack(slot, stack, ContainerSolverManager.getCurrentSolver());
 	}
 
 	/**
 	 * Redirects getStack calls to account for different stacks in experiment solvers.
 	 */
 	@Unique
-	private ItemStack skyblocker$experimentSolvers$getStack(Slot slot, @NotNull ItemStack stack, ContainerSolver currentSolver) {
+	private ItemStack getExperimentSolverStack(Slot slot, @NotNull ItemStack stack, ContainerSolver currentSolver) {
 		if (currentSolver instanceof ExperimentSolver experimentSolver && (experimentSolver instanceof SuperpairsSolver || experimentSolver instanceof UltrasequencerSolver) && experimentSolver.getState() == ExperimentSolver.State.SHOW && slot.inventory instanceof SimpleInventory) {
 			ItemStack itemStack = experimentSolver.getSlots().get(slot.getIndex());
 			return itemStack == null ? stack : itemStack;
@@ -247,7 +247,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 * @implNote This runs before {@link ScreenHandler#onSlotClick(int, int, SlotActionType, net.minecraft.entity.player.PlayerEntity)}
 	 */
 	@Inject(method = "onMouseClick(Lnet/minecraft/screen/slot/Slot;IILnet/minecraft/screen/slot/SlotActionType;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;clickSlot(IIILnet/minecraft/screen/slot/SlotActionType;Lnet/minecraft/entity/player/PlayerEntity;)V"), cancellable = true)
-	private void skyblocker$onSlotClick(Slot slot, int slotId, int button, SlotActionType actionType, CallbackInfo ci) {
+	private void onSlotClick(Slot slot, int slotId, int button, SlotActionType actionType, CallbackInfo ci) {
 		if (!Utils.isOnSkyblock()) return;
 
 		// Item Protection
@@ -260,7 +260,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 		if (slot == null) return;
 		String title = getTitle().getString();
 		ContainerSolver currentSolver = ContainerSolverManager.getCurrentSolver();
-		ItemStack stack = skyblocker$experimentSolvers$getStack(slot, slot.getStack(), currentSolver);
+		ItemStack stack = getExperimentSolverStack(slot, slot.getStack(), currentSolver);
 
 		// Prevent clicks on filler items
 		if (SkyblockerConfigManager.get().uiAndVisuals.hideEmptyTooltips && skyblocker$FILLER_ITEMS.contains(stack.getName().getString()) &&
@@ -326,14 +326,14 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	}
 
 	@Inject(at = @At("HEAD"), method = "mouseClicked")
-	public void skyblocker$mouseClicked(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir) {
+	public void mouseClicked(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir) {
 		if (VisitorHelper.shouldRender()) {
 			VisitorHelper.handleMouseClick(mouseX, mouseY, button, this.textRenderer);
 		}
 	}
 
 	@Inject(method = "drawSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;III)V"))
-	private void skyblocker$drawOnItem(DrawContext context, Slot slot, CallbackInfo ci) {
+	private void drawOnItem(DrawContext context, Slot slot, CallbackInfo ci) {
 		if (Utils.isOnSkyblock()) {
 			ItemBackgroundManager.drawBackgrounds(slot.getStack(), context, slot.x, slot.y);
 		}
@@ -351,7 +351,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	}
 
 	@Inject(method = "drawSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawStackOverlay(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V"))
-	private void skyblocker$drawSlotText(DrawContext context, Slot slot, CallbackInfo ci) {
+	private void drawSlotText(DrawContext context, Slot slot, CallbackInfo ci) {
 		if (Utils.isOnSkyblock()) {
 			SlotTextManager.renderSlotText(context, textRenderer, slot);
 		}

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -58,10 +58,10 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 * This is the slot id returned for when a click is outside the screen's bounds
 	 */
 	@Unique
-	private static final int OUT_OF_BOUNDS_SLOT = -999;
+	private static final int skyblocker$OUT_OF_BOUNDS_SLOT = -999;
 
 	@Unique
-	private static final Set<String> FILLER_ITEMS = Set.of(
+	private static final Set<String> skyblocker$FILLER_ITEMS = Set.of(
 			" ", // Empty menu item
 			"Locked Page",
 			"Quick Crafting Slot",
@@ -97,7 +97,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	protected abstract List<Text> getTooltipFromItem(ItemStack stack);
 
 	@Unique
-	private List<QuickNavButton> quickNavButtons;
+	private List<QuickNavButton> skyblocker$quickNavButtons;
 
 	protected HandledScreenMixin(Text title) {
 		super(title);
@@ -106,7 +106,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	@Inject(method = "init", at = @At("RETURN"))
 	private void skyblocker$initQuickNav(CallbackInfo ci) {
 		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().quickNav.enableQuickNav && client != null && client.player != null && !client.player.isCreative()) {
-			for (QuickNavButton quickNavButton : quickNavButtons = QuickNav.init(getTitle().getString().trim())) {
+			for (QuickNavButton quickNavButton : skyblocker$quickNavButtons = QuickNav.init(getTitle().getString().trim())) {
 				addSelectableChild(quickNavButton);
 			}
 		}
@@ -160,7 +160,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 */
 	@Inject(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;drawBackground(Lnet/minecraft/client/gui/DrawContext;FII)V"))
 	private void skyblocker$drawUnselectedQuickNavButtons(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-		if (quickNavButtons != null) for (QuickNavButton quickNavButton : quickNavButtons) {
+		if (skyblocker$quickNavButtons != null) for (QuickNavButton quickNavButton : skyblocker$quickNavButtons) {
 			// Render the button behind the main inventory background if it's not toggled or if it's still fading in
 			if (!quickNavButton.toggled() || quickNavButton.getAlpha() < 255) {
 				quickNavButton.setRenderInFront(false);
@@ -174,7 +174,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 	 */
 	@Inject(method = "renderBackground", at = @At("RETURN"))
 	private void skyblocker$drawSelectedQuickNavButtons(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-		if (quickNavButtons != null) for (QuickNavButton quickNavButton : quickNavButtons) {
+		if (skyblocker$quickNavButtons != null) for (QuickNavButton quickNavButton : skyblocker$quickNavButtons) {
 			if (quickNavButton.toggled()) {
 				quickNavButton.setRenderInFront(true);
 				quickNavButton.render(context, mouseX, mouseY, delta);
@@ -252,7 +252,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 
 		// Item Protection
 		// When you try and drop the item by picking it up then clicking outside the screen
-		if (slotId == OUT_OF_BOUNDS_SLOT && ItemProtection.isItemProtected(this.handler.getCursorStack())) {
+		if (slotId == skyblocker$OUT_OF_BOUNDS_SLOT && ItemProtection.isItemProtected(this.handler.getCursorStack())) {
 			ci.cancel();
 			return;
 		}
@@ -263,7 +263,7 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 		ItemStack stack = skyblocker$experimentSolvers$getStack(slot, slot.getStack(), currentSolver);
 
 		// Prevent clicks on filler items
-		if (SkyblockerConfigManager.get().uiAndVisuals.hideEmptyTooltips && FILLER_ITEMS.contains(stack.getName().getString()) &&
+		if (SkyblockerConfigManager.get().uiAndVisuals.hideEmptyTooltips && skyblocker$FILLER_ITEMS.contains(stack.getName().getString()) &&
 				// Allow clicks in Ultrasequencer and Superpairs
 				(!UltrasequencerSolver.INSTANCE.test(title) || SkyblockerConfigManager.get().helpers.experiments.enableUltrasequencerSolver)) {
 			ci.cancel();

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenProviderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenProviderMixin.java
@@ -26,7 +26,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public interface HandledScreenProviderMixin<T extends ScreenHandler> {
 
 	@Inject(method = "open", at = @At("HEAD"), cancellable = true)
-	private void skyblocker$open(Text name, ScreenHandlerType<T> type, MinecraftClient client, int id, CallbackInfo ci) {
+	private void open(Text name, ScreenHandlerType<T> type, MinecraftClient client, int id, CallbackInfo ci) {
 		ClientPlayerEntity player = client.player;
 		if (player == null) return;
 		if (!Utils.isOnSkyblock()) return;

--- a/src/main/java/de/hysky/skyblocker/mixins/HeldItemRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HeldItemRendererMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.item.ItemStack;
 public class HeldItemRendererMixin {
 
 	@ModifyReturnValue(method = "shouldSkipHandAnimationOnSwap", at = @At("RETURN"))
-	private boolean skyblocker$cancelComponentUpdateAnimation(boolean original, ItemStack from, ItemStack to) {
+	private boolean cancelComponentUpdateAnimation(boolean original, ItemStack from, ItemStack to) {
 		return Utils.isOnSkyblock() && from.getItem() == to.getItem() ? original || SkyblockerConfigManager.get().uiAndVisuals.cancelComponentUpdateAnimation : original;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/InGameHudMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/InGameHudMixin.java
@@ -52,7 +52,7 @@ public abstract class InGameHudMixin {
     private MinecraftClient client;
 
 	@Inject(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderHotbarItem(Lnet/minecraft/client/gui/DrawContext;IILnet/minecraft/client/render/RenderTickCounter;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/ItemStack;I)V", ordinal = 0))
-    public void skyblocker$renderHotbarItemLockOrBackground(CallbackInfo ci, @Local(argsOnly = true) DrawContext context, @Local(ordinal = 4, name = "m") int index, @Local(ordinal = 5, name = "n") int x, @Local(ordinal = 6, name = "o") int y, @Local PlayerEntity player) {
+    public void renderHotbarItemLockOrBackground(CallbackInfo ci, @Local(argsOnly = true) DrawContext context, @Local(ordinal = 4, name = "m") int index, @Local(ordinal = 5, name = "n") int x, @Local(ordinal = 6, name = "o") int y, @Local PlayerEntity player) {
         if (Utils.isOnSkyblock()) {
 			ItemBackgroundManager.drawBackgrounds(player.getInventory().getMainStacks().get(index), context, x, y);
 
@@ -69,45 +69,45 @@ public abstract class InGameHudMixin {
     }
 
     @Inject(method = { "renderExperienceBar", "renderExperienceLevel" }, at = @At("HEAD"), cancellable = true, require = 2)
-    private void skyblocker$renderExperienceBar(CallbackInfo ci) {
+    private void renderExperienceBar(CallbackInfo ci) {
         if (Utils.isOnSkyblock() && FancyStatusBars.isEnabled() && FancyStatusBars.isExperienceFancyBarVisible())
             ci.cancel();
     }
 
     @Inject(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderHealthBar(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/entity/player/PlayerEntity;IIIIFIIIZ)V", shift = At.Shift.AFTER), cancellable = true)
-    private void skyblocker$renderStatusBars(DrawContext context, CallbackInfo ci) {
+    private void renderStatusBars(DrawContext context, CallbackInfo ci) {
         if (Utils.isOnSkyblock() && skyblocker$statusBars.render(context, context.getScaledWindowWidth(), context.getScaledWindowHeight())) ci.cancel();
     }
 
     @Inject(method = "renderHealthBar", at = @At(value = "HEAD"), cancellable = true)
-    private void skyblocker$renderHealthBar(DrawContext context, PlayerEntity player, int x, int y, int lines, int regeneratingHeartIndex, float maxHealth, int lastHealth, int health, int absorption, boolean blinking, CallbackInfo ci) {
+    private void renderHealthBar(DrawContext context, PlayerEntity player, int x, int y, int lines, int regeneratingHeartIndex, float maxHealth, int lastHealth, int health, int absorption, boolean blinking, CallbackInfo ci) {
         if (!Utils.isOnSkyblock()) return;
         if (FancyStatusBars.isEnabled() && FancyStatusBars.isHealthFancyBarVisible()) ci.cancel();
     }
 
     @ModifyExpressionValue(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;getScaledWindowHeight()I"))
-    private int skyblocker$moveHealthDown(int original) {
+    private int moveHealthDown(int original) {
         return Utils.isOnSkyblock() && FancyStatusBars.isEnabled() && !FancyStatusBars.isHealthFancyBarVisible() && FancyStatusBars.isExperienceFancyBarVisible() ? original + 6 : original;
     }
 
     @Inject(method = "renderArmor", at = @At("HEAD"), cancellable = true)
-    private static void skyblocker$renderStatusBars(DrawContext context, PlayerEntity player, int i, int j, int k, int x, CallbackInfo ci) {
+    private static void renderStatusBars(DrawContext context, PlayerEntity player, int i, int j, int k, int x, CallbackInfo ci) {
         if (Utils.isOnSkyblock() && FancyStatusBars.isEnabled()) ci.cancel();
     }
 
     @Inject(method = "renderMountHealth", at = @At("HEAD"), cancellable = true)
-    private void skyblocker$renderMountHealth(CallbackInfo ci) {
+    private void renderMountHealth(CallbackInfo ci) {
         if (Utils.isOnSkyblock() && FancyStatusBars.isEnabled())
             ci.cancel();
     }
 
     @Inject(method = "renderStatusEffectOverlay", at = @At("HEAD"), cancellable = true)
-    private void skyblocker$dontRenderStatusEffects(CallbackInfo ci) {
+    private void dontRenderStatusEffects(CallbackInfo ci) {
         if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.hideStatusEffectOverlay) ci.cancel();
     }
 
     @ModifyExpressionValue(method = "renderCrosshair", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;getAttackCooldownProgress(F)F"))
-    private float skyblocker$modifyAttackIndicatorCooldown(float cooldownProgress) {
+    private float modifyAttackIndicatorCooldown(float cooldownProgress) {
         if (Utils.isOnSkyblock() && client.player != null) {
             ItemStack stack = client.player.getMainHandStack();
             if (ItemCooldowns.isOnCooldown(stack)) {
@@ -119,14 +119,14 @@ public abstract class InGameHudMixin {
     }
 
     @Inject(method = "setTitle", at = @At("HEAD"), cancellable = true)
-    private void skyblocker$dicerTitlePrevent(Text title, CallbackInfo ci) {
+    private void preventDicerTitle(Text title, CallbackInfo ci) {
         if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().farming.garden.dicerTitlePrevent && title != null && skyblocker$DICER_TITLE_BLACKLIST.matcher(title.getString()).matches()) {
             ci.cancel();
         }
     }
 
 	@WrapWithCondition(method = "renderPlayerList", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/PlayerListHud;render(Lnet/minecraft/client/gui/DrawContext;ILnet/minecraft/scoreboard/Scoreboard;Lnet/minecraft/scoreboard/ScoreboardObjective;)V"))
-	private boolean skyblocker$shouldRenderHud(PlayerListHud playerListHud, DrawContext context, int scaledWindowWidth, Scoreboard scoreboard, ScoreboardObjective objective) {
+	private boolean shouldRenderHud(PlayerListHud playerListHud, DrawContext context, int scaledWindowWidth, Scoreboard scoreboard, ScoreboardObjective objective) {
 		return !Utils.isOnSkyblock() || !SkyblockerConfigManager.get().uiAndVisuals.tabHud.tabHudEnabled || TabHud.shouldRenderVanilla() || MinecraftClient.getInstance().currentScreen instanceof WidgetsConfigurationScreen;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/InGameHudMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/InGameHudMixin.java
@@ -40,12 +40,12 @@ import java.util.regex.Pattern;
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
     @Unique
-    private static final Supplier<Identifier> SLOT_LOCK_ICON = () -> SkyblockerConfigManager.get().general.itemProtection.slotLockStyle.tex;
+    private static final Supplier<Identifier> skyblocker$SLOT_LOCK_ICON = () -> SkyblockerConfigManager.get().general.itemProtection.slotLockStyle.tex;
     @Unique
-    private static final Pattern DICER_TITLE_BLACKLIST = Pattern.compile(".+? DROP!");
+    private static final Pattern skyblocker$DICER_TITLE_BLACKLIST = Pattern.compile(".+? DROP!");
 
     @Unique
-    private final FancyStatusBars statusBars = new FancyStatusBars();
+    private final FancyStatusBars skyblocker$statusBars = new FancyStatusBars();
 
     @Shadow
     @Final
@@ -58,7 +58,7 @@ public abstract class InGameHudMixin {
 
 			// slot lock
             if (HotbarSlotLock.isLocked(index)) {
-                context.drawTexture(RenderLayer::getGuiTextured, SLOT_LOCK_ICON.get(), x, y, 0, 0, 16, 16, 16, 16);
+                context.drawTexture(RenderLayer::getGuiTextured, skyblocker$SLOT_LOCK_ICON.get(), x, y, 0, 0, 16, 16, 16, 16);
             }
 
             //item protection
@@ -76,7 +76,7 @@ public abstract class InGameHudMixin {
 
     @Inject(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderHealthBar(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/entity/player/PlayerEntity;IIIIFIIIZ)V", shift = At.Shift.AFTER), cancellable = true)
     private void skyblocker$renderStatusBars(DrawContext context, CallbackInfo ci) {
-        if (Utils.isOnSkyblock() && statusBars.render(context, context.getScaledWindowWidth(), context.getScaledWindowHeight())) ci.cancel();
+        if (Utils.isOnSkyblock() && skyblocker$statusBars.render(context, context.getScaledWindowWidth(), context.getScaledWindowHeight())) ci.cancel();
     }
 
     @Inject(method = "renderHealthBar", at = @At(value = "HEAD"), cancellable = true)
@@ -120,7 +120,7 @@ public abstract class InGameHudMixin {
 
     @Inject(method = "setTitle", at = @At("HEAD"), cancellable = true)
     private void skyblocker$dicerTitlePrevent(Text title, CallbackInfo ci) {
-        if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().farming.garden.dicerTitlePrevent && title != null && DICER_TITLE_BLACKLIST.matcher(title.getString()).matches()) {
+        if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().farming.garden.dicerTitlePrevent && title != null && skyblocker$DICER_TITLE_BLACKLIST.matcher(title.getString()).matches()) {
             ci.cancel();
         }
     }

--- a/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
@@ -40,24 +40,24 @@ public abstract class InventoryScreenMixin extends HandledScreen<PlayerScreenHan
 
 
     @ModifyArg(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/RecipeBookScreen;<init>(Lnet/minecraft/screen/AbstractRecipeScreenHandler;Lnet/minecraft/client/gui/screen/recipebook/RecipeBookWidget;Lnet/minecraft/entity/player/PlayerInventory;Lnet/minecraft/text/Text;)V"))
-    private static RecipeBookWidget<?> skyblocker$replaceRecipeBook(RecipeBookWidget<?> original, @Local(argsOnly = true) PlayerEntity player) {
+    private static RecipeBookWidget<?> replaceRecipeBook(RecipeBookWidget<?> original, @Local(argsOnly = true) PlayerEntity player) {
         return SkyblockerConfigManager.get().general.itemList.enableItemList && Utils.isOnSkyblock() ? new SkyblockRecipeBookWidget(player.playerScreenHandler) : original;
     }
 
     @ModifyArg(method = "getRecipeBookButtonPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/ScreenPos;<init>(II)V"), index = 0)
-    private int skyblocker$moveButton(int x) {
+    private int moveButton(int x) {
         return Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory ? x + 21 : x;
     }
 
 	@WrapWithCondition(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/StatusEffectsDisplay;drawStatusEffects(Lnet/minecraft/client/gui/DrawContext;IIF)V"))
-	private boolean skyblocker$dontDrawStatusEffects(StatusEffectsDisplay statusEffectsDisplay, DrawContext context, int mouseX, int mouseY, float tickDelta) {
+	private boolean dontDrawStatusEffects(StatusEffectsDisplay statusEffectsDisplay, DrawContext context, int mouseX, int mouseY, float tickDelta) {
 		return !(Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.hideStatusEffectOverlay || Utils.isInGarden() && SkyblockerConfigManager.get().farming.garden.gardenPlotsWidget);
 	}
 
 	// This makes it so that REI at least doesn't wrongly exclude the zone
 	// shouldHideStatusEffectHud should actually be showsStatusEffects
 	@ModifyReturnValue(method = "shouldHideStatusEffectHud", at = @At("RETURN"))
-	private boolean skyblocker$markStatusEffectsHidden(boolean original) {
+	private boolean markStatusEffectsHidden(boolean original) {
 		// In the garden, status effects are shown when both hideStatusEffectOverlay and gardenPlotsWidget are false
 		if (Utils.isInGarden()) return original && !SkyblockerConfigManager.get().uiAndVisuals.hideStatusEffectOverlay && !SkyblockerConfigManager.get().farming.garden.gardenPlotsWidget;
 		// In the rest of Skyblock, status effects are shown when hideStatusEffectOverlay is false
@@ -67,12 +67,12 @@ public abstract class InventoryScreenMixin extends HandledScreen<PlayerScreenHan
 	}
 
     @Inject(method = "onRecipeBookToggled", at = @At("TAIL"))
-    private void skyblocker$callRecipeToggleCallbacks(CallbackInfo ci) {
+    private void callRecipeToggleCallbacks(CallbackInfo ci) {
 		skyblocker$recipeBookToggleCallbacks.forEach(Runnable::run);
     }
 
     @Inject(method = "init", at = @At("HEAD"))
-    private void skyblocker$clearRecipeToggleCallbacks(CallbackInfo ci) {
+    private void learRecipeToggleCallbacks(CallbackInfo ci) {
 		skyblocker$recipeBookToggleCallbacks.clear();
     }
 

--- a/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
@@ -32,7 +32,7 @@ import java.util.List;
 public abstract class InventoryScreenMixin extends HandledScreen<PlayerScreenHandler> implements RecipeBookHolder {
 
 	@Unique
-	private final List<Runnable> recipeBookToggleCallbacks = new ArrayList<>();
+	private final List<Runnable> skyblocker$recipeBookToggleCallbacks = new ArrayList<>();
 
     public InventoryScreenMixin(PlayerScreenHandler handler, PlayerInventory inventory, Text title) {
         super(handler, inventory, title);
@@ -68,16 +68,16 @@ public abstract class InventoryScreenMixin extends HandledScreen<PlayerScreenHan
 
     @Inject(method = "onRecipeBookToggled", at = @At("TAIL"))
     private void skyblocker$callRecipeToggleCallbacks(CallbackInfo ci) {
-		recipeBookToggleCallbacks.forEach(Runnable::run);
+		skyblocker$recipeBookToggleCallbacks.forEach(Runnable::run);
     }
 
     @Inject(method = "init", at = @At("HEAD"))
     private void skyblocker$clearRecipeToggleCallbacks(CallbackInfo ci) {
-		recipeBookToggleCallbacks.clear();
+		skyblocker$recipeBookToggleCallbacks.clear();
     }
 
 	@Override
 	public void registerRecipeBookToggleCallback(Runnable runnable) {
-		recipeBookToggleCallbacks.add(runnable);
+		skyblocker$recipeBookToggleCallbacks.add(runnable);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/InventoryScreenMixin.java
@@ -77,7 +77,7 @@ public abstract class InventoryScreenMixin extends HandledScreen<PlayerScreenHan
     }
 
 	@Override
-	public void registerRecipeBookToggleCallback(Runnable runnable) {
+	public void skyblocker$registerRecipeBookToggleCallback(Runnable runnable) {
 		skyblocker$recipeBookToggleCallbacks.add(runnable);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ItemStackMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ItemStackMixin.java
@@ -33,22 +33,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack {
 	@Unique
-	private int maxDamage;
+	private int skyblocker$maxDamage;
 
 	@Unique
-	private String skyblockId;
+	private String skyblocker$skyblockId;
 
 	@Unique
-	private String skyblockApiId;
+	private String skyblocker$skyblockApiId;
 
 	@Unique
-	private String neuName;
+	private String skyblocker$neuName;
 
 	@Unique
-	private String uuid;
+	private String skyblocker$uuid;
 
 	@Unique
-	private PetInfo petInfo;
+	private PetInfo skyblocker$petInfo;
 
 	@Shadow
 	public abstract int getDamage();
@@ -76,7 +76,7 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 	)
 	private void skyblocker$skyblockIdTooltip(CallbackInfo ci, @Local(argsOnly = true) Consumer<Text> textConsumer) {
 		if (Utils.isOnSkyblock()) {
-			String skyblockId = getSkyblockId();
+			String skyblockId = skyblocker$getSkyblockId();
 
 			if (!skyblockId.isEmpty()) {
 				textConsumer.accept(Text.literal("skyblock:" + skyblockId).formatted(Formatting.DARK_GRAY));
@@ -98,7 +98,7 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 	@ModifyReturnValue(method = "getDamage", at = @At("RETURN"))
 	private int skyblocker$handleDamage(int original) {
 		// If the durability is already calculated, the original value should be the damage
-		if (!skyblocker$shouldProcess() || maxDamage != 0) {
+		if (!skyblocker$shouldProcess() || skyblocker$maxDamage != 0) {
 			return original;
 		}
 		return skyblocker$getAndCacheDurability() ? getDamage() : original;
@@ -110,10 +110,10 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 			return original;
 		}
 		// If the max damage is already calculated, return it
-		if (maxDamage != 0) {
-			return maxDamage;
+		if (skyblocker$maxDamage != 0) {
+			return skyblocker$maxDamage;
 		}
-		return skyblocker$getAndCacheDurability() ? maxDamage : original;
+		return skyblocker$getAndCacheDurability() ? skyblocker$maxDamage : original;
 	}
 
 	@ModifyReturnValue(method = "isDamageable", at = @At("RETURN"))
@@ -140,43 +140,43 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 			return false;
 		}
 		// Saves the calculated durability
-		maxDamage = durability.rightInt();
+		skyblocker$maxDamage = durability.rightInt();
 		setDamage(durability.rightInt() - durability.leftInt());
 		return true;
 	}
 
 	@Override
 	@NotNull
-	public String getSkyblockId() {
-		if (skyblockId != null && !skyblockId.isEmpty()) return skyblockId;
-		return skyblockId = ItemUtils.getItemId(this);
+	public String skyblocker$getSkyblockId() {
+		if (skyblocker$skyblockId != null && !skyblocker$skyblockId.isEmpty()) return skyblocker$skyblockId;
+		return skyblocker$skyblockId = ItemUtils.getItemId(this);
 	}
 
 	@Override
 	@NotNull
-	public String getSkyblockApiId() {
-		if (skyblockApiId != null && !skyblockApiId.isEmpty()) return skyblockApiId;
-		return skyblockApiId = ItemUtils.getSkyblockApiId(this);
+	public String skyblocker$getSkyblockApiId() {
+		if (skyblocker$skyblockApiId != null && !skyblocker$skyblockApiId.isEmpty()) return skyblocker$skyblockApiId;
+		return skyblocker$skyblockApiId = ItemUtils.getSkyblockApiId(this);
 	}
 
 	@Override
 	@NotNull
-	public String getNeuName() {
-		if (neuName != null && !neuName.isEmpty()) return neuName;
-		return neuName = ItemUtils.getNeuId((ItemStack) (Object) this);
+	public String skyblocker$getNeuName() {
+		if (skyblocker$neuName != null && !skyblocker$neuName.isEmpty()) return skyblocker$neuName;
+		return skyblocker$neuName = ItemUtils.getNeuId((ItemStack) (Object) this);
 	}
 
 	@Override
 	@NotNull
-	public String getUuid() {
-		if (uuid != null && !uuid.isEmpty()) return uuid;
-		return uuid = ItemUtils.getItemUuid(this);
+	public String skyblocker$getUuid() {
+		if (skyblocker$uuid != null && !skyblocker$uuid.isEmpty()) return skyblocker$uuid;
+		return skyblocker$uuid = ItemUtils.getItemUuid(this);
 	}
 
 	@Override
 	@NotNull
-	public PetInfo getPetInfo() {
-		if (petInfo != null) return petInfo;
-		return petInfo = ItemUtils.getPetInfo(this);
+	public PetInfo skyblocker$getPetInfo() {
+		if (skyblocker$petInfo != null) return skyblocker$petInfo;
+		return skyblocker$petInfo = ItemUtils.getPetInfo(this);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ItemStackMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ItemStackMixin.java
@@ -57,7 +57,7 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 	public abstract void setDamage(int damage);
 
 	@ModifyReturnValue(method = "getName", at = @At("RETURN"))
-	private Text skyblocker$customItemNames(Text original) {
+	private Text customItemNames(Text original) {
 		if (Utils.isOnSkyblock()) {
 			return SkyblockerConfigManager.get().general.customItemNames.getOrDefault(ItemUtils.getItemUuid(this), original);
 		}
@@ -66,7 +66,7 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 	}
 
 	@ModifyExpressionValue(method = "appendComponentTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/component/type/TooltipDisplayComponent;shouldDisplay(Lnet/minecraft/component/ComponentType;)Z"))
-	private boolean skyblocker$hideVanillaEnchants(boolean shouldDisplay, @Local TooltipAppender component) {
+	private boolean hideVanillaEnchants(boolean shouldDisplay, @Local TooltipAppender component) {
 		return shouldDisplay && !(Utils.isOnSkyblock() && component instanceof ItemEnchantmentsComponent);
 	}
 
@@ -74,7 +74,7 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 			slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/registry/DefaultedRegistry;getId(Ljava/lang/Object;)Lnet/minecraft/util/Identifier;")),
 			at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V", shift = At.Shift.AFTER, ordinal = 0)
 	)
-	private void skyblocker$skyblockIdTooltip(CallbackInfo ci, @Local(argsOnly = true) Consumer<Text> textConsumer) {
+	private void skyblockIdTooltip(CallbackInfo ci, @Local(argsOnly = true) Consumer<Text> textConsumer) {
 		if (Utils.isOnSkyblock()) {
 			String skyblockId = skyblocker$getSkyblockId();
 
@@ -88,51 +88,51 @@ public abstract class ItemStackMixin implements ComponentHolder, SkyblockerStack
 	 * Updates the durability of this item stack every tick when in the inventory.
 	 */
 	@Inject(method = "inventoryTick", at = @At("TAIL"))
-	private void skyblocker$updateDamage(CallbackInfo ci) {
-		if (!skyblocker$shouldProcess()) {
+	private void updateDamage(CallbackInfo ci) {
+		if (!shouldProcessCustomDurability()) {
 			return;
 		}
-		skyblocker$getAndCacheDurability();
+		getAndCacheDurability();
 	}
 
 	@ModifyReturnValue(method = "getDamage", at = @At("RETURN"))
-	private int skyblocker$handleDamage(int original) {
+	private int handleDamage(int original) {
 		// If the durability is already calculated, the original value should be the damage
-		if (!skyblocker$shouldProcess() || skyblocker$maxDamage != 0) {
+		if (!shouldProcessCustomDurability() || skyblocker$maxDamage != 0) {
 			return original;
 		}
-		return skyblocker$getAndCacheDurability() ? getDamage() : original;
+		return getAndCacheDurability() ? getDamage() : original;
 	}
 
 	@ModifyReturnValue(method = "getMaxDamage", at = @At("RETURN"))
-	private int skyblocker$handleMaxDamage(int original) {
-		if (!skyblocker$shouldProcess()) {
+	private int handleMaxDamage(int original) {
+		if (!shouldProcessCustomDurability()) {
 			return original;
 		}
 		// If the max damage is already calculated, return it
 		if (skyblocker$maxDamage != 0) {
 			return skyblocker$maxDamage;
 		}
-		return skyblocker$getAndCacheDurability() ? skyblocker$maxDamage : original;
+		return getAndCacheDurability() ? skyblocker$maxDamage : original;
 	}
 
 	@ModifyReturnValue(method = "isDamageable", at = @At("RETURN"))
-	private boolean skyblocker$handleDamageable(boolean original) {
-		return skyblocker$shouldProcess() || original;
+	private boolean handleDamageable(boolean original) {
+		return shouldProcessCustomDurability() || original;
 	}
 
 	@ModifyReturnValue(method = "isDamaged", at = @At("RETURN"))
-	private boolean skyblocker$handleDamaged(boolean original) {
-		return skyblocker$shouldProcess() || original;
+	private boolean handleDamaged(boolean original) {
+		return shouldProcessCustomDurability() || original;
 	}
 
 	@Unique
-	private boolean skyblocker$shouldProcess() { // Durability bar renders atop of tooltips in ProfileViewer so disable on this screen
+	private boolean shouldProcessCustomDurability() { // Durability bar renders atop of tooltips in ProfileViewer so disable on this screen
 		return !(MinecraftClient.getInstance() != null && MinecraftClient.getInstance().currentScreen instanceof ProfileViewerScreen) && Utils.isOnSkyblock() && SkyblockerConfigManager.get().mining.enableDrillFuel && ItemUtils.hasCustomDurability((ItemStack) (Object) this);
 	}
 
 	@Unique
-	private boolean skyblocker$getAndCacheDurability() {
+	private boolean getAndCacheDurability() {
 		// Calculate the durability
 		IntIntPair durability = ItemUtils.getDurability((ItemStack) (Object) this);
 		// Return if calculating the durability failed

--- a/src/main/java/de/hysky/skyblocker/mixins/LeverBlockMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/LeverBlockMixin.java
@@ -20,7 +20,7 @@ public abstract class LeverBlockMixin extends WallMountedBlock {
     }
 
     @Inject(method = "getOutlineShape", at = @At("HEAD"), cancellable = true)
-    public void skyblocker$onGetOutlineShape(CallbackInfoReturnable<VoxelShape> cir, @Local(argsOnly = true) BlockState state) {
+    public void onGetOutlineShape(CallbackInfoReturnable<VoxelShape> cir, @Local(argsOnly = true) BlockState state) {
         if (Utils.isOnSkyblock()) {
             VoxelShape shape = OldLever.getShape(state.get(FACE), state.get(FACING));
             if (shape != null) cir.setReturnValue(shape);

--- a/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MessageHandlerMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = MessageHandler.class, priority = 600) //Inject before the default of 1000 so it bypasses fabric's injections
 public class MessageHandlerMixin {
 	@Inject(method = "onGameMessage", at = @At("HEAD"))
-	private void skyblocker$monitorGameMessage(Text message, boolean overlay, CallbackInfo ci) {
+	private void monitorGameMessage(Text message, boolean overlay, CallbackInfo ci) {
 		if (overlay) return; //Can add overlay-specific events in the future or incorporate it into the existing events. For now, it's not necessary.
 		ChatEvents.RECEIVE_TEXT.invoker().onMessage(message);
 		ChatEvents.RECEIVE_STRING.invoker().onMessage(message.getString());

--- a/src/main/java/de/hysky/skyblocker/mixins/MinecraftClientMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MinecraftClientMixin.java
@@ -25,7 +25,7 @@ public abstract class MinecraftClientMixin {
     public ClientPlayerEntity player;
 
     @Inject(method = "handleInputEvents", at = @At("HEAD"))
-    public void skyblocker$handleInputEvents(CallbackInfo ci) {
+    public void handleInputEvents(CallbackInfo ci) {
         if (Utils.isOnSkyblock()) {
             HotbarSlotLock.handleInputEvents(player);
             ItemProtection.handleHotbarKeyPressed(player);
@@ -33,7 +33,7 @@ public abstract class MinecraftClientMixin {
     }
 
     @WrapOperation(method = "handleInputEvents", at = @At(value = "NEW", target = "Lnet/minecraft/client/gui/screen/ingame/InventoryScreen;"))
-    private InventoryScreen skyblocker$skyblockInventoryScreen(PlayerEntity player, Operation<InventoryScreen> original) {
+    private InventoryScreen skyblockInventoryScreen(PlayerEntity player, Operation<InventoryScreen> original) {
         return Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.showEquipmentInInventory ? new SkyblockInventoryScreen(player) : original.call(player);
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/MouseMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MouseMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 public class MouseMixin {
 
     @ModifyExpressionValue(method = "updateMouse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;", ordinal = 0))
-    public Object skyblocker$gardenMouseLock(Object original) {
+    public Object gardenMouseLock(Object original) {
         if (LowerSensitivity.isSensitivityLowered())
             return -1 / 3d;
         else return original;

--- a/src/main/java/de/hysky/skyblocker/mixins/MushroomPlantBlockMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MushroomPlantBlockMixin.java
@@ -16,7 +16,7 @@ public abstract class MushroomPlantBlockMixin extends Block {
 	protected static VoxelShape SHAPE;
 
 	@Unique
-	private static final VoxelShape OLD_SHAPE = Block.createCuboidShape(4.8, 0.0, 4.8, 11.2, 6.4, 11.2);
+	private static final VoxelShape skyblocker$OLD_SHAPE = Block.createCuboidShape(4.8, 0.0, 4.8, 11.2, 6.4, 11.2);
 
 	public MushroomPlantBlockMixin(Settings settings) {
 		super(settings);
@@ -24,7 +24,7 @@ public abstract class MushroomPlantBlockMixin extends Block {
 
 	@ModifyReturnValue(method = "getOutlineShape", at = @At("RETURN"))
 	private VoxelShape skyblocker$getOldMushroomOutline(VoxelShape original) {
-		return Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.hitbox.oldMushroomHitbox ? OLD_SHAPE : original;
+		return Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.hitbox.oldMushroomHitbox ? skyblocker$OLD_SHAPE : original;
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/mixins/MushroomPlantBlockMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/MushroomPlantBlockMixin.java
@@ -5,6 +5,7 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.block.*;
 import net.minecraft.util.shape.VoxelShape;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -12,8 +13,9 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(MushroomPlantBlock.class)
 public abstract class MushroomPlantBlockMixin extends Block {
+	@Final
 	@Shadow
-	protected static VoxelShape SHAPE;
+	private static VoxelShape SHAPE;
 
 	@Unique
 	private static final VoxelShape skyblocker$OLD_SHAPE = Block.createCuboidShape(4.8, 0.0, 4.8, 11.2, 6.4, 11.2);
@@ -23,7 +25,7 @@ public abstract class MushroomPlantBlockMixin extends Block {
 	}
 
 	@ModifyReturnValue(method = "getOutlineShape", at = @At("RETURN"))
-	private VoxelShape skyblocker$getOldMushroomOutline(VoxelShape original) {
+	private VoxelShape getOldMushroomOutline(VoxelShape original) {
 		return Utils.isOnSkyblock() && SkyblockerConfigManager.get().general.hitbox.oldMushroomHitbox ? skyblocker$OLD_SHAPE : original;
 	}
 

--- a/src/main/java/de/hysky/skyblocker/mixins/PingMeasurerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PingMeasurerMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public class PingMeasurerMixin {
 
     @ModifyArg(method = "onPingResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/MultiValueDebugSampleLogImpl;push(J)V"))
-    private long skyblocker$onPingResult(long ping) {
+    private long onPingResult(long ping) {
         if (Utils.isInCrimson()) {
             DojoManager.onPingResult(ping);
         }

--- a/src/main/java/de/hysky/skyblocker/mixins/PlayerInventoryMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PlayerInventoryMixin.java
@@ -15,7 +15,7 @@ public class PlayerInventoryMixin {
 	public int selectedSlot;
 
 	@Inject(method = "setSelectedSlot", at = @At("TAIL"))
-	private void skyblocker$onHotbarScroll(CallbackInfo ci) {
+	private void onHotbarScroll(CallbackInfo ci) {
 		ArrowPoisonWarning.tryWarn(selectedSlot);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/PlayerListHudMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PlayerListHudMixin.java
@@ -12,7 +12,7 @@ import net.minecraft.client.gui.hud.PlayerListHud;
 public class PlayerListHudMixin {
 
 	@Inject(method = "renderLatencyIcon", at = @At("HEAD"), cancellable = true)
-	private void skyblocker$hideLatencyIcon(CallbackInfo ci) {
+	private void hideLatencyIcon(CallbackInfo ci) {
 		if (Utils.isOnSkyblock()) ci.cancel();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinProviderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinProviderMixin.java
@@ -12,7 +12,7 @@ import de.hysky.skyblocker.utils.Utils;
 public class PlayerSkinProviderMixin {
 
 	@WrapWithCondition(method = "method_54647", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;)V", remap = false))
-	private static boolean skyblocker$dontLogInvalidSignatureWarnings(Logger logger, String message, Object profileId) {
+	private static boolean dontLogInvalidSignatureWarnings(Logger logger, String message, Object profileId) {
 		return !Utils.isOnHypixel();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinTextureDownloaderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinTextureDownloaderMixin.java
@@ -33,7 +33,7 @@ public class PlayerSkinTextureDownloaderMixin {
 	private static final float skyblocker$BRIGHTNESS_THRESHOLD = 0.1f;
 
 	@Inject(method = "remapTexture", at = @At("HEAD"))
-	private static void skyblocker$determineSkinSource(NativeImage image, String uri, CallbackInfoReturnable<NativeImage> cir, @Share("isSkyblockSkinTexture") LocalBooleanRef isSkyblockSkinTexture) {
+	private static void determineSkinSource(NativeImage image, String uri, CallbackInfoReturnable<NativeImage> cir, @Share("isSkyblockSkinTexture") LocalBooleanRef isSkyblockSkinTexture) {
 		if (SkyblockerConfigManager.get().uiAndVisuals.dontStripSkinAlphaValues && (Utils.isOnSkyblock() || MinecraftClient.getInstance().currentScreen instanceof ProfileViewerScreen)) {
 			String skinTextureHash = PlayerHeadHashCache.getSkinHash(uri);
 			int skinHash = skinTextureHash.hashCode();
@@ -47,7 +47,7 @@ public class PlayerSkinTextureDownloaderMixin {
 	}
 
 	@WrapWithCondition(method = "remapTexture", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/texture/PlayerSkinTextureDownloader;stripAlpha(Lnet/minecraft/client/texture/NativeImage;IIII)V"))
-	private static boolean skyblocker$dontStripAlphaValues(NativeImage image, int x1, int y1, int x2, int y2, @Share("isSkyblockSkinTexture") LocalBooleanRef isSkyblockSkinTexture) {
+	private static boolean dontStripAlphaValues(NativeImage image, int x1, int y1, int x2, int y2, @Share("isSkyblockSkinTexture") LocalBooleanRef isSkyblockSkinTexture) {
 		return !isSkyblockSkinTexture.get();
 	}
 

--- a/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinTextureDownloaderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PlayerSkinTextureDownloaderMixin.java
@@ -25,12 +25,12 @@ import net.minecraft.util.math.ColorHelper;
 @Mixin(PlayerSkinTextureDownloader.class)
 public class PlayerSkinTextureDownloaderMixin {
 	@Unique
-	private static final Set<String> STRIP_DE_FACTO_TRANSPARENT_PIXELS = Set.of(
+	private static final Set<String> skyblocker$STRIP_DE_FACTO_TRANSPARENT_PIXELS = Set.of(
 			"4f3b91b6aa7124f30ed4ad1b2bb012a82985a33640555e18e792f96af8f58ec6", /*Titanium Necklace*/
 			"49821410631186c6f3fbbae5f0ef5b947f475eb32027a8aad0a456512547c209", /*Titanium Cloak*/
 			"4162303bcdd770aebe7fd19fa26371390a7515140358548084361b5056cdc4e6" /*Titanium Belt*/);
 	@Unique
-	private static final float BRIGHTNESS_THRESHOLD = 0.1f;
+	private static final float skyblocker$BRIGHTNESS_THRESHOLD = 0.1f;
 
 	@Inject(method = "remapTexture", at = @At("HEAD"))
 	private static void skyblocker$determineSkinSource(NativeImage image, String uri, CallbackInfoReturnable<NativeImage> cir, @Share("isSkyblockSkinTexture") LocalBooleanRef isSkyblockSkinTexture) {
@@ -40,7 +40,7 @@ public class PlayerSkinTextureDownloaderMixin {
 			isSkyblockSkinTexture.set(PlayerHeadHashCache.contains(skinHash));
 
 			//Hypixel had the grand idea of using black pixels in place of actual transparent pixels on the titanium equipment so here we go!
-			if (STRIP_DE_FACTO_TRANSPARENT_PIXELS.contains(skinTextureHash)) {
+			if (skyblocker$STRIP_DE_FACTO_TRANSPARENT_PIXELS.contains(skinTextureHash)) {
 				stripDeFactoTransparentPixels(image);
 			}
 		}
@@ -62,7 +62,7 @@ public class PlayerSkinTextureDownloaderMixin {
 				float[] hsb = Color.RGBtoHSB((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF, null);
 
 				//Work around "fake" transparent pixels - Thanks Hypixel I totally appreciate this!
-				if (hsb[2] <= BRIGHTNESS_THRESHOLD) image.setColorArgb(x, y, ColorHelper.withAlpha(0x00, color & 0x00FFFFFF));
+				if (hsb[2] <= skyblocker$BRIGHTNESS_THRESHOLD) image.setColorArgb(x, y, ColorHelper.withAlpha(0x00, color & 0x00FFFFFF));
 			}
 		}
 	}

--- a/src/main/java/de/hysky/skyblocker/mixins/RenderFishMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/RenderFishMixin.java
@@ -15,9 +15,9 @@ import com.llamalad7.mixinextras.sugar.Local;
 @Mixin(FishingBobberEntityRenderer.class)
 public abstract class RenderFishMixin {
 
-    @ModifyReturnValue(method = "shouldRender", at = @At("RETURN"))
-    private boolean skyblocker$render(boolean original, @Local(argsOnly = true) FishingBobberEntity fishingBobberEntity) {
-        //if rendered bobber is not the players and option to hide  others is enabled do not render the bobber
+    @ModifyReturnValue(method = "shouldRender(Lnet/minecraft/entity/projectile/FishingBobberEntity;Lnet/minecraft/client/render/Frustum;DDD)Z", at = @At("RETURN"))
+    private boolean hideOtherPlayerBobbers(boolean original, @Local(argsOnly = true) FishingBobberEntity fishingBobberEntity) {
+        //if rendered bobber is not the players and option to hide others is enabled do not render the bobber
         return Utils.isOnSkyblock() && SkyblockerConfigManager.get().helpers.fishing.hideOtherPlayersRods
 				? original && Objects.equals(MinecraftClient.getInstance().player, fishingBobberEntity.getPlayerOwner())
 				: original;

--- a/src/main/java/de/hysky/skyblocker/mixins/RenderPipelineMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/RenderPipelineMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.client.gl.RenderPipelines;
 public class RenderPipelineMixin {
 
 	@ModifyReturnValue(method = "getDepthTestFunction", at = @At("RETURN"))
-	private DepthTestFunction skyblocker$modifyGlowDepthTest(DepthTestFunction original) {
+	private DepthTestFunction modifyGlowDepthTest(DepthTestFunction original) {
 		return ((Object) this == RenderPipelines.OUTLINE_CULL || (Object) this == RenderPipelines.OUTLINE_NO_CULL) && MobGlow.atLeastOneMobHasCustomGlow() ? DepthTestFunction.LEQUAL_DEPTH_TEST : original;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ScoreboardMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ScoreboardMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(Scoreboard.class)
 public abstract class ScoreboardMixin {
     @WrapWithCondition(method = "addTeam", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;)V", remap = false))
-    private boolean skyblocker$cancelTeamWarning(Logger instance, String format, Object arg) {
+    private boolean cancelTeamWarning(Logger instance, String format, Object arg) {
         return !Utils.isOnHypixel();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ScreenHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ScreenHandlerMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ScreenHandler.class)
 public class ScreenHandlerMixin {
 	@Inject(method = "setStackInSlot", at = @At("HEAD"))
-	private void onSetStackInSlot(int slot, int revision, ItemStack stack, CallbackInfo ci) {
+	private void updateInventory(int slot, int revision, ItemStack stack, CallbackInfo ci) {
 		if (InventorySearch.isSearching()) {
 			InventorySearch.refreshSlot(slot);
 		}

--- a/src/main/java/de/hysky/skyblocker/mixins/ScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ScreenMixin.java
@@ -20,7 +20,7 @@ public class ScreenMixin {
 	protected MinecraftClient client;
 
 	@Inject(method = "init(Lnet/minecraft/client/MinecraftClient;II)V", at = @At("TAIL"))
-	private void skyblocker$hideCursor(CallbackInfo ci) {
+	private void hideCursor(CallbackInfo ci) {
 		Object instance = (Object) this;
 
 		if ((instance instanceof DownloadingTerrainScreen || instance instanceof ReconfiguringScreen) && Utils.isOnHypixel()) {
@@ -30,7 +30,7 @@ public class ScreenMixin {
 	}
 
 	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
-	private void skyblocker$hideReconfiguringScreen(CallbackInfo ci) {
+	private void hideReconfiguringScreen(CallbackInfo ci) {
 		if ((Object) this instanceof ReconfiguringScreen && Utils.isOnHypixel()) ci.cancel();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
@@ -36,7 +36,7 @@ public abstract class SignEditScreenMixin extends Screen {
 	}
 
 	@Inject(method = "render", at = @At("HEAD"))
-    private void skyblocker$render(CallbackInfo ci, @Local(argsOnly = true) DrawContext context) {
+    private void render(CallbackInfo ci, @Local(argsOnly = true) DrawContext context) {
 		if (Utils.isOnSkyblock()) {
 			var config = SkyblockerConfigManager.get();
 			if (messages[1].equals("^^^^^^") && config.general.speedPresets.enableSpeedPresets) {
@@ -54,14 +54,14 @@ public abstract class SignEditScreenMixin extends Screen {
     }
 
 	@Inject(method = "keyPressed", at = @At("HEAD"))
-	private void skyblocker$keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+	private void closeWIthEnter(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
 		if (SkyblockerConfigManager.get().uiAndVisuals.inputCalculator.closeSignsWithEnter
 				&& Utils.isOnSkyblock() && isInputSign()
 				&& (keyCode == InputUtil.GLFW_KEY_ENTER || keyCode == InputUtil.GLFW_KEY_KP_ENTER)) this.close();
 	}
 
     @Inject(method = "finishEditing", at = @At("HEAD"))
-    private void skyblocker$finishEditing(CallbackInfo ci) {
+    private void modifyMessage(CallbackInfo ci) {
 		var config = SkyblockerConfigManager.get();
         if (Utils.isOnSkyblock()) {
 			//if the sign is being used to enter the speed cap, retrieve the value from speed presets.

--- a/src/main/java/de/hysky/skyblocker/mixins/SocialInteractionsPlayerListWidgetMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/SocialInteractionsPlayerListWidgetMixin.java
@@ -15,7 +15,7 @@ import net.minecraft.client.gui.screen.multiplayer.SocialInteractionsPlayerListW
 public class SocialInteractionsPlayerListWidgetMixin {
 
 	@WrapWithCondition(method = "setPlayers", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
-	private boolean skyblocker$hideInvalidPlayers(Map<Object, Object> map, Object uuid, Object entry) {
+	private boolean hideInvalidPlayers(Map<Object, Object> map, Object uuid, Object entry) {
 		return !(Utils.isOnSkyblock() && !((SocialInteractionsPlayerListEntry) entry).getName().matches("[A-Za-z0-9_]+"));
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/WindowMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/WindowMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Window.class)
 public class WindowMixin {
     @Inject(method = "setScaleFactor", at = @At("TAIL"))
-    public void skyblocker$onScaleFactorChange(CallbackInfo ci) {
+    public void onScaleFactorChange(CallbackInfo ci) {
         FancyStatusBars.updatePositions();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/WorldRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/WorldRendererMixin.java
@@ -35,7 +35,7 @@ public class WorldRendererMixin {
 	private DefaultFramebufferSet framebufferSet;
 
 	@ModifyExpressionValue(method = {"getEntitiesToRender", "renderEntities"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"), require = 2)
-	private boolean skyblocker$shouldMobGlow(boolean original, @Local Entity entity) {
+	private boolean shouldMobGlow(boolean original, @Local Entity entity) {
 		boolean allowGlow = LividColor.allowGlow();
 		boolean customGlow = MobGlow.hasOrComputeMobGlow(entity);
 		return allowGlow && original || customGlow;
@@ -45,7 +45,7 @@ public class WorldRendererMixin {
 			slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;canDrawEntityOutlines()Z")),
 			at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/CommandEncoder;clearColorAndDepthTextures(Lcom/mojang/blaze3d/textures/GpuTexture;ILcom/mojang/blaze3d/textures/GpuTexture;D)V", ordinal = 0, shift = At.Shift.AFTER)
 	)
-	private void skyblocker$copyFramebufferDepth2AdjustGlowVisibility(CallbackInfo ci, @Share(namespace = "c", value = "copiedOutlineDepth") LocalBooleanRef copiedOutlineDepth) {
+	private void copyFramebufferDepth2AdjustGlowVisibility(CallbackInfo ci, @Share(namespace = "c", value = "copiedOutlineDepth") LocalBooleanRef copiedOutlineDepth) {
 		if (MobGlow.atLeastOneMobHasCustomGlow() && !copiedOutlineDepth.get()) {
 			framebufferSet.entityOutlineFramebuffer.get().copyDepthFrom(client.getFramebuffer());
 			//Ensures that the depth isn't copied multiple times with other mods since copying it multiple times just wastes performance
@@ -57,12 +57,12 @@ public class WorldRendererMixin {
 			slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"), to = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/OutlineVertexConsumerProvider;setColor(IIII)V")),
 			at = @At("STORE"), ordinal = 0
 	)
-	private int skyblocker$modifyGlowColor(int color, @Local Entity entity) {
+	private int modifyGlowColor(int color, @Local Entity entity) {
 		return MobGlow.getMobGlowOrDefault(entity, color);
 	}
 
 	@Inject(method = "renderEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;renderEntity(Lnet/minecraft/entity/Entity;DDDFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;)V"))
-	private void skyblocker$renderMobBoundingBox(CallbackInfo ci, @Local Entity entity) {
+	private void renderMobBoundingBox(CallbackInfo ci, @Local Entity entity) {
 		boolean shouldShowBoundingBox = MobBoundingBoxes.shouldDrawMobBoundingBox(entity);
 
 		if (shouldShowBoundingBox) {

--- a/src/main/java/de/hysky/skyblocker/mixins/YggdrasilMinecraftSessionServiceMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/YggdrasilMinecraftSessionServiceMixin.java
@@ -14,7 +14,7 @@ public class YggdrasilMinecraftSessionServiceMixin {
 
 	//TODO perhaps investigate if we could fix this
 	@WrapWithCondition(method = "unpackTextures", remap = false, at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;Ljava/lang/Throwable;)V", ordinal = 0, remap = false))
-	private boolean skyblocker$dontLogIncorrectEndingByteExceptions(Logger logger, String message, Throwable throwable) {
+	private boolean dontLogIncorrectEndingByteExceptions(Logger logger, String message, Throwable throwable) {
 		return !Utils.isOnHypixel() && throwable instanceof IllegalArgumentException;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/YggdrasilServicesKeyInfoMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/YggdrasilServicesKeyInfoMixin.java
@@ -24,9 +24,9 @@ public class YggdrasilServicesKeyInfoMixin {
     @Final
     private static Logger LOGGER;
     @Unique
-    private static final Map<String, String> REPLACEMENT_MAP = Map.of();
+    private static final Map<String, String> skyblocker$REPLACEMENT_MAP = Map.of();
     @Unique
-    private static final IntList ERRONEUS_SIGNATURE_HASHES = new IntArrayList();
+    private static final IntList skyblocker$ERRONEUS_SIGNATURE_HASHES = new IntArrayList();
 
     @WrapOperation(method = "validateProperty", at = @At(value = "INVOKE", target = "Ljava/util/Base64$Decoder;decode(Ljava/lang/String;)[B", remap = false), remap = false)
     private byte[] skyblocker$replaceKnownWrongBase64(Base64.Decoder decoder, String signature, Operation<byte[]> decode) {
@@ -37,15 +37,15 @@ public class YggdrasilServicesKeyInfoMixin {
                 return decode.call(decoder, signature.replaceAll("[^A-Za-z0-9+/=]", ""));
             } catch (IllegalArgumentException e2) {
                 if (Utils.isOnSkyblock()) {
-                    if (REPLACEMENT_MAP.containsKey(signature)) {
-                        return decode.call(decoder, REPLACEMENT_MAP.get(signature));
+                    if (skyblocker$REPLACEMENT_MAP.containsKey(signature)) {
+                        return decode.call(decoder, skyblocker$REPLACEMENT_MAP.get(signature));
                     }
                     int signatureHashCode = signature.hashCode();
-                    if (!ERRONEUS_SIGNATURE_HASHES.contains(signatureHashCode)) {
-                    	ERRONEUS_SIGNATURE_HASHES.add(signatureHashCode);
-                        LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode base64 string No.{}: {}", ERRONEUS_SIGNATURE_HASHES.size() - 1, signature);
+                    if (!skyblocker$ERRONEUS_SIGNATURE_HASHES.contains(signatureHashCode)) {
+						skyblocker$ERRONEUS_SIGNATURE_HASHES.add(signatureHashCode);
+                        LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode base64 string No.{}: {}", skyblocker$ERRONEUS_SIGNATURE_HASHES.size() - 1, signature);
                     } else {
-                        LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode the base64 string No.{} again", ERRONEUS_SIGNATURE_HASHES.indexOf(signatureHashCode));
+                        LOGGER.warn("[Skyblocker Base64 Fixer] Failed to decode the base64 string No.{} again", skyblocker$ERRONEUS_SIGNATURE_HASHES.indexOf(signatureHashCode));
                     }
                 }
             }

--- a/src/main/java/de/hysky/skyblocker/mixins/YggdrasilServicesKeyInfoMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/YggdrasilServicesKeyInfoMixin.java
@@ -29,7 +29,7 @@ public class YggdrasilServicesKeyInfoMixin {
     private static final IntList skyblocker$ERRONEUS_SIGNATURE_HASHES = new IntArrayList();
 
     @WrapOperation(method = "validateProperty", at = @At(value = "INVOKE", target = "Ljava/util/Base64$Decoder;decode(Ljava/lang/String;)[B", remap = false), remap = false)
-    private byte[] skyblocker$replaceKnownWrongBase64(Base64.Decoder decoder, String signature, Operation<byte[]> decode) {
+    private byte[] replaceKnownWrongBase64(Base64.Decoder decoder, String signature, Operation<byte[]> decode) {
         try {
             return decode.call(decoder, signature);
         } catch (IllegalArgumentException e) {
@@ -54,7 +54,7 @@ public class YggdrasilServicesKeyInfoMixin {
     }
 
     @WrapWithCondition(method = "validateProperty", remap = false, at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false))
-    private boolean skyblocker$dontLogFailedSignatureValidations(Logger logger, String message, Object property, Object exception) {
+    private boolean dontLogFailedSignatureValidations(Logger logger, String message, Object property, Object exception) {
         return !Utils.isOnHypixel();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/discordipc/ConnectionMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/discordipc/ConnectionMixin.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 @Mixin(value = {UnixConnection.class, WinConnection.class}, remap = false)
 public class ConnectionMixin {
     @Redirect(method = "write", at = @At(value = "INVOKE", target = "Ljava/io/IOException;printStackTrace()V"))
-    private void write(IOException e) {
+    private void disconnectOnError(IOException e) {
         DiscordIPC.stop();
         DiscordRPCManager.LOGGER.warn("[Skyblocker] Discord RPC failed to update activity, connection lost", e);
     }

--- a/src/main/java/de/hysky/skyblocker/mixins/jgit/SystemReaderMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/jgit/SystemReaderMixin.java
@@ -10,7 +10,7 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 public class SystemReaderMixin {
 
 	@ModifyReturnValue(method = "getenv", at = @At("RETURN"))
-	private String skyblocker$blockLoadingSystemGitConfig(String original, String variable) {
+	private String blockLoadingSystemGitConfig(String original, String variable) {
 		return variable.equals(Constants.GIT_CONFIG_NOSYSTEM_KEY) ? "FORCE-ENABLE" : original;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/jgit/UrlConfigMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/jgit/UrlConfigMixin.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 public class UrlConfigMixin {
 
 	@WrapOperation(method = "load", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
-	private Object skyblocker$ignoreUrlRedirects(Map<String, String> map, Object key, Object value, Operation<Object> operation) {
+	private Object ignoreUrlRedirects(Map<String, String> map, Object key, Object value, Operation<Object> operation) {
 		return null;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/ChestValue.java
@@ -101,7 +101,7 @@ public class ChestValue {
 				}
 
 				String name = stack.getName().getString();
-				String skyblockApiId = stack.getSkyblockApiId();
+				String skyblockApiId = stack.skyblocker$getSkyblockApiId();
 
 				//Regular item price
 				if (!skyblockApiId.isEmpty()) {
@@ -195,7 +195,7 @@ public class ChestValue {
 					continue;
 				}
 
-				String id = stack.getSkyblockApiId();
+				String id = stack.skyblocker$getSkyblockApiId();
 
 				int count = switch (screenType) {
 					case SACK -> {

--- a/src/main/java/de/hysky/skyblocker/skyblock/ItemPickupWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/ItemPickupWidget.java
@@ -84,17 +84,17 @@ public class ItemPickupWidget extends ComponentBasedWidget {
 			//positive
 			int existingCount = 0;
 			if (matcher.group(1).equals("+")) {
-				if (addedCount.containsKey(item.getNeuName())) {
-					existingCount = addedCount.get(item.getNeuName()).amount;
+				if (addedCount.containsKey(item.skyblocker$getNeuName())) {
+					existingCount = addedCount.get(item.skyblocker$getNeuName()).amount;
 				}
-				addedCount.put(item.getNeuName(), new ChangeData(item, existingCount + Formatters.parseNumber(matcher.group(2)).intValue(), System.currentTimeMillis()));
+				addedCount.put(item.skyblocker$getNeuName(), new ChangeData(item, existingCount + Formatters.parseNumber(matcher.group(2)).intValue(), System.currentTimeMillis()));
 			}
 			//negative
 			else if (matcher.group(1).equals("-")) {
-				if (removedCount.containsKey(item.getNeuName())) {
-					existingCount = removedCount.get(item.getNeuName()).amount;
+				if (removedCount.containsKey(item.skyblocker$getNeuName())) {
+					existingCount = removedCount.get(item.skyblocker$getNeuName()).amount;
 				}
-				removedCount.put(item.getNeuName(), new ChangeData(item, existingCount - Formatters.parseNumber(matcher.group(2)).intValue(), System.currentTimeMillis()));
+				removedCount.put(item.skyblocker$getNeuName(), new ChangeData(item, existingCount - Formatters.parseNumber(matcher.group(2)).intValue(), System.currentTimeMillis()));
 			}
 		}
 	}
@@ -205,29 +205,29 @@ public class ItemPickupWidget extends ComponentBasedWidget {
 				return;
 			}
 
-			if (removedCount.containsKey(oldStack.getNeuName())) {
-				existingCount = removedCount.get(oldStack.getNeuName()).amount;
+			if (removedCount.containsKey(oldStack.skyblocker$getNeuName())) {
+				existingCount = removedCount.get(oldStack.skyblocker$getNeuName()).amount;
 			}
-			removedCount.put(oldStack.getNeuName(), new ChangeData(oldStack, existingCount - oldStack.getCount(), System.currentTimeMillis()));
+			removedCount.put(oldStack.skyblocker$getNeuName(), new ChangeData(oldStack, existingCount - oldStack.getCount(), System.currentTimeMillis()));
 			return;
 		}
 
 		//if there are more items than before
 		if (countDiff > 0) {
 			//see if there is already a change for this type of item
-			if (addedCount.containsKey(newStack.getNeuName())) {
-				existingCount = addedCount.get(newStack.getNeuName()).amount;
+			if (addedCount.containsKey(newStack.skyblocker$getNeuName())) {
+				existingCount = addedCount.get(newStack.skyblocker$getNeuName()).amount;
 			}
-			addedCount.put(newStack.getNeuName(), new ChangeData(newStack, existingCount + countDiff, System.currentTimeMillis()));
+			addedCount.put(newStack.skyblocker$getNeuName(), new ChangeData(newStack, existingCount + countDiff, System.currentTimeMillis()));
 
 		}
 		//if there are fewer items than before
 		else if (countDiff < 0) {
 			//see if there is already a change for this type of item
-			if (removedCount.containsKey(newStack.getNeuName())) {
-				existingCount = removedCount.get(newStack.getNeuName()).amount;
+			if (removedCount.containsKey(newStack.skyblocker$getNeuName())) {
+				existingCount = removedCount.get(newStack.skyblocker$getNeuName()).amount;
 			}
-			removedCount.put(newStack.getNeuName(), new ChangeData(newStack, existingCount + countDiff, System.currentTimeMillis()));
+			removedCount.put(newStack.skyblocker$getNeuName(), new ChangeData(newStack, existingCount + countDiff, System.currentTimeMillis()));
 		}
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/PetCache.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/PetCache.java
@@ -90,9 +90,9 @@ public class PetCache {
 	private static void parsePet(ItemStack stack, boolean clicked) {
 		String profileId = Utils.getProfileId();
 
-		if (stack.getSkyblockId().equals("PET") && !profileId.isEmpty()) {
+		if (stack.skyblocker$getSkyblockId().equals("PET") && !profileId.isEmpty()) {
 			//I once hoped that all pets would have a petInfo field, but that turned out to be false ;(
-			PetInfo petInfo = stack.getPetInfo();
+			PetInfo petInfo = stack.skyblocker$getPetInfo();
 
 			//This probably shouldn't happen since I would imagine pets inside of a pet menu would have a pet info but you never know...
 			if (petInfo.isEmpty()) return;
@@ -165,7 +165,7 @@ public class PetCache {
 					copied.set(DataComponentTypes.CUSTOM_DATA, NbtComponent.of(customData));
 
 					//If the pet from the NEU repo is missing the data then try to guess the type
-					String type = !copied.getPetInfo().isEmpty() ? copied.getPetInfo().type() : name.toUpperCase(Locale.ENGLISH).replace(" ", "_");
+					String type = !copied.skyblocker$getPetInfo().isEmpty() ? copied.skyblocker$getPetInfo().type() : name.toUpperCase(Locale.ENGLISH).replace(" ", "_");
 					PetInfo petInfo = new PetInfo(type, exp, rarity, Optional.empty(), Optional.empty(), Optional.empty());
 
 					CACHED_PETS.put(petInfo);

--- a/src/main/java/de/hysky/skyblocker/skyblock/SmoothAOTE.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/SmoothAOTE.java
@@ -1,6 +1,5 @@
 package de.hysky.skyblocker.skyblock;
 
-import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.dungeon.DungeonBoss;
@@ -172,7 +171,7 @@ public class SmoothAOTE {
 
 		//work out if the player is holding a teleporting item that is enabled and if so how far the item will take them
 		ItemStack heldItem = CLIENT.player.getMainHandStack();
-		String itemId = heldItem.getSkyblockId();
+		String itemId = heldItem.skyblocker$getSkyblockId();
 		NbtCompound customData = ItemUtils.getCustomData(heldItem);
 
 		int distance;

--- a/src/main/java/de/hysky/skyblocker/skyblock/TeleportOverlay.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/TeleportOverlay.java
@@ -31,7 +31,7 @@ public class TeleportOverlay {
     private static void render(WorldRenderContext wrc) {
         if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.teleportOverlay.enableTeleportOverlays && client.player != null && client.world != null) {
             ItemStack heldItem = client.player.getMainHandStack();
-            String itemId = heldItem.getSkyblockId();
+            String itemId = heldItem.skyblocker$getSkyblockId();
             NbtCompound customData = ItemUtils.getCustomData(heldItem);
 
             switch (itemId) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/auction/AuctionBrowserScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/auction/AuctionBrowserScreen.java
@@ -295,7 +295,7 @@ public class AuctionBrowserScreen extends AbstractCustomHypixelGUI<AuctionHouseS
                             String coins = split[1].replace(",", "").replace("coins", "").trim();
                             try {
                                 long parsed = Long.parseLong(coins);
-                                double price = TooltipInfoType.THREE_DAY_AVERAGE.getData().getDouble(stack.getNeuName());
+                                double price = TooltipInfoType.THREE_DAY_AVERAGE.getData().getDouble(stack.skyblocker$getNeuName());
                                 isSlotHighlighted.put(slotId, price > parsed);
                             } catch (Exception e) {
                                 LOGGER.error("[Skyblocker Fancy Auction House] Failed to parse BIN price", e);

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/dojo/DisciplineTestHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/dojo/DisciplineTestHelper.java
@@ -41,7 +41,7 @@ public class DisciplineTestHelper {
         if (CLIENT == null || CLIENT.player == null) {
             return false;
         }
-        String heldId = CLIENT.player.getMainHandStack().getSkyblockId();
+        String heldId = CLIENT.player.getMainHandStack().skyblocker$getSkyblockId();
         return Objects.equals(SWORD_TO_NAME_LOOKUP.get(heldId), name);
     }
 
@@ -54,7 +54,7 @@ public class DisciplineTestHelper {
         if (DojoManager.currentChallenge != DojoManager.DojoChallenges.DISCIPLINE || CLIENT == null || CLIENT.player == null) {
             return 0;
         }
-        String heldId = CLIENT.player.getMainHandStack().getSkyblockId();
+        String heldId = CLIENT.player.getMainHandStack().skyblocker$getSkyblockId();
         return SWORD_TO_COLOR_LOOKUP.getOrDefault(heldId, 0);
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/WishingCompassSolver.java
@@ -118,7 +118,7 @@ public class WishingCompassSolver {
     }
 
     private static boolean isKeyInInventory() {
-        return CLIENT.player != null && CLIENT.player.getInventory().getMainStacks().stream().anyMatch(stack -> stack != null && stack.getSkyblockId().equals("JUNGLE_KEY"));
+        return CLIENT.player != null && CLIENT.player.getInventory().getMainStacks().stream().anyMatch(stack -> stack != null && stack.skyblocker$getSkyblockId().equals("JUNGLE_KEY"));
     }
 
     private static Zone getZoneOfLocation(Vec3d location) {
@@ -288,7 +288,7 @@ public class WishingCompassSolver {
         }
         ItemStack stack = CLIENT.player.getStackInHand(hand);
         //make sure the user is in the crystal hollows and holding the wishing compass
-        if (!Utils.isInCrystalHollows() || !SkyblockerConfigManager.get().mining.crystalsWaypoints.wishingCompassSolver || !stack.getSkyblockId().equals("WISHING_COMPASS")) {
+        if (!Utils.isInCrystalHollows() || !SkyblockerConfigManager.get().mining.crystalsWaypoints.wishingCompassSolver || !stack.skyblocker$getSkyblockId().equals("WISHING_COMPASS")) {
             return ActionResult.PASS;
         }
         if (useCompass()) {
@@ -304,7 +304,7 @@ public class WishingCompassSolver {
         }
         ItemStack stack = CLIENT.player.getStackInHand(hand);
         //make sure the user is in the crystal hollows and holding the wishing compass
-        if (!Utils.isInCrystalHollows() || !SkyblockerConfigManager.get().mining.crystalsWaypoints.wishingCompassSolver || !stack.getSkyblockId().equals("WISHING_COMPASS")) {
+        if (!Utils.isInCrystalHollows() || !SkyblockerConfigManager.get().mining.crystalsWaypoints.wishingCompassSolver || !stack.skyblocker$getSkyblockId().equals("WISHING_COMPASS")) {
             return ActionResult.PASS;
         }
         if (useCompass()) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
@@ -113,7 +113,7 @@ public class GardenPlotsWidget extends ContainerWidget {
 						((HandledScreenAccessor) inventoryScreen).getY());
 				Screens.getButtons(inventoryScreen).add(widget);
 
-				((RecipeBookHolder) inventoryScreen).registerRecipeBookToggleCallback(() -> widget.setPosition(
+				((RecipeBookHolder) inventoryScreen).skyblocker$registerRecipeBookToggleCallback(() -> widget.setPosition(
 						((HandledScreenAccessor) inventoryScreen).getX() + ((HandledScreenAccessor) inventoryScreen).getBackgroundWidth() + 4,
 						((HandledScreenAccessor) inventoryScreen).getY()
 				));

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ConsumableProtection.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ConsumableProtection.java
@@ -26,7 +26,7 @@ public class ConsumableProtection {
 	private static ActionResult onInteract(PlayerEntity player, World world, Hand hand) {
 		if (world.isClient() && SkyblockerConfigManager.get().general.itemProtection.protectValuableConsumables && Utils.isOnSkyblock()) {
 			ItemStack stack = player.getStackInHand(hand);
-			String skyblockId = stack.getSkyblockId();
+			String skyblockId = stack.skyblocker$getSkyblockId();
 
 			if (!skyblockId.isEmpty() && PROTECTED_CONSUMABLES.contains(skyblockId)) {
 				return ActionResult.FAIL;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
@@ -52,13 +52,13 @@ public class ItemPrice {
 
     public static void itemPriceLookup(ClientPlayerEntity player, @NotNull Slot slot) {
         ItemStack stack = slot.getStack();
-        String skyblockApiId = stack.getSkyblockApiId();
-        ItemStack neuStack = ItemRepository.getItemStack(stack.getNeuName());
+        String skyblockApiId = stack.skyblocker$getSkyblockApiId();
+        ItemStack neuStack = ItemRepository.getItemStack(stack.skyblocker$getNeuName());
         if (neuStack != null && !neuStack.isEmpty()) {
             String itemName = Formatting.strip(neuStack.getName().getString());
 
             // Handle Pets
-            if (stack.getSkyblockId().equals("PET")) {
+            if (stack.skyblocker$getSkyblockId().equals("PET")) {
                 itemName = itemName.replaceFirst("\\[Lvl \\d+ ➡ \\d+] ", "");
             }
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/background/adders/ItemRarityBackground.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/background/adders/ItemRarityBackground.java
@@ -53,10 +53,10 @@ public class ItemRarityBackground extends ColoredItemBackground<SkyblockItemRari
 	protected SkyblockItemRarity getColorKey(ItemStack stack, Int2ReferenceOpenHashMap<SkyblockItemRarity> cache) {
 		if (stack == null || stack.isEmpty()) return null;
 
-		int hashCode = stack.getUuid().isEmpty() ? System.identityHashCode(stack) : stack.getUuid().hashCode();
+		int hashCode = stack.skyblocker$getUuid().isEmpty() ? System.identityHashCode(stack) : stack.skyblocker$getUuid().hashCode();
 		if (cache.containsKey(hashCode)) return cache.get(hashCode);
 
-		if (!stack.getSkyblockId().equals("PET")) {
+		if (!stack.skyblocker$getSkyblockId().equals("PET")) {
 			List<Text> lore = ItemUtils.getLore(stack);
 			List<String> tooltip = lore.stream().map(Text::getString).toList();
 			for (String key : LORE_RARITIES.keySet()) {
@@ -67,7 +67,7 @@ public class ItemRarityBackground extends ColoredItemBackground<SkyblockItemRari
 				}
 			}
 		} else {
-			PetInfo info = stack.getPetInfo();
+			PetInfo info = stack.skyblocker$getPetInfo();
 			if (!info.isEmpty()) {
 				SkyblockItemRarity rarity = info.item().isPresent() && info.item().get().equals("PET_ITEM_TIER_BOOST") ? info.rarity().next() : info.rarity();
 				cache.put(hashCode, rarity);

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/background/adders/JacobMedalBackground.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/background/adders/JacobMedalBackground.java
@@ -37,7 +37,7 @@ public class JacobMedalBackground extends ColoredItemBackground<Integer> {
 			return null;
 		}
 
-		int hashCode = stack.getUuid().isEmpty() ? System.identityHashCode(stack) : stack.getUuid().hashCode();
+		int hashCode = stack.skyblocker$getUuid().isEmpty() ? System.identityHashCode(stack) : stack.skyblocker$getUuid().hashCode();
 		if (cache.containsKey(hashCode)) {
 			return cache.get(hashCode);
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/CustomizeArmorScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/CustomizeArmorScreen.java
@@ -77,7 +77,7 @@ public class CustomizeArmorScreen extends Screen {
 						((HandledScreenAccessor) inventoryScreen).getY() + 10
 				);
 				Screens.getButtons(inventoryScreen).add(button);
-				((RecipeBookHolder) inventoryScreen).registerRecipeBookToggleCallback(() -> button.setPosition(
+				((RecipeBookHolder) inventoryScreen).skyblocker$registerRecipeBookToggleCallback(() -> button.setPosition(
 						((HandledScreenAccessor) inventoryScreen).getX() + 63,
 						((HandledScreenAccessor) inventoryScreen).getY() + 10
 				));

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EvolvingItemAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EvolvingItemAdder.java
@@ -26,7 +26,7 @@ public class EvolvingItemAdder extends SimpleSlotTextAdder {
 
 	@Override
 	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
-		switch (stack.getSkyblockId()) {
+		switch (stack.skyblocker$getSkyblockId()) {
 			case "NEW_BOTTLE_OF_JYRRE", "DARK_CACAO_TRUFFLE", "DISCRITE", "MOBY_DUCK" -> {
 				return actualLogic(stack, "Current Bonus: ");
 			}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/PrehistoricEggAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/PrehistoricEggAdder.java
@@ -25,7 +25,7 @@ public class PrehistoricEggAdder extends SimpleSlotTextAdder {
 
 	@Override
 	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
-		if (!stack.isOf(Items.PLAYER_HEAD) || !stack.getSkyblockId().equals("PREHISTORIC_EGG")) return List.of();
+		if (!stack.isOf(Items.PLAYER_HEAD) || !stack.skyblocker$getSkyblockId().equals("PREHISTORIC_EGG")) return List.of();
 		NbtCompound nbt = ItemUtils.getCustomData(stack);
 		if (!nbt.contains("blocks_walked")) return List.of();
 		int walked = nbt.getInt("blocks_walked", 0);

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/RancherBootsSpeedAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/RancherBootsSpeedAdder.java
@@ -26,7 +26,7 @@ public class RancherBootsSpeedAdder extends SimpleSlotTextAdder {
 
 	@Override
 	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
-		if (!stack.isOf(Items.LEATHER_BOOTS) && !stack.getSkyblockId().equals("RANCHERS_BOOTS")) return List.of();
+		if (!stack.isOf(Items.LEATHER_BOOTS) && !stack.skyblocker$getSkyblockId().equals("RANCHERS_BOOTS")) return List.of();
 		Matcher matcher = ItemUtils.getLoreLineIfMatch(stack, SPEED_PATTERN);
 		if (matcher == null) return List.of();
 		String speed = matcher.group(2);

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/AccessoryTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/AccessoryTooltip.java
@@ -20,7 +20,7 @@ public class AccessoryTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		final String internalID = stack.getSkyblockId();
+		final String internalID = stack.skyblocker$getSkyblockId();
 		if (TooltipInfoType.ACCESSORIES.hasOrNullWarning(internalID)) {
 			Pair<AccessoriesHelper.AccessoryReport, String> report = AccessoriesHelper.calculateReport4Accessory(internalID);
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/AvgBinTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/AvgBinTooltip.java
@@ -19,8 +19,8 @@ public class AvgBinTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		String skyblockApiId = stack.getSkyblockApiId();
-		String neuName = stack.getNeuName();
+		String skyblockApiId = stack.skyblocker$getSkyblockApiId();
+		String neuName = stack.skyblocker$getNeuName();
 		Average type = ItemTooltip.config.avg;
 
         if ((TooltipInfoType.ONE_DAY_AVERAGE.getData() == null && type != Average.THREE_DAY) || (TooltipInfoType.THREE_DAY_AVERAGE.getData() == null && type != Average.ONE_DAY)) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
@@ -20,7 +20,7 @@ public class BazaarPriceTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		String skyblockApiId = stack.getSkyblockApiId();
+		String skyblockApiId = stack.skyblocker$getSkyblockApiId();
 
 		if (TooltipInfoType.BAZAAR.hasOrNullWarning(skyblockApiId)) {
 			int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BitsHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BitsHelper.java
@@ -303,7 +303,7 @@ public class BitsHelper extends SimpleContainerSolver implements TooltipAdder {
 			ItemStack stack = entry.getValue();
 			if (stack == null || stack.isEmpty()) continue;
 
-			String itemId = stack.getSkyblockApiId();
+			String itemId = stack.skyblocker$getSkyblockApiId();
 			String lore = ItemUtils.concatenateLore(ItemUtils.getLore(stack));
 			Matcher bitsMatcher = BITS_PATTERN.matcher(lore);
 			if (!bitsMatcher.find()) continue;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/ColorTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/ColorTooltip.java
@@ -29,7 +29,7 @@ public class ColorTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		final String internalID = stack.getSkyblockId();
+		final String internalID = stack.skyblocker$getSkyblockId();
 		if (TooltipInfoType.COLOR.hasOrNullWarning(internalID) && stack.contains(DataComponentTypes.DYED_COLOR)) {
 			//DyedColorComponent#getColor can be ARGB so we mask out the alpha bits
 			int dyeColor = stack.get(DataComponentTypes.DYED_COLOR).rgb() & 0x00FFFFFF;
@@ -93,7 +93,7 @@ public class ColorTooltip extends SimpleTooltipAdder {
 			case String it when Constants.CRYSTAL_HEXES.contains(it) -> DyeType.CRYSTAL;
 			case String it when Constants.FAIRY_HEXES.contains(it) -> DyeType.FAIRY;
 			case String it when Constants.OG_FAIRY_HEXES.contains(it) -> DyeType.OG_FAIRY;
-			case String it when Constants.SPOOK.contains(it) && stack.getSkyblockId().startsWith("FAIRY_") -> DyeType.SPOOK;
+			case String it when Constants.SPOOK.contains(it) && stack.skyblocker$getSkyblockId().startsWith("FAIRY_") -> DyeType.SPOOK;
 			case String it when Constants.GLITCHED.contains(it) && isGlitched(stack, hex) -> DyeType.GLITCHED;
 			default -> DyeType.EXOTIC;
 		};
@@ -105,7 +105,7 @@ public class ColorTooltip extends SimpleTooltipAdder {
 
 	//Thanks to TGWaffles' guidance on how to make this more accurate
 	private static boolean isGlitched(ItemStack stack, String hex) {
-		String id = stack.getSkyblockId();
+		String id = stack.skyblocker$getSkyblockId();
 
 		if (id.contains("WITHER")) {
 			return isWitherGlitched(id, hex, ObtainedDateTooltip.getLongTimestamp(stack));

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
@@ -41,7 +41,7 @@ public class CraftPriceTooltip extends SimpleTooltipAdder {
 			return;
 		}
 
-		NEUItem neuItem = NEURepoManager.NEU_REPO.getItems().getItemBySkyblockId(stack.getNeuName());
+		NEUItem neuItem = NEURepoManager.NEU_REPO.getItems().getItemBySkyblockId(stack.skyblocker$getNeuName());
 		if (neuItem == null) return;
 
 		List<NEURecipe> neuRecipes = neuItem.getRecipes();
@@ -58,7 +58,7 @@ public class CraftPriceTooltip extends SimpleTooltipAdder {
 					lines.add(Text.literal(String.format("%-20s", "Crafting Price:")).formatted(Formatting.GOLD)
 								  .append(ItemTooltip.getCoinsMessage(totalCraftCost / outputIngredient.getAmount(), count))));
 		} catch (Exception e) {
-			LOGGER.error("[Skyblocker Craft Price] Error calculating craftprice tooltip for: " + stack.getNeuName(), e);
+			LOGGER.error("[Skyblocker Craft Price] Error calculating craftprice tooltip for: " + stack.skyblocker$getNeuName(), e);
 		}
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/LBinTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/LBinTooltip.java
@@ -23,7 +23,7 @@ public class LBinTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-        String skyblockApiId = stack.getSkyblockApiId();
+        String skyblockApiId = stack.skyblocker$getSkyblockApiId();
 
 		// Check for whether the item exist in bazaar price data, because Skytils keeps some bazaar item data in lbin api
 		if (TooltipInfoType.LOWEST_BINS.hasOrNullWarning(skyblockApiId) && !TooltipInfoType.BAZAAR.hasOrNullWarning(skyblockApiId)) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/MotesTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/MotesTooltip.java
@@ -20,7 +20,7 @@ public class MotesTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		final String internalID = stack.getSkyblockId();
+		final String internalID = stack.skyblocker$getSkyblockId();
 		if (TooltipInfoType.MOTES.hasOrNullWarning(internalID)) {
 			lines.add(Text.literal(String.format("%-20s", "Motes Price:"))
 			              .formatted(Formatting.LIGHT_PURPLE)

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/MuseumTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/MuseumTooltip.java
@@ -25,7 +25,7 @@ public class MuseumTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		final String internalID = stack.getSkyblockId();
+		final String internalID = stack.skyblocker$getSkyblockId();
 		if (TooltipInfoType.MUSEUM.hasOrNullWarning(internalID)) {
 			String itemCategory = TooltipInfoType.MUSEUM.getData().get(internalID);
 			String format = switch (itemCategory) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
@@ -26,7 +26,7 @@ public class NpcPriceTooltip extends SimpleTooltipAdder {
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
 		// NPC prices seem to use the Skyblock item id, not the Skyblock api id.
-		final String internalID = stack.getSkyblockId();
+		final String internalID = stack.skyblocker$getSkyblockId();
 		if (TooltipInfoType.NPC.getData() == null) {
 			ItemTooltip.nullWarning();
 			return;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/TrueHexDisplay.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/TrueHexDisplay.java
@@ -23,7 +23,7 @@ public class TrueHexDisplay extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		String itemId = stack.getSkyblockId();
+		String itemId = stack.skyblocker$getSkyblockId();
 
 		//Nice job on item id consistency Hypixel
 		if (itemId != null && !itemId.isEmpty() && (itemId.startsWith("DYE_") || itemId.endsWith("_DYE"))) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
@@ -121,7 +121,7 @@ public class ItemRepository {
     }
 
     /**
-     * @param neuId the NEU item id gotten through {@link NEUItem#getSkyblockItemId()}, {@link ItemStack#getNeuName()}, or {@link ItemUtils#getNeuId(ItemStack) ItemTooltip#getNeuName(String, String)}
+     * @param neuId the NEU item id gotten through {@link NEUItem#getSkyblockItemId()}, {@link ItemStack#getSkyblocker$neuName()}, or {@link ItemUtils#getNeuId(ItemStack) ItemTooltip#getNeuName(String, String)}
      */
     @Nullable
     public static ItemStack getItemStack(String neuId) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/itemLoaders/ItemLoader.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/itemLoaders/ItemLoader.java
@@ -43,7 +43,7 @@ public class ItemLoader {
                 continue;
             }
 
-            String itemId = stack.getSkyblockId();
+            String itemId = stack.skyblocker$getSkyblockId();
             NbtCompound customData = ItemUtils.getCustomData(stack);
 
             if (itemId.equals("PET")) {

--- a/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
@@ -234,12 +234,12 @@ public final class ItemUtils {
     /**
      * Gets the NEU id from an id and an api id.
      *
-     * @return the NEU id of the skyblock item, matching the id of the item gotten from {@link io.github.moulberry.repo.data.NEUItem#getSkyblockItemId() NEUItem#getSkyblockItemId()} or {@link ItemStack#getNeuName()},
+     * @return the NEU id of the skyblock item, matching the id of the item gotten from {@link io.github.moulberry.repo.data.NEUItem#getSkyblockItemId() NEUItem#getSkyblockItemId()} or {@link ItemStack#getSkyblocker$neuName()},
      * or an empty string if stack is null
      */
     public static @NotNull String getNeuId(ItemStack stack) {
         if (stack == null) return "";
-        String id = stack.getSkyblockId();
+        String id = stack.skyblocker$getSkyblockId();
         NbtCompound customData = ItemUtils.getCustomData(stack);
         return switch (id) {
             case "ENCHANTED_BOOK" -> {
@@ -295,7 +295,7 @@ public final class ItemUtils {
      * and the {@code right boolean} indicating if the price was based on complete data.
      */
     public static @NotNull DoubleBooleanPair getItemPrice(@NotNull ItemStack stack) {
-        return getItemPrice(stack.getSkyblockApiId(), false);
+        return getItemPrice(stack.skyblocker$getSkyblockApiId(), false);
     }
 
     /**
@@ -366,7 +366,7 @@ public final class ItemUtils {
         // TODO Calculate drill durability based on the drill_fuel flag, fuel_tank flag, and hotm level
         // TODO Cache the max durability and only update the current durability on inventory tick
 
-        if (stack.getSkyblockId().equals("PICKONIMBUS")) {
+        if (stack.skyblocker$getSkyblockId().equals("PICKONIMBUS")) {
             int pickonimbusDurability = customData.getInt("pickonimbus_durability", 0);
 
             return IntIntPair.of(customData.contains("pickonimbus_durability") ? pickonimbusDurability : 2000, 2000);

--- a/src/test/java/de/hysky/skyblocker/utils/ItemUtilsTest.java
+++ b/src/test/java/de/hysky/skyblocker/utils/ItemUtilsTest.java
@@ -85,36 +85,36 @@ public class ItemUtilsTest {
 
 	@Test
 	void testGetSkyblockApiId() {
-		Assertions.assertEquals("DARK_CLAYMORE", DARK_CLAYMORE.getSkyblockApiId());
-		Assertions.assertEquals("TITANIUM_DRILL_4", TITANIUM_DRILL_DR_X655.getSkyblockApiId());
-		Assertions.assertEquals("ASTRAEA", ASTRAEA.getSkyblockApiId());
-		Assertions.assertEquals("BALLOON_HAT_2024_RED", BALLOON_HAT_2024.getSkyblockApiId());
-		Assertions.assertEquals("FORAGING_XP_BOOST_POTION_3", POTION.getSkyblockApiId());
-		Assertions.assertEquals("ICE_RUNE_1", RUNE.getSkyblockApiId());
-		Assertions.assertEquals("ENCHANTMENT_FEATHER_FALLING_10", ENCHANTED_BOOK.getSkyblockApiId());
-		Assertions.assertEquals("ATTRIBUTE_SHARD-TROPHY_HUNTER_1", ATTRIBUTE_SHARD.getSkyblockApiId());
-		Assertions.assertEquals("SHINY_WITHER_CHESTPLATE", WITHER_CHESTPLATE.getSkyblockApiId());
-		Assertions.assertEquals("CRIMSON_CHESTPLATE-MAGIC_FIND-VETERAN", CRIMSON_CHESTPLATE.getSkyblockApiId());
-		Assertions.assertEquals("AURORA_CHESTPLATE-MANA_POOL-MANA_REGENERATION", AURORA_CHESTPLATE.getSkyblockApiId());
-		Assertions.assertEquals("TERROR_CHESTPLATE-LIFELINE-MANA_POOL", TERROR_CHESTPLATE.getSkyblockApiId());
-		Assertions.assertEquals("LVL_1_LEGENDARY_WITHER_SKELETON", WITHER_SKELETON_PET.getSkyblockApiId());
+		Assertions.assertEquals("DARK_CLAYMORE", DARK_CLAYMORE.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("TITANIUM_DRILL_4", TITANIUM_DRILL_DR_X655.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("ASTRAEA", ASTRAEA.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("BALLOON_HAT_2024_RED", BALLOON_HAT_2024.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("FORAGING_XP_BOOST_POTION_3", POTION.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("ICE_RUNE_1", RUNE.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("ENCHANTMENT_FEATHER_FALLING_10", ENCHANTED_BOOK.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("ATTRIBUTE_SHARD-TROPHY_HUNTER_1", ATTRIBUTE_SHARD.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("SHINY_WITHER_CHESTPLATE", WITHER_CHESTPLATE.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("CRIMSON_CHESTPLATE-MAGIC_FIND-VETERAN", CRIMSON_CHESTPLATE.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("AURORA_CHESTPLATE-MANA_POOL-MANA_REGENERATION", AURORA_CHESTPLATE.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("TERROR_CHESTPLATE-LIFELINE-MANA_POOL", TERROR_CHESTPLATE.skyblocker$getSkyblockApiId());
+		Assertions.assertEquals("LVL_1_LEGENDARY_WITHER_SKELETON", WITHER_SKELETON_PET.skyblocker$getSkyblockApiId());
 	}
 
 	@Test
 	void testGetNeuId() {
-		Assertions.assertEquals("DARK_CLAYMORE", DARK_CLAYMORE.getNeuName());
-		Assertions.assertEquals("TITANIUM_DRILL_4", TITANIUM_DRILL_DR_X655.getNeuName());
-		Assertions.assertEquals("ASTRAEA", ASTRAEA.getNeuName());
-		Assertions.assertEquals("BALLOON_HAT_2024_RED", BALLOON_HAT_2024.getNeuName());
-		Assertions.assertEquals("POTION_FORAGING_XP_BOOST;3", POTION.getNeuName());
-		Assertions.assertEquals("ICE_RUNE;1", RUNE.getNeuName());
-		Assertions.assertEquals("FEATHER_FALLING;10", ENCHANTED_BOOK.getNeuName());
-		Assertions.assertEquals("ATTRIBUTE_SHARD", ATTRIBUTE_SHARD.getNeuName());
-		Assertions.assertEquals("WITHER_CHESTPLATE", WITHER_CHESTPLATE.getNeuName());
-		Assertions.assertEquals("CRIMSON_CHESTPLATE", CRIMSON_CHESTPLATE.getNeuName());
-		Assertions.assertEquals("AURORA_CHESTPLATE", AURORA_CHESTPLATE.getNeuName());
-		Assertions.assertEquals("TERROR_CHESTPLATE", TERROR_CHESTPLATE.getNeuName());
-		Assertions.assertEquals("WITHER_SKELETON;4", WITHER_SKELETON_PET.getNeuName());
+		Assertions.assertEquals("DARK_CLAYMORE", DARK_CLAYMORE.skyblocker$getNeuName());
+		Assertions.assertEquals("TITANIUM_DRILL_4", TITANIUM_DRILL_DR_X655.skyblocker$getNeuName());
+		Assertions.assertEquals("ASTRAEA", ASTRAEA.skyblocker$getNeuName());
+		Assertions.assertEquals("BALLOON_HAT_2024_RED", BALLOON_HAT_2024.skyblocker$getNeuName());
+		Assertions.assertEquals("POTION_FORAGING_XP_BOOST;3", POTION.skyblocker$getNeuName());
+		Assertions.assertEquals("ICE_RUNE;1", RUNE.skyblocker$getNeuName());
+		Assertions.assertEquals("FEATHER_FALLING;10", ENCHANTED_BOOK.skyblocker$getNeuName());
+		Assertions.assertEquals("ATTRIBUTE_SHARD", ATTRIBUTE_SHARD.skyblocker$getNeuName());
+		Assertions.assertEquals("WITHER_CHESTPLATE", WITHER_CHESTPLATE.skyblocker$getNeuName());
+		Assertions.assertEquals("CRIMSON_CHESTPLATE", CRIMSON_CHESTPLATE.skyblocker$getNeuName());
+		Assertions.assertEquals("AURORA_CHESTPLATE", AURORA_CHESTPLATE.skyblocker$getNeuName());
+		Assertions.assertEquals("TERROR_CHESTPLATE", TERROR_CHESTPLATE.skyblocker$getNeuName());
+		Assertions.assertEquals("WITHER_SKELETON;4", WITHER_SKELETON_PET.skyblocker$getNeuName());
 	}
 
 	@Test


### PR DESCRIPTION
The mixin library does create a unique name consisting of `<6 random_chars>$<modid>$methodname` to every method that is injected or annotated with @Unique, but it does only do so for private or injected methods, public methods do not get that treatment (due to the mixin library not knowing where it is used), therefore those must have the `<modid>` prefix preapplied to prevent any possible conflicts with other mods