### PR TITLE
add "add waypoint above" button

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/waypoint/WaypointsListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/waypoint/WaypointsListWidget.java
@@ -219,6 +219,7 @@ public class WaypointsListWidget extends ElementListWidget<WaypointsListWidget.A
         private final TextFieldWidget zField;
         private final ARGBTextInput colorField;
         private final ButtonWidget buttonDelete;
+        private final ButtonWidget buttonNewWaypoint;
 
         public WaypointEntry(WaypointGroupEntry groupEntry) {
             this(groupEntry, groupEntry.group.createWaypoint(getDefaultPos()));
@@ -249,11 +250,19 @@ public class WaypointsListWidget extends ElementListWidget<WaypointsListWidget.A
 			colorField.setARGBColor(color);
 			colorField.setHeight(20);
 			colorField.setOnChange(this::updateColor);
+            buttonNewWaypoint = ButtonWidget.builder(Text.translatable("skyblocker.waypoints.new"), buttonNewWaypoint -> {
+        				WaypointEntry waypointEntry = new WaypointEntry(this.groupEntry);
+                int entryIndex = WaypointsListWidget.this.children().indexOf(this) - 1;
+                this.groupEntry.group.waypoints().add(entryIndex, waypointEntry.waypoint);
+                WaypointsListWidget.this.children().add(entryIndex, waypointEntry);
+                this.groupEntry.updateOrdered(true);
+                updateEntries();
+            }).width(38).build();
             buttonDelete = ButtonWidget.builder(Text.translatable("selectServer.deleteButton"), button -> {
                 groupEntry.group.waypoints().remove(waypoint);
                 WaypointsListWidget.this.children().remove(this);
             }).width(38).build();
-            children = List.of(enabled, nameField, xField, yField, zField, colorField, buttonDelete);
+            children = List.of(enabled, nameField, xField, yField, zField, colorField, buttonDelete, buttonNewWaypoint);
         }
 
         @Override
@@ -338,6 +347,7 @@ public class WaypointsListWidget extends ElementListWidget<WaypointsListWidget.A
             zField.setPosition(width / 2 + 34, y);
             colorField.setPosition(x + entryWidth - 99, y);
             buttonDelete.setPosition(x + entryWidth - 38, y);
+            buttonNewWaypoint.setPosition(x, y);
             for (ClickableWidget child : children) {
                 child.render(context, mouseX, mouseY, tickDelta);
             }


### PR DESCRIPTION
# THIS IS A PROOF-OF-CONCEPT
###### I don't like java much
###### anyways: you guys really need a formatter, tbh the code formatting sucks rn

This adds a button, that helps with making changes to ordered waypoints.

Lets say that we have ordered waypoint A and orderer waypoint B. Both are in remote locations. I would like to add waypoint C, that would be between them (and obviously ordered correctly). In the current newest version, there's no (intuitive) way to do that.

The button text is wrong (I didn't make it, and I don't know if I will), and the positioning is weird (I wanted to put the button to the right, but then I couldn't click it, so I just didn't bother)