### PR TITLE
Make quicknav grab backgroundScreen

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/accessors/PopupBackgroundAccessor.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/accessors/PopupBackgroundAccessor.java
@@ -1,10 +1,13 @@
 package de.hysky.skyblocker.mixins.accessors;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.PopupScreen;
 import net.minecraft.client.gui.screen.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
+@Environment(EnvType.CLIENT)
 @Mixin(PopupScreen.class)
 public interface PopupBackgroundAccessor {
 	@Accessor("backgroundScreen")

--- a/src/main/java/de/hysky/skyblocker/mixins/accessors/PopupBackgroundAccessor.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/accessors/PopupBackgroundAccessor.java
@@ -1,0 +1,12 @@
+package de.hysky.skyblocker.mixins.accessors;
+
+import net.minecraft.client.gui.screen.PopupScreen;
+import net.minecraft.client.gui.screen.Screen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PopupScreen.class)
+public interface PopupBackgroundAccessor {
+	@Accessor("backgroundScreen")
+	Screen getUnderlyingScreen();
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java
@@ -4,12 +4,14 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.JsonOps;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.mixins.accessors.HandledScreenAccessor;
+import de.hysky.skyblocker.mixins.accessors.PopupBackgroundAccessor;
 import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.PopupScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
@@ -89,6 +91,14 @@ public class QuickNavButton extends ClickableWidget {
 
     private void updateCoordinates() {
         Screen screen = MinecraftClient.getInstance().currentScreen;
+		while (screen instanceof PopupScreen) {
+			if (!(screen instanceof PopupBackgroundAccessor popup)) {
+				throw new IllegalStateException(
+						"Current PopupScreen does not support AccessorPopupBackground"
+				);
+			}
+			screen = popup.getUnderlyingScreen();
+		}
         if (screen instanceof HandledScreen<?> handledScreen) {
             var accessibleScreen = (HandledScreenAccessor) handledScreen;
             int x = accessibleScreen.getX();

--- a/src/main/resources/skyblocker.mixins.json
+++ b/src/main/resources/skyblocker.mixins.json
@@ -64,6 +64,7 @@
     "accessors.MessageHandlerAccessor",
     "accessors.MinecraftClientAccessor",
     "accessors.PlayerListHudAccessor",
+    "accessors.PopupBackgroundAccessor",
     "accessors.RecipeBookWidgetAccessor",
     "accessors.ScreenAccessor",
     "accessors.SlotAccessor",


### PR DESCRIPTION
If you open a `PopupScreen`, the quick navigation buttons previously rendered in the corner. Now, the buttons grab the screen behind it and use it instead to calculate positions.
<details>
<summary>Before</summary>
<img width="1194" height="1009" alt="image" src="https://github.com/user-attachments/assets/e4abd29a-48e2-41b6-b0dd-b880bc30b9e4" />
</details>
<details>
<summary>After</summary>
<img width="1280" height="1152" alt="image" src="https://github.com/user-attachments/assets/7e7378c6-9e6e-4d56-940f-a87f920be1e5" />
</details>