### PR TITLE
Add a minimum pickle count to sea lumies

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/ForagingCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/ForagingCategory.java
@@ -2,10 +2,9 @@ package de.hysky.skyblocker.config.categories;
 
 import de.hysky.skyblocker.config.ConfigUtils;
 import de.hysky.skyblocker.config.SkyblockerConfig;
-import dev.isxander.yacl3.api.ConfigCategory;
-import dev.isxander.yacl3.api.Option;
-import dev.isxander.yacl3.api.OptionDescription;
-import dev.isxander.yacl3.api.OptionGroup;
+import de.hysky.skyblocker.skyblock.galatea.SeaLumiesHighlighter;
+import dev.isxander.yacl3.api.*;
+import dev.isxander.yacl3.api.controller.IntegerSliderControllerBuilder;
 import net.minecraft.text.Text;
 
 public class ForagingCategory {
@@ -46,8 +45,22 @@ public class ForagingCategory {
 								.description(OptionDescription.of(Text.translatable("skyblocker.config.foraging.galatea.enableSeaLumiesHighlighter.@Tooltip")))
 								.binding(defaults.foraging.galatea.enableSeaLumiesHighlighter,
 										() -> config.foraging.galatea.enableSeaLumiesHighlighter,
-										newValue -> config.foraging.galatea.enableSeaLumiesHighlighter = newValue)
+										newValue -> {
+											config.foraging.galatea.enableSeaLumiesHighlighter = newValue;
+											SeaLumiesHighlighter.INSTANCE.configCallback();
+										})
 								.controller(ConfigUtils::createBooleanController)
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.foraging.galatea.seaLumieMinCount"))
+								.description(OptionDescription.of(Text.translatable("skyblocker.config.foraging.galatea.seaLumieMinCount.@Tooltip")))
+								.binding(defaults.foraging.galatea.seaLumiesMinimumCount,
+										() -> config.foraging.galatea.seaLumiesMinimumCount,
+										newValue -> {
+											config.foraging.galatea.seaLumiesMinimumCount = newValue;
+											SeaLumiesHighlighter.INSTANCE.configCallback();
+										})
+								.controller(opt -> IntegerSliderControllerBuilder.create(opt).range(1, 4).step(1))
 								.build())
 						.build())
 				.build();

--- a/src/main/java/de/hysky/skyblocker/config/configs/ForagingConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/ForagingConfig.java
@@ -19,5 +19,8 @@ public class ForagingConfig {
 
 		@SerialEntry
 		public boolean enableSeaLumiesHighlighter = true;
+
+		@SerialEntry
+		public int seaLumiesMinimumCount = 3;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/AbstractBlockHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/AbstractBlockHighlighter.java
@@ -1,11 +1,8 @@
 package de.hysky.skyblocker.skyblock.galatea;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import de.hysky.skyblocker.utils.ColorUtils;
 import de.hysky.skyblocker.utils.render.RenderHelper;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
@@ -18,17 +15,35 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.WorldChunk;
 
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Predicate;
+
 /**
  * Abstract class for a simple feature that highlights a certain type of block.
  */
 //TODO Move this to a more generic package since this is not Galatea specific (maybe make a world rendering utility package?)
 public abstract class AbstractBlockHighlighter {
-	private final List<BlockPos> highlightedBlocks = new ArrayList<>();
-	private final Block target;
-	private final float[] colour;
+	protected final Set<BlockPos> highlightedBlocks = new ObjectOpenHashSet<>();
+	protected final float[] colour;
+	protected final Predicate<BlockState> statePredicate;
 
+	/**
+	 * Convenience constructor for highlighting a specific block type.
+	 *
+	 * @param target Block to highlight.
+	 * @param colour Color to use for highlighting.
+	 */
 	protected AbstractBlockHighlighter(Block target, DyeColor colour) {
-		this.target = target;
+		this(state -> state.isOf(target), colour);
+	}
+
+	/**
+	 * @param statePredicate Predicate that the blockstate must match to be highlighted.
+	 * @param colour Color to use for highlighting.
+	 */
+	protected AbstractBlockHighlighter(Predicate<BlockState> statePredicate, DyeColor colour) {
+		this.statePredicate = statePredicate;
 		this.colour = ColorUtils.getFloatComponents(colour);
 	}
 
@@ -42,7 +57,7 @@ public abstract class AbstractBlockHighlighter {
 	public void onBlockUpdate(BlockPos pos, BlockState state) {
 		if (!shouldProcess()) return;
 
-		if (state.getBlock().equals(this.target)) {
+		if (this.statePredicate.test(state)) {
 			this.highlightedBlocks.add(pos.toImmutable());
 		} else {
 			this.highlightedBlocks.remove(pos);
@@ -53,18 +68,16 @@ public abstract class AbstractBlockHighlighter {
 	 * Add initial highlights since {@link #onBlockUpdate(BlockPos, BlockState)} doesn't fire when the
 	 * server sends chunk data via the {@code ChunkDataS2CPacket}.
 	 */
-	private void onChunkLoad(ClientWorld world, WorldChunk chunk) {
+	protected void onChunkLoad(ClientWorld world, WorldChunk chunk) {
 		if (!shouldProcess()) return;
 
-		chunk.forEachBlockMatchingPredicate(state -> state.getBlock().equals(this.target), (pos, state) -> {
-			this.highlightedBlocks.add(pos.toImmutable());
-		});
+		chunk.forEachBlockMatchingPredicate(statePredicate, (pos, state) -> this.highlightedBlocks.add(pos.toImmutable()));
 	}
 
 	/**
 	 * Remove highlights in unloaded chunks.
 	 */
-	private void onChunkUnload(ClientWorld world, WorldChunk chunk) {
+	protected void onChunkUnload(ClientWorld world, WorldChunk chunk) {
 		if (!shouldProcess()) return;
 		Iterator<BlockPos> iterator = this.highlightedBlocks.iterator();
 
@@ -82,13 +95,17 @@ public abstract class AbstractBlockHighlighter {
 		if (!shouldProcess()) return;
 
 		for (BlockPos highlight : this.highlightedBlocks) {
-			RenderHelper.renderFilled(context, highlight, this.colour, 0.5f, false);
+			RenderHelper.renderFilled(context, highlight, this.colour, 0.4f, false);
 		}
 	}
 
-	private void reset() {
+	public void reset() {
 		this.highlightedBlocks.clear();
 	}
 
+	/**
+	 * @return Whether this highlighter should try to process blocks.
+	 */
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	protected abstract boolean shouldProcess();
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/SeaLumiesHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/SeaLumiesHighlighter.java
@@ -3,15 +3,38 @@ package de.hysky.skyblocker.skyblock.galatea;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Utils;
-import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.SeaPickleBlock;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.DyeColor;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.chunk.WorldChunk;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SeaLumiesHighlighter extends AbstractBlockHighlighter {
-	public static final SeaLumiesHighlighter INSTANCE = new SeaLumiesHighlighter(Blocks.SEA_PICKLE, DyeColor.CYAN);
+	private final List<BlockPos> allBlocks = new ArrayList<>();
 
-	private SeaLumiesHighlighter(Block target, DyeColor colour) {
-		super(target, colour);
+	@Override
+	public void onBlockUpdate(BlockPos pos, BlockState state) {
+		if (!shouldProcess()) return;
+
+		if (this.statePredicate.test(state)) {
+			this.allBlocks.add(pos.toImmutable());
+			if (isEnoughPickles(state)) this.highlightedBlocks.add(pos.toImmutable());
+		} else {
+			this.allBlocks.remove(pos);
+			this.highlightedBlocks.remove(pos);
+		}
+	}
+
+	public static final SeaLumiesHighlighter INSTANCE = new SeaLumiesHighlighter();
+
+	private SeaLumiesHighlighter() {
+		super(Blocks.SEA_PICKLE, DyeColor.CYAN);
 	}
 
 	@Init
@@ -20,7 +43,43 @@ public class SeaLumiesHighlighter extends AbstractBlockHighlighter {
 	}
 
 	@Override
+	protected void onChunkLoad(ClientWorld world, WorldChunk chunk) {
+		if (!shouldProcess()) return;
+
+		chunk.forEachBlockMatchingPredicate(statePredicate, (pos, state) -> {
+			this.allBlocks.add(pos.toImmutable());
+			if (isEnoughPickles(state)) this.highlightedBlocks.add(pos.toImmutable());
+		});
+	}
+
+	@Override
 	protected boolean shouldProcess() {
-		return Utils.isInGalatea() && SkyblockerConfigManager.get().foraging.galatea.enableSeaLumiesHighlighter;
+		return Utils.isInGalatea(); // Process all blocks, just don't highlight them if the config is disabled. This way, changing the config has an immediate effect rather than waiting for a chunk reload.
+	}
+
+	@Override
+	public void reset() {
+		this.allBlocks.clear();
+		this.highlightedBlocks.clear();
+	}
+
+	// Called when either the min count or the enabled state changes.
+	public void configCallback() {
+		this.highlightedBlocks.clear();
+		ClientWorld world = MinecraftClient.getInstance().world;
+		if (!shouldProcess() || world == null || !SkyblockerConfigManager.get().foraging.galatea.enableSeaLumiesHighlighter) {
+			return;
+		}
+
+		for (BlockPos pos : this.allBlocks) {
+			BlockState state = world.getBlockState(pos);
+			if (this.statePredicate.test(state) && isEnoughPickles(state)) {
+				this.highlightedBlocks.add(pos);
+			}
+		}
+	}
+
+	private boolean isEnoughPickles(BlockState state) {
+		return state.get(SeaPickleBlock.PICKLES) >= SkyblockerConfigManager.get().foraging.galatea.seaLumiesMinimumCount;
 	}
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -282,6 +282,8 @@
   "skyblocker.config.foraging.galatea.enableLushlilacHighlighter.@Tooltip": "Highlights Lushlilacs in magenta to assist in locating them.",
   "skyblocker.config.foraging.galatea.enableSeaLumiesHighlighter": "Enable Sea Lumies Highlighter",
   "skyblocker.config.foraging.galatea.enableSeaLumiesHighlighter.@Tooltip": "Highlights Sea Lumies in cyan to assist in locating them.",
+  "skyblocker.config.foraging.galatea.seaLumieMinCount": "Minimum Sea Lumie Count to Highlight",
+  "skyblocker.config.foraging.galatea.seaLumieMinCount.@Tooltip": "The minimum number of Sea Lumies that must be present within a block for it to be highlighted.",
   "skyblocker.config.foraging.galatea.solveForestTemplePuzzle": "Solve Forest Temple Puzzle",
   "skyblocker.config.foraging.galatea.solveForestTemplePuzzle.@Tooltip": "Displays the amount of times you need to rotate the terracotta blocks. For positive rotations you right click while for negative rotations you left click.",
 


### PR DESCRIPTION
That's pretty much it.

I also refactored `AbstractBlockHighlighter` a little to allow more than just block type matching, now it uses a `Predicate<BlockState>` and the previous constructor that set a target block now defaults to `state -> state.isOf(target)`.

I've messed around with the config a little, and everything seems to work fine. Could count as tested.