### PR TITLE
Improve sea lumies highlighter

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/LushlilacHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/LushlilacHighlighter.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.skyblock.galatea;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.render.world.AbstractBlockHighlighter;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.DyeColor;

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/SeaLumiesHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/SeaLumiesHighlighter.java
@@ -3,10 +3,15 @@ package de.hysky.skyblocker.skyblock.galatea;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.render.RenderHelper;
 import de.hysky.skyblocker.utils.render.world.AbstractBlockHighlighter;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.SeaPickleBlock;
 import net.minecraft.util.DyeColor;
+import net.minecraft.util.math.BlockPos;
 
 public class SeaLumiesHighlighter extends AbstractBlockHighlighter {
 	public static final SeaLumiesHighlighter INSTANCE = new SeaLumiesHighlighter(Blocks.SEA_PICKLE, DyeColor.CYAN);
@@ -23,5 +28,14 @@ public class SeaLumiesHighlighter extends AbstractBlockHighlighter {
 	@Override
 	protected boolean shouldProcess() {
 		return Utils.isInGalatea() && SkyblockerConfigManager.get().foraging.galatea.enableSeaLumiesHighlighter;
+	}
+
+	@Override
+	protected void renderBlock(BlockPos pos, WorldRenderContext context) {
+		BlockState state = context.world().getBlockState(pos);
+		int pickles = state.get(SeaPickleBlock.PICKLES, 0);
+		if (pickles > 0) {
+			RenderHelper.renderFilled(context, pos, color, 0.2f * pickles, false);
+		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/SeaLumiesHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/SeaLumiesHighlighter.java
@@ -3,6 +3,7 @@ package de.hysky.skyblocker.skyblock.galatea;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.render.world.AbstractBlockHighlighter;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.DyeColor;

--- a/src/main/java/de/hysky/skyblocker/utils/render/world/AbstractBlockHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/world/AbstractBlockHighlighter.java
@@ -21,28 +21,28 @@ import net.minecraft.world.chunk.WorldChunk;
  */
 public abstract class AbstractBlockHighlighter {
 	private final Set<BlockPos> highlightedBlocks = new HashSet<>();
-	private final Block target;
-	private final float[] colour;
+	protected final Block target;
+	protected final float[] color;
 
-	protected AbstractBlockHighlighter(Block target, DyeColor colour) {
+	protected AbstractBlockHighlighter(Block target, DyeColor color) {
 		this.target = target;
-		this.colour = ColorUtils.getFloatComponents(colour);
+		this.color = ColorUtils.getFloatComponents(color);
 	}
 
 	protected void init() {
 		ClientChunkEvents.CHUNK_LOAD.register(this::onChunkLoad);
 		ClientChunkEvents.CHUNK_UNLOAD.register(this::onChunkUnload);
 		WorldRenderEvents.AFTER_TRANSLUCENT.register(this::render);
-		ClientPlayConnectionEvents.JOIN.register((_handler, _sender, _client) -> this.reset());
+		ClientPlayConnectionEvents.JOIN.register((_handler, _sender, _client) -> reset());
 	}
 
 	public void onBlockUpdate(BlockPos pos, BlockState state) {
 		if (!shouldProcess()) return;
 
 		if (shouldHighlight(state)) {
-			this.highlightedBlocks.add(pos.toImmutable());
+			highlightedBlocks.add(pos.toImmutable());
 		} else {
-			this.highlightedBlocks.remove(pos);
+			highlightedBlocks.remove(pos);
 		}
 	}
 
@@ -58,7 +58,7 @@ public abstract class AbstractBlockHighlighter {
 		if (!shouldProcess()) return;
 
 		chunk.forEachBlockMatchingPredicate(this::shouldHighlight, (pos, state) -> {
-			this.highlightedBlocks.add(pos.toImmutable());
+			highlightedBlocks.add(pos.toImmutable());
 		});
 	}
 
@@ -67,7 +67,7 @@ public abstract class AbstractBlockHighlighter {
 	 */
 	private void onChunkUnload(ClientWorld world, WorldChunk chunk) {
 		if (!shouldProcess()) return;
-		Iterator<BlockPos> iterator = this.highlightedBlocks.iterator();
+		Iterator<BlockPos> iterator = highlightedBlocks.iterator();
 
 		while (iterator.hasNext()) {
 			BlockPos pos = iterator.next();
@@ -82,17 +82,17 @@ public abstract class AbstractBlockHighlighter {
 	private void render(WorldRenderContext context) {
 		if (!shouldProcess()) return;
 
-		for (BlockPos highlight : this.highlightedBlocks) {
+		for (BlockPos highlight : highlightedBlocks) {
 			renderBlock(highlight, context);
 		}
 	}
 
 	protected void renderBlock(BlockPos pos, WorldRenderContext context) {
-		RenderHelper.renderFilled(context, pos, this.colour, 0.5f, false);
+		RenderHelper.renderFilled(context, pos, color, 0.5f, false);
 	}
 
 	private void reset() {
-		this.highlightedBlocks.clear();
+		highlightedBlocks.clear();
 	}
 
 	protected abstract boolean shouldProcess();


### PR DESCRIPTION
Fixes many bugs with the highlighter, making it hard to use:
- Some blocks were rendered with too much opacity, making it very hard to see the sea lumies
- Right clicking inside the block but without collecting the sea lumies would increase the opacity even further
- Some highlighted blocks had no sea lumies in them
- Collecting the sea lumies would not always make the highlight disappear, requiring several more clicks to fade away completely

 Also scales block opacity with the number of sea lumies in the given block, to make it easier to see where to go next.

![2025-06-25_15 47 02](https://github.com/user-attachments/assets/5581150d-50f4-4982-9696-d00d3028015d)