### PR TITLE
Add attribute level slot text

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/hunting/AttributeLevelHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/hunting/AttributeLevelHelper.java
@@ -1,0 +1,47 @@
+package de.hysky.skyblocker.skyblock.hunting;
+
+import de.hysky.skyblocker.skyblock.item.slottext.SimpleSlotTextAdder;
+import de.hysky.skyblocker.skyblock.item.slottext.SlotText;
+import de.hysky.skyblocker.utils.RomanNumerals;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.text.Text;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+//TODO: Add required amount of shards to reach max level in the tooltip via a TooltipAdder implementation once people get enough shards to figure them out
+//      It can be seen by clicking on the attribute but that's too much effort, we could bring that up a layer, into the tooltip of the attribute
+public class AttributeLevelHelper extends SimpleSlotTextAdder {
+	public static final AttributeLevelHelper INSTANCE = new AttributeLevelHelper();
+	private static final ConfigInformation CONFIG_INFORMATION = new ConfigInformation("attribute_levels",
+			"skyblocker.config.uiAndVisuals.slotText.attributeLevels",
+			"skyblocker.config.uiAndVisuals.slotText.attributeLevels.@Tooltip");
+
+
+	private AttributeLevelHelper() {
+		super("Attribute Menu", CONFIG_INFORMATION);
+	}
+
+	@Override
+	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
+		if (slot == null || stack.isEmpty()) return List.of();
+		if (slot.id <= 9 || slot.id >= 44) return List.of(); // Don't need to process the first row and the last row
+		if (stack.isOf(Items.BLACK_STAINED_GLASS_PANE)) return List.of();
+
+		Text customName = stack.getCustomName();
+		if (customName == null) return List.of();
+
+		String itemName = customName.getString();
+		String levelText = StringUtils.substringAfterLast(itemName, " ");
+		if (levelText.isEmpty() || !RomanNumerals.isValidRomanNumeral(levelText)) return List.of();
+
+		int level = RomanNumerals.romanToDecimal(levelText);
+		if (level < 1 || level > 10) return List.of(); // Should not go beyond these bounds, but just in case.
+
+		return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(level == 10 ? SlotText.GOLD : SlotText.CREAM));
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
@@ -5,6 +5,7 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.WardrobeKeybinds;
 import de.hysky.skyblocker.skyblock.bazaar.BazaarHelper;
 import de.hysky.skyblocker.skyblock.chocolatefactory.ChocolateFactorySolver;
+import de.hysky.skyblocker.skyblock.hunting.AttributeLevelHelper;
 import de.hysky.skyblocker.skyblock.item.slottext.adders.*;
 import de.hysky.skyblocker.skyblock.profileviewer.ProfileViewerScreen;
 import de.hysky.skyblocker.utils.Utils;
@@ -58,7 +59,8 @@ public class SlotTextManager {
 			new EvolvingItemAdder(),
 			new NewYearCakeAdder(),
 			WardrobeKeybinds.INSTANCE,
-			new SkyblockGuideAdder()
+			new SkyblockGuideAdder(),
+			AttributeLevelHelper.INSTANCE
 	};
 	private static final ArrayList<SlotTextAdder> currentScreenAdders = new ArrayList<>();
 	private static final KeyBinding keyBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.skyblocker.slottext", GLFW.GLFW_KEY_LEFT_ALT, "key.categories.skyblocker"));

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -971,6 +971,8 @@
   "skyblocker.config.uiAndVisuals.slotText.mode.DISABLED": "Disabled",
   "skyblocker.config.uiAndVisuals.slotText.separator": "Individual Toggles",
 
+  "skyblocker.config.uiAndVisuals.slotText.attributeLevels": "Attribute Level",
+  "skyblocker.config.uiAndVisuals.slotText.attributeLevels.@Tooltip": "Displays the level of the attribute in the Attribute Menu.",
   "skyblocker.config.uiAndVisuals.slotText.attributeShard": "Attribute Shards",
   "skyblocker.config.uiAndVisuals.slotText.attributeShard.@Tooltip": "Displays the attribute's level and the initials of the attribute's name.",
   "skyblocker.config.uiAndVisuals.slotText.catacombsLevel": "Catacombs Class Level",


### PR DESCRIPTION
Title.
![image](https://github.com/user-attachments/assets/1b91c410-3dfd-449a-8e37-8ff357ffbc03)


I also changed around `ConfigInformation` a little to be more flexible in terms of how you can add descriptions, though it's not actively used in this PR.