### PR TITLE
Fix ColorSelectionWidget showing on chain armor.

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/ColorSelectionWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/ColorSelectionWidget.java
@@ -261,7 +261,12 @@ public class ColorSelectionWidget extends ContainerWidget implements Closeable {
 		this.currentItem = currentItem;
 		String itemUuid = ItemUtils.getItemUuid(currentItem);
 		customizable = currentItem.isIn(ItemTags.DYEABLE);
-		if (!customizable) return;
+		if (!customizable) {
+			animated = false;
+			((CheckboxWidgetAccessor) animatedCheckbox).setChecked(false);
+			changeVisibilities();
+			return;
+		}
 		if (SkyblockerConfigManager.get().general.customAnimatedDyes.containsKey(itemUuid)) {
 			animated = true;
 			CustomArmorAnimatedDyes.AnimatedDye animatedDye = SkyblockerConfigManager.get().general.customAnimatedDyes.get(itemUuid);


### PR DESCRIPTION
Bug when first opening the customize armor screen with chain armor. The two widgets both render. Doesn't fix until "reset color" is clicked.

![Screenshot 2025-06-28 042425](https://github.com/user-attachments/assets/6e111c5b-6b9c-499a-a377-404be4c75f21)

After fix

![image](https://github.com/user-attachments/assets/dcbd960e-5ce6-41ad-8653-deda44fd6270)
