### PR TITLE
Fix Item Pickup Widget Network Protocol Error Disconnect

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/ItemPickupWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/ItemPickupWidget.java
@@ -58,6 +58,7 @@ public class ItemPickupWidget extends ComponentBasedWidget {
 	 * Searches the NEU REPO for the item linked to the name
 	 */
 	private static ItemStack getItem(String itemName) {
+		if (NEURepoManager.isLoading() || !ItemRepository.filesImported()) return new ItemStack(Items.BARRIER);
 		return NEURepoManager.NEU_REPO.getItems().getItems()
 				.values().stream()
 				.filter(item -> Formatting.strip(item.getDisplayName()).equals(itemName))


### PR DESCRIPTION
Fixes NullPointerException in Item Pickup Widget if the NEU Repo has not finished loading yet.

```
---- Minecraft Network Protocol Error Report ----
// Wait, was the last bit one or zero?
// Server bug reporting link: https://hypixel.net/bug-reports/create

Time: 2025-06-24 21:00:26
Description: Packet handling error

java.lang.NullPointerException: Cannot invoke "java.util.Map.values()" because the return value of "io.github.moulberry.repo.NEUItems.getItems()" is null
	at knot//de.hysky.skyblocker.skyblock.ItemPickupWidget.getItem(ItemPickupWidget.java:62)
	at knot//de.hysky.skyblocker.skyblock.ItemPickupWidget.onChatMessage(ItemPickupWidget.java:83)
	at knot//net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents.lambda$static$8(ClientReceiveMessageEvents.java:124)
```