### PR TITLE
fix quick nav offset

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
@@ -11,6 +11,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.tooltip.Tooltip;
@@ -94,6 +95,7 @@ public class QuickNavButton extends ClickableWidget {
             int x = accessibleScreen.getX();
             int y = accessibleScreen.getY();
             int h = accessibleScreen.getBackgroundHeight();
+			if (handledScreen instanceof GenericContainerScreen) h--; // they messed up the height on these.
             int w = accessibleScreen.getBackgroundWidth();
             this.setX(x + this.index % 7 * 25 + w / 2 - 176 / 2);
             this.setY(this.index < 7 ? y - 28 : y + h - 4);


### PR DESCRIPTION
Fixes the bottom the bottom buttons being offset due to backgroundHeight in GenericContainerScreen not being correct (it is 114 + rows instead of 113 + rows). This was only really visible when the button was selected

Before:
<img width="139" height="126" alt="image" src="https://github.com/user-attachments/assets/f37e267f-83d7-474b-9227-3bc2d0a71282" />
