### PR TITLE
Removes the Estimated Price from Bazaar Items

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
@@ -28,7 +28,6 @@ public class EstimatedItemValueTooltip extends SimpleTooltipAdder {
 
 		int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
 
-
 		NetworthResult result = NetworthCalculator.getItemNetworth(stack, count);
 
 		if (result.price() > 0) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
@@ -22,7 +22,12 @@ public class EstimatedItemValueTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
+		if (TooltipInfoType.BAZAAR.getData() != null && TooltipInfoType.BAZAAR.getData().containsKey(stack.getSkyblockApiId())) {
+			return; // Bazaar price already displayed
+		}
+
 		int count = Math.max(ItemUtils.getItemCountInSack(stack, lines).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
+
 
 		NetworthResult result = NetworthCalculator.getItemNetworth(stack, count);
 


### PR DESCRIPTION
Removes the Estimated Price from Bazaar Items as these are always the bazaar buy price. Didn't see a place this wasn't the case


![Screenshot 2025-06-21 130626](https://github.com/user-attachments/assets/8245448b-a0a4-483b-8487-47284d646f74)
Before


![Screenshot 2025-06-21 130336](https://github.com/user-attachments/assets/2b963864-376b-4ac9-b0cd-152802442731)
After

Addresses issue https://github.com/SkyblockerMod/Skyblocker/issues/1289