### PR TITLE
Livid Highlighter Localization Cleanup + Custom Color Option

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -18,6 +18,8 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
+import java.awt.Color;
+
 public class DungeonsCategory {
 
 	public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
@@ -268,6 +270,13 @@ public class DungeonsCategory {
 										newValue -> config.dungeons.livid.enableSolidColor = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
+						.option(Option.<Color>createBuilder()
+								.name(Text.translatable("skyblocker.config.dungeons.livid.customColor"))
+								.binding(defaults.dungeons.livid.customColor,
+										() -> config.dungeons.livid.customColor,
+										newValue -> config.dungeons.livid.customColor = newValue)
+								.controller(ConfigUtils.createColourController(false))
+								.build())
 						.option(Option.<Boolean>createBuilder()
 								.name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorGlow"))
 								.description(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorGlow.@Tooltip"))
@@ -285,19 +294,19 @@ public class DungeonsCategory {
 								.controller(ConfigUtils.createBooleanController())
 								.build())
 						.option(Option.<Boolean>createBuilder()
-								.name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorText"))
-								.description(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorText.@Tooltip"))
-								.binding(defaults.dungeons.livid.enableLividColorText,
-										() -> config.dungeons.livid.enableLividColorText,
-										newValue -> config.dungeons.livid.enableLividColorText = newValue)
-								.controller(ConfigUtils.createBooleanController())
-								.build())
-						.option(Option.<Boolean>createBuilder()
 								.name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorTitle"))
 								.description(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorTitle.@Tooltip"))
 								.binding(defaults.dungeons.livid.enableLividColorTitle,
 										() -> config.dungeons.livid.enableLividColorTitle,
 										newValue -> config.dungeons.livid.enableLividColorTitle = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorText"))
+								.description(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorText.@Tooltip"))
+								.binding(defaults.dungeons.livid.enableLividColorText,
+										() -> config.dungeons.livid.enableLividColorText,
+										newValue -> config.dungeons.livid.enableLividColorText = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
 						.option(Option.<String>createBuilder()

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -4,6 +4,8 @@ import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.util.Formatting;
 
+import java.awt.Color;
+
 public class DungeonsConfig {
 	public boolean fancyPartyFinder = true;
 
@@ -98,6 +100,8 @@ public class DungeonsConfig {
 
 	public static class Livid {
 		public boolean enableSolidColor = false;
+
+		public Color customColor = Color.RED;
 
 		public boolean enableLividColorGlow = false;
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -126,7 +126,7 @@ public class LividColor {
 
     @SuppressWarnings("DataFlowIssue")
     public static int getGlowColor(String name) {
-        if (SkyblockerConfigManager.get().dungeons.livid.enableSolidColor) return Formatting.RED.getColorValue();
+        if (SkyblockerConfigManager.get().dungeons.livid.enableSolidColor) return SkyblockerConfigManager.get().dungeons.livid.customColor.getRGB();
         if (LIVID_TO_FORMATTING.containsKey(name)) return LIVID_TO_FORMATTING.get(name).getColorValue();
         return Formatting.WHITE.getColorValue();
     }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -152,18 +152,19 @@
   "skyblocker.config.dungeons.hideSoulweaverSkulls.@Tooltip": "Hides the Haunted Skulls spawned that are spawned as a result of using Soulweaver Gloves.",
 
   "skyblocker.config.dungeons.livid": "Livid (F5/M5)",
-  "skyblocker.config.dungeons.livid.enableSolidColor": "Enable Glow and/or Bounding use same color",
-  "skyblocker.config.dungeons.livid.enableSolidColor.@Tooltip": "Instead of Livid color an Red color is Shown",
+  "skyblocker.config.dungeons.livid.enableSolidColor": "Enable Custom Livid Color",
+  "skyblocker.config.dungeons.livid.enableSolidColor.@Tooltip": "Use the custom color instead of the Livid color for glow and bounding box.",
+  "skyblocker.config.dungeons.livid.customColor": "Custom Livid Color",
   "skyblocker.config.dungeons.livid.enableLividColorGlow": "Enable Livid Color Glow",
   "skyblocker.config.dungeons.livid.enableLividColorGlow.@Tooltip": "Applies the glowing effect to the correct Livid in F5/M5.",
   "skyblocker.config.dungeons.livid.enableLividColorBoundingBox": "Enable Livid Color Bounding Box",
-  "skyblocker.config.dungeons.livid.enableLividColorBoundingBox.@Tooltip": "Applies a bounding box to the correct Livid in F5/M5.",
-  "skyblocker.config.dungeons.livid.enableLividColorText": "Enable Livid Color Text",
-  "skyblocker.config.dungeons.livid.enableLividColorText.@Tooltip": "Send the livid color in the chat during the Livid boss fight.",
+  "skyblocker.config.dungeons.livid.enableLividColorBoundingBox.@Tooltip": "Shows a bounding box on the correct Livid in F5/M5.",
   "skyblocker.config.dungeons.livid.enableLividColorTitle": "Enable Livid Color Title",
-  "skyblocker.config.dungeons.livid.enableLividColorTitle.@Tooltip": "Display the livid color in the title during the Livid boss fight.",
-  "skyblocker.config.dungeons.livid.lividColorText": "Livid Color Text",
-  "skyblocker.config.dungeons.livid.lividColorText.@Tooltip": "Text which will be sent in the chat during the Livid boss fight. The string \"[color]\" will be replaced with the livid color.",
+  "skyblocker.config.dungeons.livid.enableLividColorTitle.@Tooltip": "Display the Livid color as a title during the boss fight.",
+  "skyblocker.config.dungeons.livid.enableLividColorText": "Send Livid Color in Chat",
+  "skyblocker.config.dungeons.livid.enableLividColorText.@Tooltip": "Whether to send the Livid color in the chat during the boss fight.",
+  "skyblocker.config.dungeons.livid.lividColorText": "Livid Color Chat Message",
+  "skyblocker.config.dungeons.livid.lividColorText.@Tooltip": "Text for the chat message, the string \"[color]\" will be replaced with the livid color.",
 
   "skyblocker.config.dungeons.map": "Map",
   "skyblocker.config.dungeons.map.enableMap": "Enable Map",
@@ -298,7 +299,7 @@
   "skyblocker.config.foraging.sweepOverlay.enableThrownAbilityOverlay.@Tooltip": "Highlights logs when using an axe's thrown ability.",
   "skyblocker.config.foraging.sweepOverlay.sweepOverlayColor": "Sweep Overlay Color",
   "skyblocker.config.foraging.sweepOverlay.sweepStatMissingMessage": "Sweep Missing: Add the Sweep stat to your player list with /tablist",
-  
+
   "skyblocker.config.foraging.hunting": "Hunting",
 
   "skyblocker.config.general": "General",


### PR DESCRIPTION
Rewords some of the titles/descriptions for the Config options to sound better, and adds a custom color config option since it seems better than forcing a red color (if solid color option is enabled).