### PR TITLE
Don't apply Hunter Box tooltip adder for shards in the inventory

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/HuntingBoxPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/HuntingBoxPriceTooltip.java
@@ -25,6 +25,7 @@ public class HuntingBoxPriceTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public void addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
+		if (focusedSlot == null || focusedSlot.id > 53) return;
 		Attribute attribute = Attributes.getAttributeFromItemName(stack);
 
 		if (attribute != null && TooltipInfoType.BAZAAR.hasOrNullWarning(attribute.apiId())) {


### PR DESCRIPTION
Hides the "Shard(s) Sell Price" text for shards in the inventory, as the Bazaar Buy/Sell Price text does the same thing