### PR TITLE
Add a config option to toggle item protection chat notifications

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -341,6 +341,14 @@ public class GeneralCategory {
                                         newValue -> config.general.itemProtection.protectValuableConsumables = newValue)
                                 .controller(ConfigUtils::createBooleanController)
                                 .build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.general.itemProtection.displayChatNotification"))
+								.description(OptionDescription.of(Text.translatable("skyblocker.config.general.itemProtection.displayChatNotification.@Tooltip")))
+								.binding(defaults.general.itemProtection.displayChatNotification,
+										() -> config.general.itemProtection.displayChatNotification,
+										newValue -> config.general.itemProtection.displayChatNotification = newValue)
+								.controller(ConfigUtils::createBooleanController)
+								.build())
                         .build())
 
                 //Wiki Lookup

--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -228,6 +228,9 @@ public class GeneralConfig {
         @SerialEntry
         public SlotLockStyle slotLockStyle = SlotLockStyle.FANCY;
 
+		@SerialEntry
+		public boolean displayChatNotification = true;
+
         @SerialEntry
         public boolean protectValuableConsumables = true;
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemProtection.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemProtection.java
@@ -61,6 +61,7 @@ public class ItemProtection {
 	}
 
 	private static int protectMyItem(FabricClientCommandSource source) {
+		boolean notifyConfiguration = SkyblockerConfigManager.get().general.itemProtection.displayChatNotification;
 		ItemStack heldItem = source.getPlayer().getMainHandStack();
 
 		if (Utils.isOnSkyblock()) {
@@ -72,13 +73,15 @@ public class ItemProtection {
 				if (!protectedItems.contains(itemUuid)) {
 					protectedItems.add(itemUuid);
 					SkyblockerConfigManager.save();
-
-					source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.added", heldItem.getName())));
+					if(notifyConfiguration) {
+						source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.added", heldItem.getName())));
+					}
 				} else {
 					protectedItems.remove(itemUuid);
 					SkyblockerConfigManager.save();
-
-					source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.removed", heldItem.getName())));
+					if(notifyConfiguration) {
+						source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.removed", heldItem.getName())));
+					}
 				}
 			} else {
 				source.sendFeedback(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.noItemUuid")));
@@ -91,6 +94,8 @@ public class ItemProtection {
 	}
 
 	public static void handleKeyPressed(ItemStack heldItem) {
+		boolean notifyConfiguration = SkyblockerConfigManager.get().general.itemProtection.displayChatNotification;
+
 		PlayerEntity playerEntity = MinecraftClient.getInstance().player;
 		if (playerEntity == null){
 			return;
@@ -112,13 +117,15 @@ public class ItemProtection {
 			if (!protectedItems.contains(itemUuid)) {
 				protectedItems.add(itemUuid);
 				SkyblockerConfigManager.save();
-
-				playerEntity.sendMessage(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.added", heldItem.getName())), false);
+				if(notifyConfiguration) {
+					playerEntity.sendMessage(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.added", heldItem.getName())), false);
+				}
 			} else {
 				protectedItems.remove(itemUuid);
 				SkyblockerConfigManager.save();
-
-				playerEntity.sendMessage(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.removed", heldItem.getName())), false);
+				if(notifyConfiguration) {
+					playerEntity.sendMessage(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.removed", heldItem.getName())), false);
+				}
 			}
 		} else {
 			playerEntity.sendMessage(Constants.PREFIX.get().append(Text.translatable("skyblocker.itemProtection.noItemUuid")), false);

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -322,6 +322,8 @@
   "skyblocker.config.general.itemProtection": "Item Protection",
   "skyblocker.config.general.itemProtection.protectValuableConsumables": "Protect Valuable Consumables",
   "skyblocker.config.general.itemProtection.protectValuableConsumables.@Tooltip": "Prevents consuming items such as Bottles of Jyrre, Dark Cacao Truffles, and Discrite before they have evolved.",
+  "skyblocker.config.general.itemProtection.displayChatNotification": "Display Chat Notifications",
+  "skyblocker.config.general.itemProtection.displayChatNotification.@Tooltip": "Displays a chat notification when toggling the protection state of an item.",
   "skyblocker.config.general.itemProtection.slotLockStyle": "Slot Lock Icon Style",
   "skyblocker.config.general.itemProtection.slotLockStyle.@Tooltip": "Choose between the fancy or the classic slot lock icon.",
   "skyblocker.config.general.itemProtection.slotLockStyle.style.CLASSIC": "Classic",


### PR DESCRIPTION
I was asked to quickly add this feature in Discord.

Adds a config option to the Item Protection Feature to stop writing the notification of successful toggles in the chat.

Errors are still always reported.

![image](https://github.com/user-attachments/assets/dc1271a8-8aff-4140-9c2c-27437e8f5f53)
