### PR TITLE
Fix chat waypoints not working with decimal points

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
@@ -26,12 +26,11 @@ import java.util.regex.Pattern;
 
 public class ChatPositionShare {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChatPositionShare.class);
-	private static final Pattern SIMPLE_COORDS_PATTERN = Pattern.compile("(?<x>-?[0-9]+) (?<y>[0-9]+) (?<z>-?[0-9]+)");
-	private static final Pattern SIMPLE_COMMA_COORDS_PATTERN = Pattern.compile("(?<x>-?[0-9]+), (?<y>[0-9]+), (?<z>-?[0-9]+)");
-	private static final Pattern GENERIC_COORDS_PATTERN = Pattern.compile("x: (?<x>-?[0-9]+), y: (?<y>[0-9]+), z: (?<z>-?[0-9]+)");
-    private static final Pattern SKYBLOCKER_COORDS_PATTERN = Pattern.compile("x: (?<x>-?[0-9]+), y: (?<y>[0-9]+), z: (?<z>-?[0-9]+)(?: \\| (?<area>[^|]+))");
-    private static final Pattern SKYHANNI_DIANA_PATTERN = Pattern.compile("A MINOS INQUISITOR has spawned near \\[(?<area>[^]]*)] at Coords (?<x>-?[0-9]+) (?<y>[0-9]+) (?<z>-?[0-9]+)");
-    private static final List<Pattern> PATTERNS = List.of(SKYBLOCKER_COORDS_PATTERN, SKYHANNI_DIANA_PATTERN, GENERIC_COORDS_PATTERN, SIMPLE_COMMA_COORDS_PATTERN, SIMPLE_COORDS_PATTERN);
+    private static final Pattern SIMPLE_COORDS_PATTERN = Pattern.compile("(?<x>-?\\d+)[\\d.]*?(?: |, ?)(?<y>\\d+)[\\d.]*?(?: |, ?)(?<z>-?\\d+)");
+    private static final Pattern GENERIC_COORDS_PATTERN = Pattern.compile("x: ?(?<x>-?\\d+)[\\d.]*?(?: |, ?)y: ?(?<y>-?\\d+)[\\d.]*?(?: |, ?)z: ?(?<z>-?\\d+)");
+    private static final Pattern SKYBLOCKER_COORDS_PATTERN = Pattern.compile("x: (?<x>-?\\d+), y: (?<y>\\d+), z: (?<z>-?\\d+)(?: \\| (?<area>[^|]+))");
+    private static final Pattern SKYHANNI_DIANA_PATTERN = Pattern.compile("A MINOS INQUISITOR has spawned near \\[(?<area>[^]]*)] at Coords (?<x>-?\\d+) (?<y>\\d+) (?<z>-?\\d+)");
+    private static final List<Pattern> PATTERNS = List.of(SKYBLOCKER_COORDS_PATTERN, SKYHANNI_DIANA_PATTERN, GENERIC_COORDS_PATTERN, SIMPLE_COORDS_PATTERN);
 
     @Init
     public static void init() {


### PR DESCRIPTION
Related to #1443 
and some other improvements on  regex
![showcase](https://github.com/user-attachments/assets/d42a1d8c-9fb8-4cb4-af65-a24fcd0f274f)