### PR TITLE
Add hunting box helper

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/HuntingCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/HuntingCategory.java
@@ -1,14 +1,25 @@
 package de.hysky.skyblocker.config.categories;
 
+import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
 import dev.isxander.yacl3.api.ConfigCategory;
+import dev.isxander.yacl3.api.Option;
+import dev.isxander.yacl3.api.OptionDescription;
 import net.minecraft.text.Text;
 
 public class HuntingCategory {
 
 	public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
 		return ConfigCategory.createBuilder()
-				.name(Text.translatable("skyblocker.config.hunting"))
-				.build();
+							 .name(Text.translatable("skyblocker.config.hunting"))
+							 .option(Option.<Boolean>createBuilder()
+										   .name(Text.translatable("skyblocker.config.hunting.huntingBoxHelper"))
+										   .binding(defaults.hunting.huntingBox.enabled,
+												   () -> config.hunting.huntingBox.enabled,
+												   value -> config.hunting.huntingBox.enabled = value)
+										   .controller(ConfigUtils::createBooleanController)
+										   .description(OptionDescription.of(Text.translatable("skyblocker.config.hunting.huntingBoxHelper.@Tooltip")))
+										   .build())
+							 .build();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/config/configs/HuntingConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/HuntingConfig.java
@@ -1,5 +1,13 @@
 package de.hysky.skyblocker.config.configs;
 
-public class HuntingConfig {
+import dev.isxander.yacl3.config.v2.api.SerialEntry;
 
+public class HuntingConfig {
+	@SerialEntry
+	public HuntingBox huntingBox = new HuntingBox();
+
+	public static class HuntingBox {
+		@SerialEntry
+		public boolean enabled = true;
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/hunting/HuntingBoxHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/hunting/HuntingBoxHelper.java
@@ -1,0 +1,71 @@
+package de.hysky.skyblocker.skyblock.hunting;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.ItemUtils;
+import de.hysky.skyblocker.utils.container.SimpleContainerSolver;
+import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.text.Text;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HuntingBoxHelper extends SimpleContainerSolver {
+	private static final Pattern OWNED_PATTERN = Pattern.compile("Owned: (\\d+) Shards?");
+	private static final Pattern SYPHON_PATTERN = Pattern.compile("Syphon (\\d+) more to level up!");
+	private static final Logger LOGGER = LoggerFactory.getLogger(HuntingBoxHelper.class);
+
+	public HuntingBoxHelper() {
+		super("^Hunting Box$");
+	}
+
+	@Override
+	public List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		ArrayList<ColorHighlight> highlights = new ArrayList<>();
+		for (var entry : slots.int2ObjectEntrySet()) {
+			ItemStack stack = entry.getValue();
+			if (!stack.isOf(Items.PLAYER_HEAD)) continue;
+
+			List<Text> lore = ItemUtils.getLore(stack);
+			if (lore.isEmpty()) continue;
+
+			String owned = null, syphon = null;
+			for (Text line : lore) { // We iterate manually instead of the ItemUtils helper methods because the lines are adjacent, this way we only iterate once rather than twice.
+				String text = line.getString();
+				if (owned == null) {
+					Matcher matcher = OWNED_PATTERN.matcher(text);
+					if (matcher.matches()) owned = matcher.group(1);
+				} else {
+					Matcher matcher = SYPHON_PATTERN.matcher(text);
+					if (matcher.matches()) syphon = matcher.group(1);
+					break; // Somehow owned pattern matched but not syphon pattern
+				}
+			}
+			if (owned == null || syphon == null) continue;
+			int ownedCount = NumberUtils.toInt(owned, -1);
+			int syphonCount = NumberUtils.toInt(syphon, -1);
+			if (ownedCount < 0 || syphonCount < 0) {
+				LOGGER.warn("Invalid owned or syphon count in Hunting Box: owned={}, syphon={}.", owned, syphon);
+				continue;
+			}
+			if (ownedCount >= syphonCount) {
+				boolean enoughButNotUnlocked = lore.getLast().getString().startsWith("Requires");
+				highlights.add(enoughButNotUnlocked ? ColorHighlight.yellow(entry.getIntKey())
+													: ColorHighlight.green(entry.getIntKey()));
+			}
+		}
+		return highlights;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return SkyblockerConfigManager.get().hunting.huntingBox.enabled;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
@@ -19,6 +19,7 @@ import de.hysky.skyblocker.skyblock.dwarven.fossil.FossilSolver;
 import de.hysky.skyblocker.skyblock.experiment.ChronomatronSolver;
 import de.hysky.skyblocker.skyblock.experiment.SuperpairsSolver;
 import de.hysky.skyblocker.skyblock.experiment.UltrasequencerSolver;
+import de.hysky.skyblocker.skyblock.hunting.HuntingBoxHelper;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.BitsHelper;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
@@ -56,7 +57,8 @@ public class ContainerSolverManager {
 			new ReorderHelper(),
 			BitsHelper.INSTANCE,
 			new RaffleTaskHighlight(),
-			new FossilSolver()
+			new FossilSolver(),
+			new HuntingBoxHelper()
 	};
 	private static ContainerSolver currentSolver = null;
 	private static List<ColorHighlight> highlights;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -513,6 +513,8 @@
   "skyblocker.config.helpers.mythologicalRitual.enableMythologicalRitualHelper": "Enable Mythological Ritual Helper",
 
   "skyblocker.config.hunting": "Hunting",
+  "skyblocker.config.hunting.huntingBoxHelper": "Enable Hunting Box Helper",
+  "skyblocker.config.hunting.huntingBoxHelper.@Tooltip": "Highlights shards that you have enough of to syphon and reach the next tier of the attribute in the Hunting Box.",
 
   "skyblocker.config.chat": "Chat",
 


### PR DESCRIPTION
Highlights shards that you have enough of to level up.
This is mostly tested, and includes a toggle config.
The untested case is when you have shards but it's maxed. Idk if that's testable in the near future though. It probably just doesn't highlight, but still untested.

When you have enough shards:
![image](https://github.com/user-attachments/assets/337e5a55-c3fa-441f-af7a-a2433ebcf93a)
When you have enough shards but it's locked:
![image](https://github.com/user-attachments/assets/c1294239-342a-4c86-8f32-491838250aa3)
