### PR TITLE
Get rid of ETF log spam

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/PlayerHeadHashCache.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/PlayerHeadHashCache.java
@@ -28,6 +28,7 @@ public class PlayerHeadHashCache {
 			.map(profile -> JsonParser.parseString(profile).getAsJsonObject())
 			.map(profile -> profile.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString())
 			.map(PlayerHeadHashCache::getSkinHash)
+			.filter(hash -> hash != null && !hash.isEmpty())
 			.mapToInt(String::hashCode)
 			.forEach(CACHE::add);
 
@@ -42,7 +43,7 @@ public class PlayerHeadHashCache {
 		if (url != null && url.equals("ETF pre test, skin check")) {
 			return "";
 		}
-		
+
 		try {
 			return FilenameUtils.getBaseName(new URI(url).getPath());
 		} catch (Exception e) {


### PR DESCRIPTION
Added checks to exit if it would cause an error.

For some reason, with ETF installed, getSkinHash is called with "ETF pre test, skin check" for the url. This then triggers the LOGGER.error line. I made the code not reach that line.


Possible ideas:
- add a LOGGER.warn
  - would cause log spam though
- more robust checks than .equals
- ~~figure out why ETF sends this anyways~~
  - ~~maybe it is expecting a specific response~~
    - ~~should the `return "";` be changed if so?~~
    
~~I'll check ETF in the meantime.~~