### PR TITLE
Add REI exclusion zone for Visitor Helper Gui

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.compatibility.rei;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.mixins.accessors.HandledScreenAccessor;
+import de.hysky.skyblocker.skyblock.garden.visitor.VisitorHelper;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.Utils;
@@ -14,6 +15,7 @@ import me.shedaniel.rei.api.client.registry.entry.EntryRegistry;
 import me.shedaniel.rei.api.client.registry.screen.ExclusionZones;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.item.Items;
 
@@ -47,6 +49,11 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
             if (!SkyblockerConfigManager.get().farming.garden.gardenPlotsWidget || !Utils.getLocation().equals(Location.GARDEN)) return List.of();
             HandledScreenAccessor accessor = (HandledScreenAccessor) screen;
             return List.of(new Rectangle(accessor.getX() + accessor.getBackgroundWidth() + 4, accessor.getY(), 104, 127));
+        });
+
+        zones.register(Screen.class, screen -> {
+            if (!VisitorHelper.shouldRender()) return List.of();
+            return VisitorHelper.getExclusionZones();
         });
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/visitor/VisitorHelper.java
@@ -14,6 +14,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import me.shedaniel.math.Rectangle;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
@@ -61,6 +62,17 @@ public class VisitorHelper {
 		boolean isHelperEnabled = SkyblockerConfigManager.get().farming.visitorHelper.visitorHelper;
 		boolean isGardenMode = SkyblockerConfigManager.get().farming.visitorHelper.visitorHelperGardenOnly;
 		return isHelperEnabled && (!isGardenMode || Utils.isInGarden() || Utils.getIslandArea().contains("Bazaar"));
+	}
+
+	public static List<Rectangle> getExclusionZones() {
+		if (activeVisitors.isEmpty()) return List.of();
+
+		int maxXPosition = X_OFFSET + 215;
+		int textFontHeight = MinecraftClient.getInstance().textRenderer.fontHeight;
+		int count = groupedItems.size() + activeVisitors.size();
+		int maxYPosition = Y_OFFSET + count * (LINE_HEIGHT + textFontHeight);
+
+		return List.of(new Rectangle(X_OFFSET, Y_OFFSET, maxXPosition, maxYPosition));
 	}
 
 	/**


### PR DESCRIPTION
Fixes issues of Visitor Helper text not being clickable when using REI (favorited items block clicks)

Randomly favorited some items:
![image](https://github.com/user-attachments/assets/14357645-3d83-41e6-9f96-426f208bde0d)
