### PR TITLE
Same Color Terminal Solver

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -321,6 +321,13 @@ public class DungeonsCategory {
                                         newValue -> config.dungeons.terminals.solveStartsWith = newValue)
                                 .controller(ConfigUtils::createBooleanController)
                                 .build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.dungeons.terminals.solveSameColor"))
+								.binding(defaults.dungeons.terminals.solveSameColor,
+										() -> config.dungeons.terminals.solveSameColor,
+										newValue -> config.dungeons.terminals.solveSameColor = newValue)
+								.controller(ConfigUtils::createBooleanController)
+								.build())
                         .option(Option.<Boolean>createBuilder()
                                 .name(Text.translatable("skyblocker.config.dungeons.terminals.blockIncorrectClicks"))
                                 .binding(defaults.dungeons.terminals.blockIncorrectClicks,

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -159,6 +159,9 @@ public class DungeonsConfig {
         @SerialEntry
         public boolean solveColor = true;
 
+		@SerialEntry
+		public boolean solveSameColor = true;
+
         @SerialEntry
         public boolean solveOrder = true;
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/SameColorTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/SameColorTerminal.java
@@ -88,7 +88,7 @@ public final class SameColorTerminal extends SimpleContainerSolver implements Te
 	@Override
 	public List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
 		computeClicks(slots);
-		return Collections.emptyList();
+		return List.of();
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/SameColorTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/SameColorTerminal.java
@@ -1,0 +1,108 @@
+package de.hysky.skyblocker.skyblock.dungeon.terminal;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.item.slottext.SlotText;
+import de.hysky.skyblocker.utils.container.SimpleContainerSolver;
+import de.hysky.skyblocker.utils.container.SlotTextAdder;
+import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * Solver for the "Change all to same color!" terminal.
+ * It displays the minimal number of clicks required to change each pane
+ * to the most common color in the grid.
+ */
+public final class SameColorTerminal extends SimpleContainerSolver implements TerminalSolver, SlotTextAdder {
+	public static final SameColorTerminal INSTANCE = new SameColorTerminal();
+	private static final Item[] ORDER = new Item[]{
+			Items.RED_STAINED_GLASS_PANE,
+			Items.ORANGE_STAINED_GLASS_PANE,
+			Items.YELLOW_STAINED_GLASS_PANE,
+			Items.GREEN_STAINED_GLASS_PANE,
+			Items.BLUE_STAINED_GLASS_PANE
+	};
+	private static final Map<Item, Integer> INDEX = new HashMap<>();
+
+	static {
+		for (int i = 0; i < ORDER.length; i++) {
+			INDEX.put(ORDER[i], i);
+		}
+	}
+
+	private final Int2IntMap clickMap = new Int2IntOpenHashMap();
+
+	private SameColorTerminal() {
+		super("^Change all to same color!$");
+	}
+
+	@Override
+	public boolean isEnabled() {
+		clickMap.clear();
+		return SkyblockerConfigManager.get().dungeons.terminals.solveSameColor;
+	}
+
+	private void computeClicks(Int2ObjectMap<ItemStack> slots) {
+		clickMap.clear();
+		int[] counts = new int[ORDER.length];
+		Int2IntMap slotColors = new Int2IntOpenHashMap();
+
+		for (Int2ObjectMap.Entry<ItemStack> entry : slots.int2ObjectEntrySet()) {
+			Item item = entry.getValue().getItem();
+			Integer idx = INDEX.get(item);
+			if (idx != null) {
+				slotColors.put(entry.getIntKey(), idx.intValue());
+				counts[idx]++;
+			}
+		}
+		if (slotColors.isEmpty()) {
+			return;
+		}
+
+		int target = 0;
+		for (int i = 1; i < counts.length; i++) {
+			if (counts[i] > counts[target]) target = i;
+		}
+
+		for (Int2IntMap.Entry entry : slotColors.int2IntEntrySet()) {
+			int slot = entry.getIntKey();
+			int color = entry.getIntValue();
+			int diffForward = Math.floorMod(target - color, ORDER.length);
+			int diffBackward = Math.floorMod(color - target, ORDER.length);
+			int clicks = diffForward <= diffBackward ? diffForward : -diffBackward;
+			clickMap.put(slot, clicks);
+		}
+	}
+
+	@Override
+	public List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		computeClicks(slots);
+		return Collections.emptyList();
+	}
+
+	@Override
+	public boolean onClickSlot(int slot, ItemStack stack, int screenId) {
+		if (clickMap.containsKey(slot) && clickMap.get(slot) == 0) {
+			return shouldBlockIncorrectClicks();
+		}
+		return false;
+	}
+
+	@Override
+	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
+		int clicks = clickMap.getOrDefault(slotId, 0);
+		if (clicks == 0) return List.of();
+		return SlotText.topLeftList(Text.literal(String.valueOf(clicks)).formatted(Formatting.GOLD));
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/TerminalSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/TerminalSolver.java
@@ -2,7 +2,7 @@ package de.hysky.skyblocker.skyblock.dungeon.terminal;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 
-public sealed interface TerminalSolver permits ColorTerminal, LightsOnTerminal, OrderTerminal, StartsWithTerminal {
+public sealed interface TerminalSolver permits ColorTerminal, LightsOnTerminal, OrderTerminal, SameColorTerminal, StartsWithTerminal {
 	default boolean shouldBlockIncorrectClicks() {
 		return SkyblockerConfigManager.get().dungeons.terminals.blockIncorrectClicks;
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
@@ -5,6 +5,7 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.WardrobeKeybinds;
 import de.hysky.skyblocker.skyblock.bazaar.BazaarHelper;
 import de.hysky.skyblocker.skyblock.chocolatefactory.ChocolateFactorySolver;
+import de.hysky.skyblocker.skyblock.dungeon.terminal.SameColorTerminal;
 import de.hysky.skyblocker.skyblock.item.slottext.adders.*;
 import de.hysky.skyblocker.skyblock.profileviewer.ProfileViewerScreen;
 import de.hysky.skyblocker.utils.Utils;
@@ -57,7 +58,8 @@ public class SlotTextManager {
 			new EvolvingItemAdder(),
 			new NewYearCakeAdder(),
 			WardrobeKeybinds.INSTANCE,
-			new SkyblockGuideAdder()
+			new SkyblockGuideAdder(),
+			SameColorTerminal.INSTANCE,
 	};
 	private static final ArrayList<SlotTextAdder> currentScreenAdders = new ArrayList<>();
 	private static final KeyBinding keyBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.skyblocker.slottext", GLFW.GLFW_KEY_LEFT_ALT, "key.categories.skyblocker"));

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
@@ -14,6 +14,7 @@ import de.hysky.skyblocker.skyblock.dungeon.terminal.ColorTerminal;
 import de.hysky.skyblocker.skyblock.dungeon.terminal.LightsOnTerminal;
 import de.hysky.skyblocker.skyblock.dungeon.terminal.OrderTerminal;
 import de.hysky.skyblocker.skyblock.dungeon.terminal.StartsWithTerminal;
+import de.hysky.skyblocker.skyblock.dungeon.terminal.SameColorTerminal;
 import de.hysky.skyblocker.skyblock.dwarven.CommissionHighlight;
 import de.hysky.skyblocker.skyblock.dwarven.fossil.FossilSolver;
 import de.hysky.skyblocker.skyblock.experiment.ChronomatronSolver;
@@ -56,7 +57,8 @@ public class ContainerSolverManager {
 			new ReorderHelper(),
 			BitsHelper.INSTANCE,
 			new RaffleTaskHighlight(),
-			new FossilSolver()
+			new FossilSolver(),
+			SameColorTerminal.INSTANCE
 	};
 	private static ContainerSolver currentSolver = null;
 	private static List<ColorHighlight> highlights;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -236,6 +236,7 @@
   "skyblocker.config.dungeons.terminals.solveColor": "Solve Select Colored",
   "skyblocker.config.dungeons.terminals.solveOrder": "Solve Click In Order",
   "skyblocker.config.dungeons.terminals.solveStartsWith": "Solve Starts With",
+  "skyblocker.config.dungeons.terminals.solveSameColor": "Solve Change All to Same Color",
 
   "skyblocker.config.farming": "Farming",
 


### PR DESCRIPTION
Overlays the number of clicks needed for each pane to match. Positive numbers indicate left click, negative numbers indicate right click.

![Screenshot 2025-06-20 210541](https://github.com/user-attachments/assets/7c0909a4-8969-4f84-9641-a3b49fac791c)
