### PR TITLE
Fix Bobber Time widget not working after max time was exceeded

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/fishing/FishingHudWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fishing/FishingHudWidget.java
@@ -18,7 +18,6 @@ import it.unimi.dsi.fastutil.objects.ObjectFloatPair;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 
 import java.util.Set;
@@ -114,7 +113,7 @@ public class FishingHudWidget extends ComponentBasedWidget {
 			}else{
 				maxTime = 20;
 			}
-			time = MathHelper.clamp(time, 0, maxTime);
+			time = Math.clamp(time, 0, maxTime);
 			addComponent(Components.progressComponent(Ico.CLOCK, Text.of("Bobber Time"), SkyblockTime.formatTime(maxTime - time),  100 - (time / maxTime) * 100));
 		}
 		// rod reel timer

--- a/src/main/java/de/hysky/skyblocker/skyblock/fishing/FishingHudWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fishing/FishingHudWidget.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.objects.ObjectFloatPair;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 
 import java.util.Set;
@@ -113,6 +114,7 @@ public class FishingHudWidget extends ComponentBasedWidget {
 			}else{
 				maxTime = 20;
 			}
+			time = MathHelper.clamp(time, 0, maxTime);
 			addComponent(Components.progressComponent(Ico.CLOCK, Text.of("Bobber Time"), SkyblockTime.formatTime(maxTime - time),  100 - (time / maxTime) * 100));
 		}
 		// rod reel timer


### PR DESCRIPTION
Fixes Bobber Time percentage going negative by clamping time between 0 and maxTime, prevents the following error:
```
Failed to update contents of de.hysky.skyblocker.skyblock.fishing.FishingHudWidget@4cc17012
java.lang.RuntimeException: Something went wrong when converting from HSV to RGB. Input was -0.5833333, 1.0, 1.0
```