### PR TITLE
Fix AH Popup Freeze

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/auction/AuctionViewScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/auction/AuctionViewScreen.java
@@ -4,6 +4,7 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.render.gui.AbstractCustomHypixelGUI;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.NonClosingPopupScreen;
 import net.minecraft.client.gui.screen.PopupScreen;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -293,13 +294,19 @@ public class AuctionViewScreen extends AbstractCustomHypixelGUI<AuctionHouseScre
         updateLayout();
     }
 
-    public PopupScreen getConfirmPurchasePopup(Text title) {
+    public NonClosingPopupScreen getConfirmPurchasePopup(Text title) {
         // This really shouldn't be possible to be null in its ACTUAL use case.
         //noinspection DataFlowIssue
-        return new PopupScreen.Builder(this, title)
+        return new NonClosingPopupScreen.Builder(this, title)
                 .button(Text.translatable("text.skyblocker.confirm"), popupScreen -> this.client.interactionManager.clickSlot(this.client.player.currentScreenHandler.syncId, 11, 0, SlotActionType.PICKUP, client.player))
-                .button(Text.translatable("gui.cancel"), popupScreen -> this.client.interactionManager.clickSlot(this.client.player.currentScreenHandler.syncId, 15, 0, SlotActionType.PICKUP, client.player))
-                .message((isBinAuction ? Text.translatable("skyblocker.fancyAuctionHouse.price") : Text.translatable("skyblocker.fancyAuctionHouse.newBid")).append(" ").append(priceText)).build();
+                .button(Text.translatable("gui.cancel"), PopupScreen::close)
+                .message((isBinAuction ? Text.translatable("skyblocker.fancyAuctionHouse.price") : Text.translatable("skyblocker.fancyAuctionHouse.newBid")).append(" ").append(priceText))
+				.onClosed(() -> {
+					// This really shouldn't be possible to be null in its ACTUAL use case.
+					//noinspection DataFlowIssue
+					this.client.interactionManager.clickSlot(this.client.player.currentScreenHandler.syncId, 15, 0, SlotActionType.PICKUP, client.player);
+				})
+				.build();
     }
 
     private enum BuyState {

--- a/src/main/java/de/hysky/skyblocker/skyblock/auction/AuctionViewScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/auction/AuctionViewScreen.java
@@ -4,7 +4,7 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.render.gui.AbstractCustomHypixelGUI;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.NonClosingPopupScreen;
+import de.hysky.skyblocker.utils.render.gui.NonClosingPopupScreen;
 import net.minecraft.client.gui.screen.PopupScreen;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.ButtonWidget;

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/NonClosingPopupScreen.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/NonClosingPopupScreen.java
@@ -1,7 +1,9 @@
-package net.minecraft.client.gui.screen;
+package de.hysky.skyblocker.utils.render.gui;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.screen.PopupScreen;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;

--- a/src/main/java/net/minecraft/client/gui/screen/NonClosingPopupScreen.java
+++ b/src/main/java/net/minecraft/client/gui/screen/NonClosingPopupScreen.java
@@ -1,0 +1,76 @@
+package net.minecraft.client.gui.screen;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class NonClosingPopupScreen extends PopupScreen {
+	public NonClosingPopupScreen(Screen backgroundScreen, int width, @Nullable Identifier image, Text title, Text message, List<PopupScreen.Button> buttons, @Nullable Runnable onClosed) {
+		super(backgroundScreen, width, image, title, message, buttons, onClosed);
+	}
+
+	@Override
+	public void close() {
+		if (this.onClosed != null) {
+			this.onClosed.run();
+		}
+	}
+
+	@Environment(EnvType.CLIENT)
+	public static class Builder {
+		private final Screen backgroundScreen;
+		private final Text title;
+		private Text message = ScreenTexts.EMPTY;
+		private int width = 250;
+		@Nullable
+		private Identifier image;
+		private final List<PopupScreen.Button> buttons = new ArrayList<>();
+		@Nullable
+		private Runnable onClosed = null;
+
+		public Builder(Screen backgroundScreen, Text title) {
+			this.backgroundScreen = backgroundScreen;
+			this.title = title;
+		}
+
+		public NonClosingPopupScreen.Builder width(int width) {
+			this.width = width;
+			return this;
+		}
+
+		public NonClosingPopupScreen.Builder image(Identifier image) {
+			this.image = image;
+			return this;
+		}
+
+		public NonClosingPopupScreen.Builder message(Text message) {
+			this.message = message;
+			return this;
+		}
+
+		public NonClosingPopupScreen.Builder button(Text message, Consumer<PopupScreen> action) {
+			this.buttons.add(new PopupScreen.Button(message, action));
+			return this;
+		}
+
+		public NonClosingPopupScreen.Builder onClosed(Runnable onClosed) {
+			this.onClosed = onClosed;
+			return this;
+		}
+
+		public NonClosingPopupScreen build() {
+			if (this.buttons.isEmpty()) {
+				throw new IllegalStateException("Popup must have at least one button");
+			} else {
+				return new NonClosingPopupScreen(this.backgroundScreen, this.width, this.image, this.title, this.message, List.copyOf(this.buttons), this.onClosed);
+			}
+		}
+	}
+}

--- a/src/main/resources/skyblocker.accesswidener
+++ b/src/main/resources/skyblocker.accesswidener
@@ -23,3 +23,9 @@ extendable method net/minecraft/client/gui/screen/recipebook/RecipeBookWidget tr
 
 # Block Shapes
 accessible field net/minecraft/block/CarpetBlock SHAPE Lnet/minecraft/util/shape/VoxelShape;
+
+# Popup Screen
+accessible class net/minecraft/client/gui/screen/PopupScreen$Button
+accessible method net/minecraft/client/gui/screen/PopupScreen$Button <init> (Lnet/minecraft/text/Text;Ljava/util/function/Consumer;)V
+accessible field net/minecraft/client/gui/screen/PopupScreen onClosed Ljava/lang/Runnable;
+accessible method net/minecraft/client/gui/screen/PopupScreen <init> (Lnet/minecraft/client/gui/screen/Screen;ILnet/minecraft/util/Identifier;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;Ljava/util/List;Ljava/lang/Runnable;)V


### PR DESCRIPTION
If you try to close the `confirm purchase` screen with escape, the screen gets stuck. This pr fixes that by making a new `PopupScreen` that does not automatically close (`NonClosingPopupScreen`), and instead calls the code for the `cancel` button.