### PR TITLE
Bestiary Level Slot Text & Slot Text Fixes

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
@@ -61,7 +61,8 @@ public class SlotTextManager {
 			WardrobeKeybinds.INSTANCE,
 			new SkyblockGuideAdder(),
 			SameColorTerminal.INSTANCE,
-			AttributeLevelHelper.INSTANCE
+			AttributeLevelHelper.INSTANCE,
+			new BestiaryLevelAdder()
 	};
 	private static final ArrayList<SlotTextAdder> currentScreenAdders = new ArrayList<>();
 	private static final KeyBinding keyBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.skyblocker.slottext", GLFW.GLFW_KEY_LEFT_ALT, "key.categories.skyblocker"));

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
@@ -32,17 +32,17 @@ public class BestiaryLevelAdder extends SimpleSlotTextAdder {
 
 	@Override
 	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
-		if (slotId < 54) { // Prevent accidentally adding text to slots which also match the pattern in the inventory (like minions)
-			Matcher matcher = BESTIARY.matcher(stack.getName().getString());
-			if (matcher.matches()) {
-				int level = RomanNumerals.romanToDecimal(matcher.group("level"));
-				if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Overall Progress: 100%")) != null) {
-					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.GOLD));
-				} else {
-					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
-				}
+		if (slotId > 53) return List.of(); // Prevent accidentally adding text to slots which also match the pattern in the inventory (like minions)
+		Matcher matcher = BESTIARY.matcher(stack.getName().getString());
+		if (matcher.matches()) {
+			int level = RomanNumerals.romanToDecimal(matcher.group("level"));
+			if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Overall Progress: 100%")) != null) {
+				return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.GOLD));
+			} else {
+				return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
 			}
 		}
+
 		return List.of();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
@@ -1,0 +1,48 @@
+package de.hysky.skyblocker.skyblock.item.slottext.adders;
+
+import de.hysky.skyblocker.SkyblockerMod;
+import de.hysky.skyblocker.skyblock.item.slottext.SimpleSlotTextAdder;
+import de.hysky.skyblocker.skyblock.item.slottext.SlotText;
+import de.hysky.skyblocker.skyblock.item.slottext.SlotTextManager;
+import de.hysky.skyblocker.utils.ItemUtils;
+import de.hysky.skyblocker.utils.RomanNumerals;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BestiaryLevelAdder extends SimpleSlotTextAdder {
+	private static final Pattern BESTIARY = Pattern.compile("^[\\w -]+ (?<level>[IVXLCDM]+)$");
+	private static final ConfigInformation CONFIG_INFORMATION = new ConfigInformation(
+			"bestiary_level",
+			"skyblocker.config.uiAndVisuals.slotText.bestiaryLevel"
+	);
+
+	public BestiaryLevelAdder() {
+		super("Bestiary ➜ .+", CONFIG_INFORMATION);
+	}
+
+
+	@Override
+	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
+		if (slotId < 54) { // Prevent accidentally adding text to slots which also match the pattern in the inventory (like minions)
+			Matcher matcher = BESTIARY.matcher(stack.getName().getString());
+			if (matcher.matches()) {
+				int level = RomanNumerals.romanToDecimal(matcher.group("level"));
+				if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Overall Progress: 100%")) != null) {
+					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.GOLD));
+				} else {
+					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
+				}
+			}
+		}
+		return List.of();
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
@@ -1,9 +1,7 @@
 package de.hysky.skyblocker.skyblock.item.slottext.adders;
 
-import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.skyblock.item.slottext.SimpleSlotTextAdder;
 import de.hysky.skyblocker.skyblock.item.slottext.SlotText;
-import de.hysky.skyblocker.skyblock.item.slottext.SlotTextManager;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.RomanNumerals;
 import net.minecraft.item.ItemStack;
@@ -11,8 +9,6 @@ import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.regex.Matcher;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CollectionAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CollectionAdder.java
@@ -27,17 +27,17 @@ public class CollectionAdder extends SimpleSlotTextAdder {
 
     @Override
     public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
-		if (slotId < 54) {
-			Matcher matcher = COLLECTION.matcher(stack.getName().getString());
-			if (matcher.matches()) {
-				int level = RomanNumerals.romanToDecimal(matcher.group("level"));
-				if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Progress to ")) != null) {
-					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
-				} else {
-					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.GOLD));
-				}
+		if (slotId > 53) return List.of();
+		Matcher matcher = COLLECTION.matcher(stack.getName().getString());
+		if (matcher.matches()) {
+			int level = RomanNumerals.romanToDecimal(matcher.group("level"));
+			if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Progress to ")) != null) {
+				return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
+			} else {
+				return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.GOLD));
 			}
 		}
-        return List.of();
+
+		return List.of();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CollectionAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/CollectionAdder.java
@@ -27,15 +27,17 @@ public class CollectionAdder extends SimpleSlotTextAdder {
 
     @Override
     public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
-        Matcher matcher = COLLECTION.matcher(stack.getName().getString());
-        if (matcher.matches()) {
-            int level = RomanNumerals.romanToDecimal(matcher.group("level"));
-            if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Progress to ")) != null) {
-                return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
-            } else {
-                return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.GOLD));
-            }
-        }
+		if (slotId < 54) {
+			Matcher matcher = COLLECTION.matcher(stack.getName().getString());
+			if (matcher.matches()) {
+				int level = RomanNumerals.romanToDecimal(matcher.group("level"));
+				if (ItemUtils.getLoreLineIf(stack, s -> s.contains("Progress to ")) != null) {
+					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.CREAM));
+				} else {
+					return SlotText.bottomRightList(Text.literal(String.valueOf(level)).withColor(SlotText.GOLD));
+				}
+			}
+		}
         return List.of();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EssenceShopAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EssenceShopAdder.java
@@ -32,6 +32,7 @@ public class EssenceShopAdder extends SimpleSlotTextAdder {
 
     @Override
     public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
+		if (slotId > 53) return List.of();
         Matcher essenceLevelMatcher = ESSENCELEVEL.matcher(stack.getName().getString());
         Matcher essenceAmountMatcher = ItemUtils.getLoreLineIfMatch(stack, ESSENCE);
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1030,6 +1030,7 @@
   "skyblocker.config.uiAndVisuals.slotText.statsTuning": "Stats Tuning",
   "skyblocker.config.uiAndVisuals.slotText.statsTuning.@Tooltip": "Displays your assigned and unassigned tuning points",
   "skyblocker.config.uiAndVisuals.slotText.yourEssence": "Your Essence",
+  "skyblocker.config.uiAndVisuals.slotText.bestiaryLevel": "Bestiary Level",
 
   "skyblocker.config.uiAndVisuals.searchOverlay": "AH/BZ Search Overlay",
   "skyblocker.config.uiAndVisuals.searchOverlay.enableAuctionHouse": "Enable For Auction House",


### PR DESCRIPTION
This PR does two (or three depending on how you count) things:

1. Adds Slot Text for bestiary levels
2. Fixes an issue where minions (and potentially other) items in your inventory would have double slot text rendered in the Collection and Essence Shop GUIs, because they matched the pattern used for that slot text adder.


