### PR TITLE
Fix Farming Hud Skill EXP not working when Fancy Status bars are disabled

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/FarmingHud.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/FarmingHud.java
@@ -78,7 +78,7 @@ public class FarmingHud {
 		ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
 			if (shouldRender() && overlay) {
 				Matcher matcher = FARMING_XP.matcher(Formatting.strip(message.getString()));
-				if (matcher.matches()) {
+				if (matcher.find()) {
 					try {
 						farmingXp.offer(FloatLongPair.of(NUMBER_FORMAT.parse(matcher.group("xp")).floatValue(), System.currentTimeMillis()));
 						farmingXpPercentProgress = NUMBER_FORMAT.parse(matcher.group("percent")).floatValue();


### PR DESCRIPTION
Matcher#matches() requires the entire message to match, Matcher#find() does not.