### PR TITLE
Hide Tooltips

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -39,12 +39,12 @@ import java.util.List;
 import java.util.Objects;
 
 public class UIAndVisualsCategory {
-    public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
-        return ConfigCategory.createBuilder()
-        		.id(Identifier.of(SkyblockerMod.NAMESPACE, "config/uiandvisuals"))
+	public static ConfigCategory create(SkyblockerConfig defaults, SkyblockerConfig config) {
+		return ConfigCategory.createBuilder()
+				.id(Identifier.of(SkyblockerMod.NAMESPACE, "config/uiandvisuals"))
 				.name(Text.translatable("skyblocker.config.uiAndVisuals"))
 
-                //Ungrouped Options
+				//Ungrouped Options
 				.option(Option.<Boolean>createBuilder()
 						.name(Text.translatable("skyblocker.config.uiAndVisuals.swingOnAbilities"))
 						.description(Text.translatable("skyblocker.config.uiAndVisuals.swingOnAbilities.@Tooltip"))
@@ -61,66 +61,66 @@ public class UIAndVisualsCategory {
 								newValue -> config.uiAndVisuals.nightVisionStrength = newValue)
 						.controller(IntegerController.createBuilder().range(0, 100).slider(1).build())
 						.build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.compactorDeletorPreview"))
-                        .binding(defaults.uiAndVisuals.compactorDeletorPreview,
-                                () -> config.uiAndVisuals.compactorDeletorPreview,
-                                newValue -> config.uiAndVisuals.compactorDeletorPreview = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.dontStripSkinAlphaValues"))
-                        .description(Text.translatable("skyblocker.config.uiAndVisuals.dontStripSkinAlphaValues.@Tooltip"))
-                        .binding(defaults.uiAndVisuals.dontStripSkinAlphaValues,
-                                () -> config.uiAndVisuals.dontStripSkinAlphaValues,
-                                newValue -> config.uiAndVisuals.dontStripSkinAlphaValues = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .flags(OptionFlag.ASSET_RELOAD)
-                        .build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.backpackPreviewWithoutShift"))
-                        .binding(defaults.uiAndVisuals.backpackPreviewWithoutShift,
-                                () -> config.uiAndVisuals.backpackPreviewWithoutShift,
-                                newValue -> config.uiAndVisuals.backpackPreviewWithoutShift = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.hideEmptyTooltips"))
-                        .description(Text.translatable("skyblocker.config.uiAndVisuals.hideEmptyTooltips.@Tooltip"))
-                        .binding(defaults.uiAndVisuals.hideEmptyTooltips,
-                                () -> config.uiAndVisuals.hideEmptyTooltips,
-                                newValue -> config.uiAndVisuals.hideEmptyTooltips = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.fancyCraftingTable"))
-                        .binding(defaults.uiAndVisuals.fancyCraftingTable,
-                                () -> config.uiAndVisuals.fancyCraftingTable,
-                                newValue -> config.uiAndVisuals.fancyCraftingTable = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.hideStatusEffectOverlay"))
-                        .binding(defaults.uiAndVisuals.hideStatusEffectOverlay,
-                                () -> config.uiAndVisuals.hideStatusEffectOverlay,
-                                newValue -> config.uiAndVisuals.hideStatusEffectOverlay = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.showEquipmentInInventory"))
-                        .binding(defaults.uiAndVisuals.showEquipmentInInventory,
-                                () -> config.uiAndVisuals.showEquipmentInInventory,
-                                newValue -> config.uiAndVisuals.showEquipmentInInventory = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .build())
-                .option(Option.<Boolean>createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.cancelComponentUpdateAnimation"))
-                        .description(Text.translatable("skyblocker.config.uiAndVisuals.cancelComponentUpdateAnimation.@Tooltip"))
-                        .binding(defaults.uiAndVisuals.cancelComponentUpdateAnimation,
-                                () -> config.uiAndVisuals.cancelComponentUpdateAnimation,
-                                newValue -> config.uiAndVisuals.cancelComponentUpdateAnimation = newValue)
-                        .controller(ConfigUtils.createBooleanController())
-                        .build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.compactorDeletorPreview"))
+						.binding(defaults.uiAndVisuals.compactorDeletorPreview,
+								() -> config.uiAndVisuals.compactorDeletorPreview,
+								newValue -> config.uiAndVisuals.compactorDeletorPreview = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.dontStripSkinAlphaValues"))
+						.description(Text.translatable("skyblocker.config.uiAndVisuals.dontStripSkinAlphaValues.@Tooltip"))
+						.binding(defaults.uiAndVisuals.dontStripSkinAlphaValues,
+								() -> config.uiAndVisuals.dontStripSkinAlphaValues,
+								newValue -> config.uiAndVisuals.dontStripSkinAlphaValues = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.flags(OptionFlag.ASSET_RELOAD)
+						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.backpackPreviewWithoutShift"))
+						.binding(defaults.uiAndVisuals.backpackPreviewWithoutShift,
+								() -> config.uiAndVisuals.backpackPreviewWithoutShift,
+								newValue -> config.uiAndVisuals.backpackPreviewWithoutShift = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.hideEmptyTooltips"))
+						.description(Text.translatable("skyblocker.config.uiAndVisuals.hideEmptyTooltips.@Tooltip"))
+						.binding(defaults.uiAndVisuals.hideEmptyTooltips,
+								() -> config.uiAndVisuals.hideEmptyTooltips,
+								newValue -> config.uiAndVisuals.hideEmptyTooltips = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.fancyCraftingTable"))
+						.binding(defaults.uiAndVisuals.fancyCraftingTable,
+								() -> config.uiAndVisuals.fancyCraftingTable,
+								newValue -> config.uiAndVisuals.fancyCraftingTable = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.hideStatusEffectOverlay"))
+						.binding(defaults.uiAndVisuals.hideStatusEffectOverlay,
+								() -> config.uiAndVisuals.hideStatusEffectOverlay,
+								newValue -> config.uiAndVisuals.hideStatusEffectOverlay = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.showEquipmentInInventory"))
+						.binding(defaults.uiAndVisuals.showEquipmentInInventory,
+								() -> config.uiAndVisuals.showEquipmentInInventory,
+								newValue -> config.uiAndVisuals.showEquipmentInInventory = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.cancelComponentUpdateAnimation"))
+						.description(Text.translatable("skyblocker.config.uiAndVisuals.cancelComponentUpdateAnimation.@Tooltip"))
+						.binding(defaults.uiAndVisuals.cancelComponentUpdateAnimation,
+								() -> config.uiAndVisuals.cancelComponentUpdateAnimation,
+								newValue -> config.uiAndVisuals.cancelComponentUpdateAnimation = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
 				.option(Option.<Boolean>createBuilder()
 						.name(Text.translatable("skyblocker.config.uiAndVisuals.showCustomizeButton"))
 						.description(Text.translatable("skyblocker.config.uiAndVisuals.showCustomizeButton.@Tooltip"))
@@ -137,48 +137,56 @@ public class UIAndVisualsCategory {
 								newValue -> config.uiAndVisuals.showConfigButton = newValue)
 						.controller(ConfigUtils.createBooleanController())
 						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.showTooltipToggleButton"))
+						.description(Text.translatable("skyblocker.config.uiAndVisuals.showTooltipToggleButton.@Tooltip"))
+						.binding(defaults.uiAndVisuals.showTooltipToggleButton,
+								() -> config.uiAndVisuals.showTooltipToggleButton,
+								newValue -> config.uiAndVisuals.showTooltipToggleButton = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
 
-                //Chest Value FIXME change dropdown to color controller
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.enableChestValue"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.enableChestValue.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.chestValue.enableChestValue,
-                                        () -> config.uiAndVisuals.chestValue.enableChestValue,
-                                        newValue -> config.uiAndVisuals.chestValue.enableChestValue = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Formatting>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.color"))
-                                .binding(defaults.uiAndVisuals.chestValue.color,
-                                        () -> config.uiAndVisuals.chestValue.color,
-                                        newValue -> config.uiAndVisuals.chestValue.color = newValue)
-                                .controller(ConfigUtils.createEnumDropdownController(ConfigUtils.FORMATTING_FORMATTER))
-                                .build())
-                        .option(Option.<Formatting>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.incompleteColor"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.incompleteColor.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.chestValue.incompleteColor,
-                                        () -> config.uiAndVisuals.chestValue.incompleteColor,
-                                        newValue -> config.uiAndVisuals.chestValue.incompleteColor = newValue)
-                                .controller(ConfigUtils.createEnumDropdownController(ConfigUtils.FORMATTING_FORMATTER))
-                                .build())
-                        .build())
+				//Chest Value FIXME change dropdown to color controller
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.enableChestValue"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.enableChestValue.@Tooltip"))
+								.binding(defaults.uiAndVisuals.chestValue.enableChestValue,
+										() -> config.uiAndVisuals.chestValue.enableChestValue,
+										newValue -> config.uiAndVisuals.chestValue.enableChestValue = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Formatting>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.color"))
+								.binding(defaults.uiAndVisuals.chestValue.color,
+										() -> config.uiAndVisuals.chestValue.color,
+										newValue -> config.uiAndVisuals.chestValue.color = newValue)
+								.controller(ConfigUtils.createEnumDropdownController(ConfigUtils.FORMATTING_FORMATTER))
+								.build())
+						.option(Option.<Formatting>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.incompleteColor"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.chestValue.incompleteColor.@Tooltip"))
+								.binding(defaults.uiAndVisuals.chestValue.incompleteColor,
+										() -> config.uiAndVisuals.chestValue.incompleteColor,
+										newValue -> config.uiAndVisuals.chestValue.incompleteColor = newValue)
+								.controller(ConfigUtils.createEnumDropdownController(ConfigUtils.FORMATTING_FORMATTER))
+								.build())
+						.build())
 
-                //Item Cooldown
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.itemCooldown"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.itemCooldown.enableItemCooldowns"))
-                                .binding(defaults.uiAndVisuals.itemCooldown.enableItemCooldowns,
-                                        () -> config.uiAndVisuals.itemCooldown.enableItemCooldowns,
-                                        newValue -> config.uiAndVisuals.itemCooldown.enableItemCooldowns = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .build())
+				//Item Cooldown
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.itemCooldown"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.itemCooldown.enableItemCooldowns"))
+								.binding(defaults.uiAndVisuals.itemCooldown.enableItemCooldowns,
+										() -> config.uiAndVisuals.itemCooldown.enableItemCooldowns,
+										newValue -> config.uiAndVisuals.itemCooldown.enableItemCooldowns = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.build())
 
 				.group(OptionGroup.createBuilder()
 						.name(Text.translatable("skyblocker.config.uiAndVisuals.slotText"))
@@ -199,64 +207,64 @@ public class UIAndVisualsCategory {
 						.build()
 				)
 
-                // Inventory Search
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch"))
-                        .collapsed(true)
-                        .option(Option.<UIAndVisualsConfig.InventorySearchConfig.EnableState>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.enabled"))
-                                .binding(defaults.uiAndVisuals.inventorySearch.enabled,
-                                        () -> config.uiAndVisuals.inventorySearch.enabled,
-                                        newValue -> config.uiAndVisuals.inventorySearch.enabled = newValue)
-                                .controller(ConfigUtils.createEnumController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(MinecraftClient.IS_SYSTEM_MAC ? Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.cmdK") : Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.ctrlK"))
-                                .binding(defaults.uiAndVisuals.inventorySearch.ctrlK,
-                                        () -> config.uiAndVisuals.inventorySearch.ctrlK,
-                                        newValue -> config.uiAndVisuals.inventorySearch.ctrlK = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.showClickableText"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.showClickableText.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.inventorySearch.clickableText,
-                                        () -> config.uiAndVisuals.inventorySearch.clickableText,
-                                        newValue -> config.uiAndVisuals.inventorySearch.clickableText = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .build())
+				// Inventory Search
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch"))
+						.collapsed(true)
+						.option(Option.<UIAndVisualsConfig.InventorySearchConfig.EnableState>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.enabled"))
+								.binding(defaults.uiAndVisuals.inventorySearch.enabled,
+										() -> config.uiAndVisuals.inventorySearch.enabled,
+										newValue -> config.uiAndVisuals.inventorySearch.enabled = newValue)
+								.controller(ConfigUtils.createEnumController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(MinecraftClient.IS_SYSTEM_MAC ? Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.cmdK") : Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.ctrlK"))
+								.binding(defaults.uiAndVisuals.inventorySearch.ctrlK,
+										() -> config.uiAndVisuals.inventorySearch.ctrlK,
+										newValue -> config.uiAndVisuals.inventorySearch.ctrlK = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.showClickableText"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.inventorySearch.showClickableText.@Tooltip"))
+								.binding(defaults.uiAndVisuals.inventorySearch.clickableText,
+										() -> config.uiAndVisuals.inventorySearch.clickableText,
+										newValue -> config.uiAndVisuals.inventorySearch.clickableText = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.build())
 
-                //Title Container
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer"))
-                        .description(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer.@Tooltip"))
-                        .collapsed(true)
-                        .option(Option.<Float>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer.titleContainerScale"))
-                                .binding(defaults.uiAndVisuals.titleContainer.titleContainerScale,
-                                        () -> config.uiAndVisuals.titleContainer.titleContainerScale,
-                                        newValue -> config.uiAndVisuals.titleContainer.titleContainerScale = newValue)
-                                .controller(FloatController.createBuilder().range(30f, 140f).build())
-                                .build())
-                        .option(ButtonOption.createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer.config"))
-                                .prompt(Text.translatable("text.skyblocker.open"))
-                                .action(screen -> MinecraftClient.getInstance().setScreen(new TitleContainerConfigScreen(screen)))
-                                .build())
-                        .build())
+				//Title Container
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer"))
+						.description(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer.@Tooltip"))
+						.collapsed(true)
+						.option(Option.<Float>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer.titleContainerScale"))
+								.binding(defaults.uiAndVisuals.titleContainer.titleContainerScale,
+										() -> config.uiAndVisuals.titleContainer.titleContainerScale,
+										newValue -> config.uiAndVisuals.titleContainer.titleContainerScale = newValue)
+								.controller(FloatController.createBuilder().range(30f, 140f).build())
+								.build())
+						.option(ButtonOption.createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.titleContainer.config"))
+								.prompt(Text.translatable("text.skyblocker.open"))
+								.action(screen -> MinecraftClient.getInstance().setScreen(new TitleContainerConfigScreen(screen)))
+								.build())
+						.build())
 
-                //Tab Hud
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.tabHudEnabled"))
-                                .binding(defaults.uiAndVisuals.tabHud.tabHudEnabled,
-                                        () -> config.uiAndVisuals.tabHud.tabHudEnabled,
-                                        newValue -> config.uiAndVisuals.tabHud.tabHudEnabled = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
+				//Tab Hud
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.tabHudEnabled"))
+								.binding(defaults.uiAndVisuals.tabHud.tabHudEnabled,
+										() -> config.uiAndVisuals.tabHud.tabHudEnabled,
+										newValue -> config.uiAndVisuals.tabHud.tabHudEnabled = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.option(ButtonOption.createBuilder()
 								.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.configScreen"))
 								.prompt(Text.translatable("text.skyblocker.open"))
@@ -268,14 +276,14 @@ public class UIAndVisualsCategory {
 									}
 								})
 								.build())
-                        .option(Option.<Integer>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.tabHudScale"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.tabHudScale.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.tabHud.tabHudScale,
-                                        () -> config.uiAndVisuals.tabHud.tabHudScale,
-                                        newValue -> config.uiAndVisuals.tabHud.tabHudScale = newValue)
-                                .controller(IntegerController.createBuilder().range(10, 200).slider(1).build())
-                                .build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.tabHudScale"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.tabHudScale.@Tooltip"))
+								.binding(defaults.uiAndVisuals.tabHud.tabHudScale,
+										() -> config.uiAndVisuals.tabHud.tabHudScale,
+										newValue -> config.uiAndVisuals.tabHud.tabHudScale = newValue)
+								.controller(IntegerController.createBuilder().range(10, 200).slider(1).build())
+								.build())
 						.option(Option.<Boolean>createBuilder()
 								.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.showVanillaTabByDefault"))
 								.description(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.showVanillaTabByDefault.@Tooltip"))
@@ -295,68 +303,68 @@ public class UIAndVisualsCategory {
 										newValue -> config.uiAndVisuals.tabHud.style = newValue)
 								.controller(ConfigUtils.createEnumController())
 								.build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.enableHudBackground"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.enableHudBackground.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.tabHud.enableHudBackground,
-                                        () -> config.uiAndVisuals.tabHud.enableHudBackground,
-                                        newValue -> config.uiAndVisuals.tabHud.enableHudBackground = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.effectsFooter"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.effectsFooter.@Tooltip"))
-                                .controller(ConfigUtils.createBooleanController())
-                                .binding(defaults.uiAndVisuals.tabHud.effectsFromFooter,
-                                        () -> config.uiAndVisuals.tabHud.effectsFromFooter,
-                                        newValue -> config.uiAndVisuals.tabHud.effectsFromFooter = newValue)
-                                .build())
-                        .option(Option.<ScreenBuilder.DefaultPositioner>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.defaultPositioning"))
-                                .binding(defaults.uiAndVisuals.tabHud.defaultPositioning,
-                                        () -> config.uiAndVisuals.tabHud.defaultPositioning,
-                                        newValue -> config.uiAndVisuals.tabHud.defaultPositioning = newValue)
-                                .controller(ConfigUtils.createEnumController())
-                                .build()
-                        )
-                        .build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.enableHudBackground"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.enableHudBackground.@Tooltip"))
+								.binding(defaults.uiAndVisuals.tabHud.enableHudBackground,
+										() -> config.uiAndVisuals.tabHud.enableHudBackground,
+										newValue -> config.uiAndVisuals.tabHud.enableHudBackground = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.effectsFooter"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.effectsFooter.@Tooltip"))
+								.controller(ConfigUtils.createBooleanController())
+								.binding(defaults.uiAndVisuals.tabHud.effectsFromFooter,
+										() -> config.uiAndVisuals.tabHud.effectsFromFooter,
+										newValue -> config.uiAndVisuals.tabHud.effectsFromFooter = newValue)
+								.build())
+						.option(Option.<ScreenBuilder.DefaultPositioner>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.tabHud.defaultPositioning"))
+								.binding(defaults.uiAndVisuals.tabHud.defaultPositioning,
+										() -> config.uiAndVisuals.tabHud.defaultPositioning,
+										newValue -> config.uiAndVisuals.tabHud.defaultPositioning = newValue)
+								.controller(ConfigUtils.createEnumController())
+								.build()
+						)
+						.build())
 
-                // Fancy Auction House
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.fancyAuctionHouse"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.fancyAuctionHouse.enabled"))
-                                .binding(defaults.uiAndVisuals.fancyAuctionHouse.enabled,
-                                        () -> config.uiAndVisuals.fancyAuctionHouse.enabled,
-                                        newValue -> config.uiAndVisuals.fancyAuctionHouse.enabled = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.fancyAuctionHouse.highlightUnderAvgPrice"))
-                                .binding(defaults.uiAndVisuals.fancyAuctionHouse.highlightCheapBIN,
-                                        () -> config.uiAndVisuals.fancyAuctionHouse.highlightCheapBIN,
-                                        newValue -> config.uiAndVisuals.fancyAuctionHouse.highlightCheapBIN = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .build())
+				// Fancy Auction House
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.fancyAuctionHouse"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.fancyAuctionHouse.enabled"))
+								.binding(defaults.uiAndVisuals.fancyAuctionHouse.enabled,
+										() -> config.uiAndVisuals.fancyAuctionHouse.enabled,
+										newValue -> config.uiAndVisuals.fancyAuctionHouse.enabled = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.fancyAuctionHouse.highlightUnderAvgPrice"))
+								.binding(defaults.uiAndVisuals.fancyAuctionHouse.highlightCheapBIN,
+										() -> config.uiAndVisuals.fancyAuctionHouse.highlightCheapBIN,
+										newValue -> config.uiAndVisuals.fancyAuctionHouse.highlightCheapBIN = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.build())
 
-                //Fancy Bars
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.bars"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.bars.enableBars"))
-                                .binding(defaults.uiAndVisuals.bars.enableBars,
-                                        () -> config.uiAndVisuals.bars.enableBars,
-                                        newValue -> config.uiAndVisuals.bars.enableBars = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(ButtonOption.createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.bars.openScreen"))
-                                .prompt(Text.translatable("text.skyblocker.open"))
-                                .action(screen -> MinecraftClient.getInstance().setScreen(new StatusBarsConfigScreen()))
-                                .build())
+				//Fancy Bars
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.bars"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.bars.enableBars"))
+								.binding(defaults.uiAndVisuals.bars.enableBars,
+										() -> config.uiAndVisuals.bars.enableBars,
+										newValue -> config.uiAndVisuals.bars.enableBars = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(ButtonOption.createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.bars.openScreen"))
+								.prompt(Text.translatable("text.skyblocker.open"))
+								.action(screen -> MinecraftClient.getInstance().setScreen(new StatusBarsConfigScreen()))
+								.build())
 						.option(Option.<UIAndVisualsConfig.IntelligenceDisplay>createBuilder()
 								.name(Text.translatable("skyblocker.config.uiAndVisuals.bars.intelligenceDisplay"))
 								.binding(defaults.uiAndVisuals.bars.intelligenceDisplay,
@@ -365,138 +373,138 @@ public class UIAndVisualsCategory {
 								.controller(ConfigUtils.createEnumController(intelligenceDisplay -> Text.translatable("skyblocker.config.uiAndVisuals.bars.intelligenceDisplay." + intelligenceDisplay.name())))
 								.build()
 						)
-                        .build())
+						.build())
 
-                //Waypoints
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.waypoints"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.waypoints.enableWaypoints"))
-                                .binding(defaults.uiAndVisuals.waypoints.enableWaypoints,
-                                        () -> config.uiAndVisuals.waypoints.enableWaypoints,
-                                        newValue -> config.uiAndVisuals.waypoints.enableWaypoints = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Waypoint.Type>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.waypoints.waypointType"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.waypoints.waypointType.@Tooltip"),
-                                        Text.translatable("skyblocker.config.uiAndVisuals.waypoints.waypointType.generalNote"))
-                                .binding(defaults.uiAndVisuals.waypoints.waypointType,
-                                        () -> config.uiAndVisuals.waypoints.waypointType,
-                                        newValue -> config.uiAndVisuals.waypoints.waypointType = newValue)
-                                .controller(ConfigUtils.createEnumController())
-                                .build())
-                        .option(ButtonOption.createBuilder()
-                                .name(Text.translatable("skyblocker.waypoints.config"))
-                                .prompt(Text.translatable("text.skyblocker.open"))
-                                .action(screen -> MinecraftClient.getInstance().setScreen(new WaypointsScreen(screen)))
-                                .build())
-                        .build())
+				//Waypoints
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.waypoints"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.waypoints.enableWaypoints"))
+								.binding(defaults.uiAndVisuals.waypoints.enableWaypoints,
+										() -> config.uiAndVisuals.waypoints.enableWaypoints,
+										newValue -> config.uiAndVisuals.waypoints.enableWaypoints = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Waypoint.Type>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.waypoints.waypointType"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.waypoints.waypointType.@Tooltip"),
+										Text.translatable("skyblocker.config.uiAndVisuals.waypoints.waypointType.generalNote"))
+								.binding(defaults.uiAndVisuals.waypoints.waypointType,
+										() -> config.uiAndVisuals.waypoints.waypointType,
+										newValue -> config.uiAndVisuals.waypoints.waypointType = newValue)
+								.controller(ConfigUtils.createEnumController())
+								.build())
+						.option(ButtonOption.createBuilder()
+								.name(Text.translatable("skyblocker.waypoints.config"))
+								.prompt(Text.translatable("text.skyblocker.open"))
+								.action(screen -> MinecraftClient.getInstance().setScreen(new WaypointsScreen(screen)))
+								.build())
+						.build())
 
-                //Teleport Overlays
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableTeleportOverlays"))
-                                .binding(defaults.uiAndVisuals.teleportOverlay.enableTeleportOverlays,
-                                        () -> config.uiAndVisuals.teleportOverlay.enableTeleportOverlays,
-                                        newValue -> config.uiAndVisuals.teleportOverlay.enableTeleportOverlays = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Color>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.teleportOverlayColor"))
-                                .binding(defaults.uiAndVisuals.teleportOverlay.teleportOverlayColor,
-                                        () -> config.uiAndVisuals.teleportOverlay.teleportOverlayColor,
-                                        newValue -> {
-                                            config.uiAndVisuals.teleportOverlay.teleportOverlayColor = newValue;
-                                            TeleportOverlay.configCallback(newValue);
-                                       })
-                                .controller(ColourController.createBuilder().hasAlpha(true).build())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableWeirdTransmission"))
-                                .binding(defaults.uiAndVisuals.teleportOverlay.enableWeirdTransmission,
-                                        () -> config.uiAndVisuals.teleportOverlay.enableWeirdTransmission,
-                                        newValue -> config.uiAndVisuals.teleportOverlay.enableWeirdTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableInstantTransmission"))
-                                .binding(defaults.uiAndVisuals.teleportOverlay.enableInstantTransmission,
-                                        () -> config.uiAndVisuals.teleportOverlay.enableInstantTransmission,
-                                        newValue -> config.uiAndVisuals.teleportOverlay.enableInstantTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableEtherTransmission"))
-                                .binding(defaults.uiAndVisuals.teleportOverlay.enableEtherTransmission,
-                                        () -> config.uiAndVisuals.teleportOverlay.enableEtherTransmission,
-                                        newValue -> config.uiAndVisuals.teleportOverlay.enableEtherTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableSinrecallTransmission"))
-                                .binding(defaults.uiAndVisuals.teleportOverlay.enableSinrecallTransmission,
-                                        () -> config.uiAndVisuals.teleportOverlay.enableSinrecallTransmission,
-                                        newValue -> config.uiAndVisuals.teleportOverlay.enableSinrecallTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableWitherImpact"))
-                                .binding(defaults.uiAndVisuals.teleportOverlay.enableWitherImpact,
-                                        () -> config.uiAndVisuals.teleportOverlay.enableWitherImpact,
-                                        newValue -> config.uiAndVisuals.teleportOverlay.enableWitherImpact = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .build())
+				//Teleport Overlays
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableTeleportOverlays"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.enableTeleportOverlays,
+										() -> config.uiAndVisuals.teleportOverlay.enableTeleportOverlays,
+										newValue -> config.uiAndVisuals.teleportOverlay.enableTeleportOverlays = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Color>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.teleportOverlayColor"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.teleportOverlayColor,
+										() -> config.uiAndVisuals.teleportOverlay.teleportOverlayColor,
+										newValue -> {
+											config.uiAndVisuals.teleportOverlay.teleportOverlayColor = newValue;
+											TeleportOverlay.configCallback(newValue);
+										})
+								.controller(ColourController.createBuilder().hasAlpha(true).build())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableWeirdTransmission"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.enableWeirdTransmission,
+										() -> config.uiAndVisuals.teleportOverlay.enableWeirdTransmission,
+										newValue -> config.uiAndVisuals.teleportOverlay.enableWeirdTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableInstantTransmission"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.enableInstantTransmission,
+										() -> config.uiAndVisuals.teleportOverlay.enableInstantTransmission,
+										newValue -> config.uiAndVisuals.teleportOverlay.enableInstantTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableEtherTransmission"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.enableEtherTransmission,
+										() -> config.uiAndVisuals.teleportOverlay.enableEtherTransmission,
+										newValue -> config.uiAndVisuals.teleportOverlay.enableEtherTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableSinrecallTransmission"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.enableSinrecallTransmission,
+										() -> config.uiAndVisuals.teleportOverlay.enableSinrecallTransmission,
+										newValue -> config.uiAndVisuals.teleportOverlay.enableSinrecallTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableWitherImpact"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.enableWitherImpact,
+										() -> config.uiAndVisuals.teleportOverlay.enableWitherImpact,
+										newValue -> config.uiAndVisuals.teleportOverlay.enableWitherImpact = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.build())
 
-                //Smooth AOTE
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE"))
-                        .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.@Tooltip"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWeirdTransmission"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWeirdTransmission.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.smoothAOTE.enableWeirdTransmission,
-                                        () -> config.uiAndVisuals.smoothAOTE.enableWeirdTransmission,
-                                        newValue -> config.uiAndVisuals.smoothAOTE.enableWeirdTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableInstantTransmission"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableInstantTransmission.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.smoothAOTE.enableInstantTransmission,
-                                        () -> config.uiAndVisuals.smoothAOTE.enableInstantTransmission,
-                                        newValue -> config.uiAndVisuals.smoothAOTE.enableInstantTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.smoothAOTE.enableEtherTransmission,
-                                        () -> config.uiAndVisuals.smoothAOTE.enableEtherTransmission,
-                                        newValue -> config.uiAndVisuals.smoothAOTE.enableEtherTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.smoothAOTE.enableSinrecallTransmission,
-                                        () -> config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission,
-                                        newValue -> config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWitherImpact"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWitherImpact.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.smoothAOTE.enableWitherImpact,
-                                        () -> config.uiAndVisuals.smoothAOTE.enableWitherImpact,
-                                        newValue -> config.uiAndVisuals.smoothAOTE.enableWitherImpact = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
+				//Smooth AOTE
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE"))
+						.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.@Tooltip"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWeirdTransmission"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWeirdTransmission.@Tooltip"))
+								.binding(defaults.uiAndVisuals.smoothAOTE.enableWeirdTransmission,
+										() -> config.uiAndVisuals.smoothAOTE.enableWeirdTransmission,
+										newValue -> config.uiAndVisuals.smoothAOTE.enableWeirdTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableInstantTransmission"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableInstantTransmission.@Tooltip"))
+								.binding(defaults.uiAndVisuals.smoothAOTE.enableInstantTransmission,
+										() -> config.uiAndVisuals.smoothAOTE.enableInstantTransmission,
+										newValue -> config.uiAndVisuals.smoothAOTE.enableInstantTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission.@Tooltip"))
+								.binding(defaults.uiAndVisuals.smoothAOTE.enableEtherTransmission,
+										() -> config.uiAndVisuals.smoothAOTE.enableEtherTransmission,
+										newValue -> config.uiAndVisuals.smoothAOTE.enableEtherTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission.@Tooltip"))
+								.binding(defaults.uiAndVisuals.smoothAOTE.enableSinrecallTransmission,
+										() -> config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission,
+										newValue -> config.uiAndVisuals.smoothAOTE.enableSinrecallTransmission = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWitherImpact"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWitherImpact.@Tooltip"))
+								.binding(defaults.uiAndVisuals.smoothAOTE.enableWitherImpact,
+										() -> config.uiAndVisuals.smoothAOTE.enableWitherImpact,
+										newValue -> config.uiAndVisuals.smoothAOTE.enableWitherImpact = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.option(Option.<Integer>createBuilder()
 								.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.maximumAddedLag"))
 								.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.maximumAddedLag.@Tooltip"))
@@ -505,61 +513,61 @@ public class UIAndVisualsCategory {
 										newValue -> config.uiAndVisuals.smoothAOTE.maximumAddedLag = newValue)
 								.controller(IntegerController.createBuilder().range(0, 500).slider(1).build())
 								.build())
-                        .build())
+						.build())
 
-                //Search overlay
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableBazaar"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableBazaar.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.searchOverlay.enableBazaar,
-                                        () -> config.uiAndVisuals.searchOverlay.enableBazaar,
-                                        newValue -> config.uiAndVisuals.searchOverlay.enableBazaar = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableAuctionHouse"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableAuctionHouse.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.searchOverlay.enableAuctionHouse,
-                                        () -> config.uiAndVisuals.searchOverlay.enableAuctionHouse,
-                                        newValue -> config.uiAndVisuals.searchOverlay.enableAuctionHouse = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.keepPreviousSearches"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.keepPreviousSearches.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.searchOverlay.keepPreviousSearches,
-                                        () -> config.uiAndVisuals.searchOverlay.keepPreviousSearches,
-                                        newValue -> config.uiAndVisuals.searchOverlay.keepPreviousSearches = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Integer>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.maxSuggestions"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.maxSuggestions.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.searchOverlay.maxSuggestions,
-                                        () -> config.uiAndVisuals.searchOverlay.maxSuggestions,
-                                        newValue -> config.uiAndVisuals.searchOverlay.maxSuggestions = newValue)
-                                .controller(IntegerController.createBuilder().range(0, 5).slider(1).build())
-                                .build())
-                        .option(Option.<Integer>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.historyLength"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.historyLength.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.searchOverlay.historyLength,
-                                        () -> config.uiAndVisuals.searchOverlay.historyLength,
-                                        newValue -> config.uiAndVisuals.searchOverlay.historyLength = newValue)
-                                .controller(IntegerController.createBuilder().range(0, 5).slider(1).build())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableCommands"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableCommands.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.searchOverlay.enableCommands,
-                                        () -> config.uiAndVisuals.searchOverlay.enableCommands,
-                                        newValue -> config.uiAndVisuals.searchOverlay.enableCommands = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .build())
+				//Search overlay
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableBazaar"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableBazaar.@Tooltip"))
+								.binding(defaults.uiAndVisuals.searchOverlay.enableBazaar,
+										() -> config.uiAndVisuals.searchOverlay.enableBazaar,
+										newValue -> config.uiAndVisuals.searchOverlay.enableBazaar = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableAuctionHouse"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableAuctionHouse.@Tooltip"))
+								.binding(defaults.uiAndVisuals.searchOverlay.enableAuctionHouse,
+										() -> config.uiAndVisuals.searchOverlay.enableAuctionHouse,
+										newValue -> config.uiAndVisuals.searchOverlay.enableAuctionHouse = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.keepPreviousSearches"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.keepPreviousSearches.@Tooltip"))
+								.binding(defaults.uiAndVisuals.searchOverlay.keepPreviousSearches,
+										() -> config.uiAndVisuals.searchOverlay.keepPreviousSearches,
+										newValue -> config.uiAndVisuals.searchOverlay.keepPreviousSearches = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.maxSuggestions"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.maxSuggestions.@Tooltip"))
+								.binding(defaults.uiAndVisuals.searchOverlay.maxSuggestions,
+										() -> config.uiAndVisuals.searchOverlay.maxSuggestions,
+										newValue -> config.uiAndVisuals.searchOverlay.maxSuggestions = newValue)
+								.controller(IntegerController.createBuilder().range(0, 5).slider(1).build())
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.historyLength"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.historyLength.@Tooltip"))
+								.binding(defaults.uiAndVisuals.searchOverlay.historyLength,
+										() -> config.uiAndVisuals.searchOverlay.historyLength,
+										newValue -> config.uiAndVisuals.searchOverlay.historyLength = newValue)
+								.controller(IntegerController.createBuilder().range(0, 5).slider(1).build())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableCommands"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.searchOverlay.enableCommands.@Tooltip"))
+								.binding(defaults.uiAndVisuals.searchOverlay.enableCommands,
+										() -> config.uiAndVisuals.searchOverlay.enableCommands,
+										newValue -> config.uiAndVisuals.searchOverlay.enableCommands = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.build())
 
 				// Bazaar Quick Quantities
 				.group(OptionGroup.createBuilder()
@@ -603,26 +611,26 @@ public class UIAndVisualsCategory {
 								.build())
 						.build())
 
-                //Input Calculator
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.enabled"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.enabled.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.inputCalculator.enabled,
-                                        () -> config.uiAndVisuals.inputCalculator.enabled,
-                                        newValue -> config.uiAndVisuals.inputCalculator.enabled = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.requiresEquals"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.requiresEquals.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.inputCalculator.requiresEquals,
-                                        () -> config.uiAndVisuals.inputCalculator.requiresEquals,
-                                        newValue -> config.uiAndVisuals.inputCalculator.requiresEquals = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
+				//Input Calculator
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.enabled"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.enabled.@Tooltip"))
+								.binding(defaults.uiAndVisuals.inputCalculator.enabled,
+										() -> config.uiAndVisuals.inputCalculator.enabled,
+										newValue -> config.uiAndVisuals.inputCalculator.enabled = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.requiresEquals"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.requiresEquals.@Tooltip"))
+								.binding(defaults.uiAndVisuals.inputCalculator.requiresEquals,
+										() -> config.uiAndVisuals.inputCalculator.requiresEquals,
+										newValue -> config.uiAndVisuals.inputCalculator.requiresEquals = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.option(Option.<Boolean>createBuilder()
 								.name(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.closeSignsWithEnter"))
 								.description(Text.translatable("skyblocker.config.uiAndVisuals.inputCalculator.closeSignsWithEnter.@Tooltip"))
@@ -631,72 +639,72 @@ public class UIAndVisualsCategory {
 										newValue -> config.uiAndVisuals.inputCalculator.closeSignsWithEnter = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
-                        .build())
+						.build())
 
-                //Flame Overlay
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay"))
-                        .collapsed(true)
-                        .option(Option.<Integer>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameHeight"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameHeight.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.flameOverlay.flameHeight,
-                                        () -> config.uiAndVisuals.flameOverlay.flameHeight,
-                                        newValue -> config.uiAndVisuals.flameOverlay.flameHeight = newValue)
-                                .controller(IntegerController.createBuilder().range(0, 100).slider(1).build())
-                                .build())
-                        .option(Option.<Integer>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameOpacity"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameOpacity.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.flameOverlay.flameOpacity,
-                                        () -> config.uiAndVisuals.flameOverlay.flameOpacity,
-                                        newValue -> config.uiAndVisuals.flameOverlay.flameOpacity = newValue)
-                                .controller(IntegerController.createBuilder().range(0, 100).slider(1).build())
-                                .build())
-                        .build())
+				//Flame Overlay
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay"))
+						.collapsed(true)
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameHeight"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameHeight.@Tooltip"))
+								.binding(defaults.uiAndVisuals.flameOverlay.flameHeight,
+										() -> config.uiAndVisuals.flameOverlay.flameHeight,
+										newValue -> config.uiAndVisuals.flameOverlay.flameHeight = newValue)
+								.controller(IntegerController.createBuilder().range(0, 100).slider(1).build())
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameOpacity"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.flameOverlay.flameOpacity.@Tooltip"))
+								.binding(defaults.uiAndVisuals.flameOverlay.flameOpacity,
+										() -> config.uiAndVisuals.flameOverlay.flameOpacity,
+										newValue -> config.uiAndVisuals.flameOverlay.flameOpacity = newValue)
+								.controller(IntegerController.createBuilder().range(0, 100).slider(1).build())
+								.build())
+						.build())
 
-                //Compact Damage Numbers
-                .group(OptionGroup.createBuilder()
-                        .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage"))
-                        .collapsed(true)
-                        .option(Option.<Boolean>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.enabled"))
-                                .binding(defaults.uiAndVisuals.compactDamage.enabled,
-                                        () -> config.uiAndVisuals.compactDamage.enabled,
-                                        newValue -> config.uiAndVisuals.compactDamage.enabled = newValue)
-                                .controller(ConfigUtils.createBooleanController())
-                                .build())
-                        .option(Option.<Integer>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.precision"))
-                                .description(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.precision.@Tooltip"))
-                                .binding(defaults.uiAndVisuals.compactDamage.precision,
-                                        () -> config.uiAndVisuals.compactDamage.precision,
-                                        newValue -> config.uiAndVisuals.compactDamage.precision = newValue)
-                                .controller(IntegerController.createBuilder().range(1, 3).slider(1).build())
-                                .build())
-                        .option(Option.<Color>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.normalDamageColor"))
-                                .binding(defaults.uiAndVisuals.compactDamage.normalDamageColor,
-                                        () -> config.uiAndVisuals.compactDamage.normalDamageColor,
-                                        newValue -> config.uiAndVisuals.compactDamage.normalDamageColor = newValue)
-                                .controller(ColourController.createBuilder().build())
-                                .build())
-                        .option(Option.<Color>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientStart"))
-                                .binding(defaults.uiAndVisuals.compactDamage.critDamageGradientStart,
-                                        () -> config.uiAndVisuals.compactDamage.critDamageGradientStart,
-                                        newValue -> config.uiAndVisuals.compactDamage.critDamageGradientStart = newValue)
-                                .controller(ColourController.createBuilder().build())
-                                .build())
-                        .option(Option.<Color>createBuilder()
-                                .name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientEnd"))
-                                .binding(defaults.uiAndVisuals.compactDamage.critDamageGradientEnd,
-                                        () -> config.uiAndVisuals.compactDamage.critDamageGradientEnd,
-                                        newValue -> config.uiAndVisuals.compactDamage.critDamageGradientEnd = newValue)
-                                .controller(ColourController.createBuilder().build())
-                                .build())
-                        .build()
-                )
+				//Compact Damage Numbers
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.enabled"))
+								.binding(defaults.uiAndVisuals.compactDamage.enabled,
+										() -> config.uiAndVisuals.compactDamage.enabled,
+										newValue -> config.uiAndVisuals.compactDamage.enabled = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Integer>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.precision"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.precision.@Tooltip"))
+								.binding(defaults.uiAndVisuals.compactDamage.precision,
+										() -> config.uiAndVisuals.compactDamage.precision,
+										newValue -> config.uiAndVisuals.compactDamage.precision = newValue)
+								.controller(IntegerController.createBuilder().range(1, 3).slider(1).build())
+								.build())
+						.option(Option.<Color>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.normalDamageColor"))
+								.binding(defaults.uiAndVisuals.compactDamage.normalDamageColor,
+										() -> config.uiAndVisuals.compactDamage.normalDamageColor,
+										newValue -> config.uiAndVisuals.compactDamage.normalDamageColor = newValue)
+								.controller(ColourController.createBuilder().build())
+								.build())
+						.option(Option.<Color>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientStart"))
+								.binding(defaults.uiAndVisuals.compactDamage.critDamageGradientStart,
+										() -> config.uiAndVisuals.compactDamage.critDamageGradientStart,
+										newValue -> config.uiAndVisuals.compactDamage.critDamageGradientStart = newValue)
+								.controller(ColourController.createBuilder().build())
+								.build())
+						.option(Option.<Color>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.compactDamage.critDamageGradientEnd"))
+								.binding(defaults.uiAndVisuals.compactDamage.critDamageGradientEnd,
+										() -> config.uiAndVisuals.compactDamage.critDamageGradientEnd,
+										newValue -> config.uiAndVisuals.compactDamage.critDamageGradientEnd = newValue)
+								.controller(ColourController.createBuilder().build())
+								.build())
+						.build()
+				)
 
 				//Custom Health bars
 				.group(OptionGroup.createBuilder()
@@ -811,8 +819,8 @@ public class UIAndVisualsCategory {
 								.build())
 						.build()
 				)
-                .build();
-    }
+				.build();
+	}
 
 	private static List<Option<Boolean>> createSlotTextToggles(SkyblockerConfig config) {
 		return SlotTextManager.getAdderStream().map(SlotTextAdder::getConfigInformation).filter(Objects::nonNull).distinct()

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -4,12 +4,14 @@ import de.hysky.skyblocker.skyblock.item.slottext.SlotTextMode;
 import de.hysky.skyblocker.skyblock.tabhud.screenbuilder.ScreenBuilder;
 import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.util.Formatting;
 
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class UIAndVisualsConfig {
 
@@ -17,73 +19,83 @@ public class UIAndVisualsConfig {
 
 	public int nightVisionStrength = 100;
 
-    public boolean compactorDeletorPreview = true;
+	public boolean compactorDeletorPreview = true;
 
-    public boolean dontStripSkinAlphaValues = true;
+	public boolean dontStripSkinAlphaValues = true;
 
-    public boolean backpackPreviewWithoutShift = false;
+	public boolean backpackPreviewWithoutShift = false;
 
-    public boolean hideEmptyTooltips = true;
+	public boolean hideEmptyTooltips = true;
 
-    public boolean fancyCraftingTable = true;
+	public boolean fancyCraftingTable = true;
 
-    public boolean hideStatusEffectOverlay = true;
+	public boolean hideStatusEffectOverlay = true;
 
-    public boolean showEquipmentInInventory = true;
+	public boolean showEquipmentInInventory = true;
 
-    public boolean cancelComponentUpdateAnimation = true;
+	public boolean cancelComponentUpdateAnimation = true;
 
 	public boolean showCustomizeButton = true;
 
 	public boolean showConfigButton = false;
 
-    public ChestValue chestValue = new ChestValue();
+	/**
+	 * Show the tooltip toggle button in container screens.
+	 */
+	public boolean showTooltipToggleButton = true;
 
-    public ItemCooldown itemCooldown = new ItemCooldown();
+	public ChestValue chestValue = new ChestValue();
+
+	public ItemCooldown itemCooldown = new ItemCooldown();
 
 	public SlotText slotText = new SlotText();
 
-    public InventorySearchConfig inventorySearch = new InventorySearchConfig();
+	public InventorySearchConfig inventorySearch = new InventorySearchConfig();
 
-    public TitleContainer titleContainer = new TitleContainer();
+	/**
+	 * Titles of container screens that should not display Skyblocker tooltips.
+	 */
+	public Set<String> tooltipBlacklist = new ObjectOpenHashSet<>();
 
-    public TabHudConf tabHud = new TabHudConf();
+	public TitleContainer titleContainer = new TitleContainer();
 
-    public FancyAuctionHouse fancyAuctionHouse = new FancyAuctionHouse();
+	public TabHudConf tabHud = new TabHudConf();
 
-    public Bars bars = new Bars();
+	public FancyAuctionHouse fancyAuctionHouse = new FancyAuctionHouse();
 
-    public Waypoints waypoints = new Waypoints();
+	public Bars bars = new Bars();
 
-    public TeleportOverlay teleportOverlay = new TeleportOverlay();
+	public Waypoints waypoints = new Waypoints();
 
-    public SmoothAOTE smoothAOTE = new SmoothAOTE();
+	public TeleportOverlay teleportOverlay = new TeleportOverlay();
 
-    public SearchOverlay searchOverlay = new SearchOverlay();
+	public SmoothAOTE smoothAOTE = new SmoothAOTE();
+
+	public SearchOverlay searchOverlay = new SearchOverlay();
 
 	public BazaarQuickQuantities bazaarQuickQuantities = new BazaarQuickQuantities();
 
-    public InputCalculator inputCalculator = new InputCalculator();
+	public InputCalculator inputCalculator = new InputCalculator();
 
-    public FlameOverlay flameOverlay = new FlameOverlay();
+	public FlameOverlay flameOverlay = new FlameOverlay();
 
-    public CompactDamage compactDamage = new CompactDamage();
+	public CompactDamage compactDamage = new CompactDamage();
 
 	public HealthBars healthBars = new HealthBars();
 
 	public ItemPickup itemPickup = new ItemPickup();
 
-    public static class ChestValue {
-        public boolean enableChestValue = true;
+	public static class ChestValue {
+		public boolean enableChestValue = true;
 
-        public Formatting color = Formatting.DARK_GREEN;
+		public Formatting color = Formatting.DARK_GREEN;
 
-        public Formatting incompleteColor = Formatting.BLUE;
-    }
+		public Formatting incompleteColor = Formatting.BLUE;
+	}
 
-    public static class ItemCooldown {
-        public boolean enableItemCooldowns = true;
-    }
+	public static class ItemCooldown {
+		public boolean enableItemCooldowns = true;
+	}
 
 	public static class SlotText {
 		public SlotTextMode slotTextMode = SlotTextMode.ENABLED;
@@ -94,88 +106,88 @@ public class UIAndVisualsConfig {
 
 	}
 
-    public static class InventorySearchConfig {
-        public EnableState enabled = EnableState.SKYBLOCK;
+	public static class InventorySearchConfig {
+		public EnableState enabled = EnableState.SKYBLOCK;
 
-        public boolean ctrlK = false;
+		public boolean ctrlK = false;
 
-        public boolean clickableText = false;
+		public boolean clickableText = false;
 
-        public enum EnableState {
-            OFF,
-            SKYBLOCK,
-            EVERYWHERE;
+		public enum EnableState {
+			OFF,
+			SKYBLOCK,
+			EVERYWHERE;
 
-            @Override
-            public String toString() {
-                return I18n.translate("skyblocker.config.uiAndVisuals.inventorySearch.state." + this.name());
-            }
+			@Override
+			public String toString() {
+				return I18n.translate("skyblocker.config.uiAndVisuals.inventorySearch.state." + this.name());
+			}
 
-            public boolean isEnabled() {
-                return switch (this) {
-                    case OFF -> false;
-                    case SKYBLOCK -> de.hysky.skyblocker.utils.Utils.isOnSkyblock();
-                    case EVERYWHERE -> true;
-                };
-            }
-        }
-    }
+			public boolean isEnabled() {
+				return switch (this) {
+					case OFF -> false;
+					case SKYBLOCK -> de.hysky.skyblocker.utils.Utils.isOnSkyblock();
+					case EVERYWHERE -> true;
+				};
+			}
+		}
+	}
 
-    public static class TitleContainer {
-        public float titleContainerScale = 100;
+	public static class TitleContainer {
+		public float titleContainerScale = 100;
 
-        public int x = 540;
+		public int x = 540;
 
-        public int y = 10;
+		public int y = 10;
 
-        public Direction direction = Direction.VERTICAL;
+		public Direction direction = Direction.VERTICAL;
 
-        public Alignment alignment = Alignment.MIDDLE;
+		public Alignment alignment = Alignment.MIDDLE;
 
-        public float getRenderScale() {
-            return titleContainerScale * 0.03f;
-        }
-    }
+		public float getRenderScale() {
+			return titleContainerScale * 0.03f;
+		}
+	}
 
-    public enum Direction {
-        HORIZONTAL, VERTICAL;
+	public enum Direction {
+		HORIZONTAL, VERTICAL;
 
-        @Override
-        public String toString() {
-            return I18n.translate("skyblocker.config.uiAndVisuals.titleContainer.direction." + name());
-        }
-    }
+		@Override
+		public String toString() {
+			return I18n.translate("skyblocker.config.uiAndVisuals.titleContainer.direction." + name());
+		}
+	}
 
-    public enum Alignment {
-        LEFT, MIDDLE, RIGHT;
+	public enum Alignment {
+		LEFT, MIDDLE, RIGHT;
 
-        @Override
-        public String toString() {
-            return I18n.translate("skyblocker.config.uiAndVisuals.titleContainer.alignment." + name());
-        }
-    }
+		@Override
+		public String toString() {
+			return I18n.translate("skyblocker.config.uiAndVisuals.titleContainer.alignment." + name());
+		}
+	}
 
-    public static class TabHudConf {
-        public boolean tabHudEnabled = true;
+	public static class TabHudConf {
+		public boolean tabHudEnabled = true;
 
-        public int tabHudScale = 100;
+		public int tabHudScale = 100;
 
 		public boolean showVanillaTabByDefault = false;
 
 		public TabHudStyle style = TabHudStyle.FANCY;
 
-        public boolean enableHudBackground = true;
+		public boolean enableHudBackground = true;
 
-        public boolean effectsFromFooter = false;
+		public boolean effectsFromFooter = false;
 
-        public ScreenBuilder.DefaultPositioner defaultPositioning = ScreenBuilder.DefaultPositioner.CENTERED;
+		public ScreenBuilder.DefaultPositioner defaultPositioning = ScreenBuilder.DefaultPositioner.CENTERED;
 
-        @Deprecated
-        public transient boolean plainPlayerNames = false;
+		@Deprecated
+		public transient boolean plainPlayerNames = false;
 
-        @Deprecated
-        public transient NameSorting nameSorting = NameSorting.DEFAULT;
-    }
+		@Deprecated
+		public transient NameSorting nameSorting = NameSorting.DEFAULT;
+	}
 
 	public enum TabHudStyle {
 		/**
@@ -207,35 +219,35 @@ public class UIAndVisualsConfig {
 		}
 	}
 
-    @Deprecated
-    public enum NameSorting {
-        DEFAULT, ALPHABETICAL;
+	@Deprecated
+	public enum NameSorting {
+		DEFAULT, ALPHABETICAL;
 
-        @Override
-        public String toString() {
-            return switch (this) {
-                case DEFAULT -> "Default";
-                case ALPHABETICAL -> "Alphabetical";
-            };
-        }
-    }
+		@Override
+		public String toString() {
+			return switch (this) {
+				case DEFAULT -> "Default";
+				case ALPHABETICAL -> "Alphabetical";
+			};
+		}
+	}
 
-    public static class FancyAuctionHouse {
-        public boolean enabled = true;
+	public static class FancyAuctionHouse {
+		public boolean enabled = true;
 
-        public boolean highlightCheapBIN = true;
-    }
+		public boolean highlightCheapBIN = true;
+	}
 
-    public static class Bars {
-        public boolean enableBars = true;
+	public static class Bars {
+		public boolean enableBars = true;
 
 		public IntelligenceDisplay intelligenceDisplay = IntelligenceDisplay.ORIGINAL;
 
-        // Kept in for backwards compatibility, remove if needed
-        @SuppressWarnings("DeprecatedIsStillUsed")
-        @Deprecated
-        public LegacyBarPositions barPositions = new LegacyBarPositions();
-    }
+		// Kept in for backwards compatibility, remove if needed
+		@SuppressWarnings("DeprecatedIsStillUsed")
+		@Deprecated
+		public LegacyBarPositions barPositions = new LegacyBarPositions();
+	}
 
 	public enum IntelligenceDisplay {
 		ORIGINAL,
@@ -243,84 +255,84 @@ public class UIAndVisualsConfig {
 		IN_FRONT;
 	}
 
-    /**
-     * Backwards compat.
-     * <p>
-     * Used to load the legacy bar positions, which will not have an effect once the bars are saved in the new format at {@code /skyblocker/status_bars.json}.
-     * New bars do not need to be added here.
-     */
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    @Deprecated
-    public static class LegacyBarPositions {
-        public LegacyBarPosition healthBarPosition = LegacyBarPosition.LAYER1;
+	/**
+	 * Backwards compat.
+	 * <p>
+	 * Used to load the legacy bar positions, which will not have an effect once the bars are saved in the new format at {@code /skyblocker/status_bars.json}.
+	 * New bars do not need to be added here.
+	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
+	public static class LegacyBarPositions {
+		public LegacyBarPosition healthBarPosition = LegacyBarPosition.LAYER1;
 
-        public LegacyBarPosition manaBarPosition = LegacyBarPosition.LAYER1;
+		public LegacyBarPosition manaBarPosition = LegacyBarPosition.LAYER1;
 
-        public LegacyBarPosition defenceBarPosition = LegacyBarPosition.RIGHT;
+		public LegacyBarPosition defenceBarPosition = LegacyBarPosition.RIGHT;
 
-        public LegacyBarPosition experienceBarPosition = LegacyBarPosition.LAYER2;
-    }
+		public LegacyBarPosition experienceBarPosition = LegacyBarPosition.LAYER2;
+	}
 
-    /**
-     * Backwards compat
-     */
-    public enum LegacyBarPosition {
-        LAYER1, LAYER2, RIGHT, NONE
-    }
+	/**
+	 * Backwards compat
+	 */
+	public enum LegacyBarPosition {
+		LAYER1, LAYER2, RIGHT, NONE
+	}
 
-    public static class Waypoints {
-        public boolean enableWaypoints = true;
+	public static class Waypoints {
+		public boolean enableWaypoints = true;
 
-        public Waypoint.Type waypointType = Waypoint.Type.WAYPOINT;
-    }
+		public Waypoint.Type waypointType = Waypoint.Type.WAYPOINT;
+	}
 
-    public static class TeleportOverlay {
-        public boolean enableTeleportOverlays = true;
+	public static class TeleportOverlay {
+		public boolean enableTeleportOverlays = true;
 
-        public Color teleportOverlayColor = new Color(0x7F761594, true);
+		public Color teleportOverlayColor = new Color(0x7F761594, true);
 
-        public boolean enableWeirdTransmission = true;
+		public boolean enableWeirdTransmission = true;
 
-        public boolean enableInstantTransmission = true;
+		public boolean enableInstantTransmission = true;
 
-        public boolean enableEtherTransmission = true;
+		public boolean enableEtherTransmission = true;
 
-        public boolean enableSinrecallTransmission = true;
+		public boolean enableSinrecallTransmission = true;
 
-        public boolean enableWitherImpact = true;
-    }
+		public boolean enableWitherImpact = true;
+	}
 
-    public static class SmoothAOTE {
-        public boolean enableWeirdTransmission = false;
+	public static class SmoothAOTE {
+		public boolean enableWeirdTransmission = false;
 
-        public boolean enableInstantTransmission = false;
+		public boolean enableInstantTransmission = false;
 
-        public boolean enableEtherTransmission = false;
+		public boolean enableEtherTransmission = false;
 
-        public boolean enableSinrecallTransmission = false;
+		public boolean enableSinrecallTransmission = false;
 
-        public boolean enableWitherImpact = false;
+		public boolean enableWitherImpact = false;
 
 		public int maximumAddedLag = 100;
-    }
+	}
 
-    public static class SearchOverlay {
-        public boolean enableBazaar = true;
+	public static class SearchOverlay {
+		public boolean enableBazaar = true;
 
-        public boolean enableAuctionHouse = true;
+		public boolean enableAuctionHouse = true;
 
-        public boolean keepPreviousSearches = false;
+		public boolean keepPreviousSearches = false;
 
-        public int maxSuggestions = 3;
+		public int maxSuggestions = 3;
 
-        public int historyLength = 3;
+		public int historyLength = 3;
 
-        public boolean enableCommands = false;
+		public boolean enableCommands = false;
 
-        public List<String> bazaarHistory = new ArrayList<>();
+		public List<String> bazaarHistory = new ArrayList<>();
 
-        public List<String> auctionHistory = new ArrayList<>();
-    }
+		public List<String> auctionHistory = new ArrayList<>();
+	}
 
 	public static class BazaarQuickQuantities {
 		public boolean enabled = false;
@@ -334,31 +346,31 @@ public class UIAndVisualsConfig {
 		public int slot3Quantity = 256;
 	}
 
-    public static class InputCalculator {
-        public boolean enabled = true;
+	public static class InputCalculator {
+		public boolean enabled = true;
 
-        public boolean requiresEquals = false;
+		public boolean requiresEquals = false;
 
 		public boolean closeSignsWithEnter = true;
-    }
+	}
 
-    public static class FlameOverlay {
-        public int flameHeight = 100;
+	public static class FlameOverlay {
+		public int flameHeight = 100;
 
-        public int flameOpacity = 100;
-    }
+		public int flameOpacity = 100;
+	}
 
-    public static class CompactDamage {
-        public boolean enabled = true;
+	public static class CompactDamage {
+		public boolean enabled = true;
 
-        public int precision = 1;
+		public int precision = 1;
 
-        public Color normalDamageColor = new Color(0xFFFFFF);
+		public Color normalDamageColor = new Color(0xFFFFFF);
 
-        public Color critDamageGradientStart = new Color(0xFFFF55);
+		public Color critDamageGradientStart = new Color(0xFFFF55);
 
-        public Color critDamageGradientEnd = new Color(0xFF5555);
-    }
+		public Color critDamageGradientEnd = new Color(0xFF5555);
+	}
 
 	public static class HealthBars {
 		public boolean enabled = false;

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -182,6 +182,13 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 		}
 	}
 
+	@Inject(method = "drawMouseoverTooltip", at = @At("HEAD"), cancellable = true)
+	private void skyblocker$disableTooltips(DrawContext context, int mouseX, int mouseY, CallbackInfo ci) {
+		if (Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.tooltipBlacklist.contains(getTitle().getString())) {
+			ci.cancel();
+		}
+	}
+
 	@SuppressWarnings("DataFlowIssue")
 	// makes intellij be quiet about this.focusedSlot maybe being null. It's already null checked in mixined method.
 	@Inject(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;IILnet/minecraft/util/Identifier;)V"), cancellable = true)

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
@@ -8,19 +8,27 @@ import de.hysky.skyblocker.skyblock.dwarven.fossil.FossilSolver;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.*;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.container.TooltipAdder;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 public class TooltipManager {
 	private static final TooltipAdder[] adders = new TooltipAdder[]{
@@ -50,6 +58,7 @@ public class TooltipManager {
 			new HuntingBoxPriceTooltip(15)
 	};
 	private static final ArrayList<TooltipAdder> currentScreenAdders = new ArrayList<>();
+	private static boolean disabledForCurrentScreen = false;
 
 	private TooltipManager() {
 	}
@@ -65,18 +74,64 @@ public class TooltipManager {
 		});
 		ScreenEvents.AFTER_INIT.register((client, screen, width, height) -> {
 			onScreenChange(screen);
+			if (screen instanceof GenericContainerScreen containerScreen &&
+					SkyblockerConfigManager.get().uiAndVisuals.showTooltipToggleButton) {
+				addToggleButton(containerScreen);
+			}
 			ScreenEvents.remove(screen).register(ignored -> currentScreenAdders.clear());
 		});
 	}
 
 	private static void onScreenChange(Screen screen) {
 		currentScreenAdders.clear();
+		disabledForCurrentScreen = false;
+		if (screen instanceof GenericContainerScreen containerScreen &&
+				SkyblockerConfigManager.get().uiAndVisuals.tooltipBlacklist.contains(screen.getTitle().getString())) {
+			disabledForCurrentScreen = true;
+			return;
+		}
 		for (TooltipAdder adder : adders) {
 			if (adder.isEnabled() && adder.test(screen)) {
 				currentScreenAdders.add(adder);
 			}
 		}
 		currentScreenAdders.sort(Comparator.comparingInt(TooltipAdder::getPriority));
+	}
+
+	private static void addToggleButton(GenericContainerScreen screen) {
+		String title = screen.getTitle().getString();
+		boolean disabled = SkyblockerConfigManager.get().uiAndVisuals.tooltipBlacklist.contains(title);
+
+		Text message = Text.translatable("skyblocker.ui.tooltipToggle.button")
+				.setStyle(Style.EMPTY.withColor(disabled ? Formatting.RED : Formatting.GREEN));
+
+		int width = MinecraftClient.getInstance().textRenderer.getWidth(message) + 6;
+		int height = 20;
+		int x = ((HandledScreenAccessor) screen).getX() - width - 6;
+		int y = ((HandledScreenAccessor) screen).getY();
+
+		ButtonWidget button = ButtonWidget.builder(message, b -> {
+					SkyblockerConfigManager.update(cfg -> {
+						Set<String> set = cfg.uiAndVisuals.tooltipBlacklist;
+						if (!set.add(title)) {
+							set.remove(title);
+						}
+					});
+					onScreenChange(screen);
+					boolean nowDisabled = SkyblockerConfigManager.get().uiAndVisuals.tooltipBlacklist.contains(title);
+					Text newMessage = Text.translatable("skyblocker.ui.tooltipToggle.button")
+							.setStyle(Style.EMPTY.withColor(nowDisabled ? Formatting.RED : Formatting.GREEN));
+					b.setMessage(newMessage);
+					int newWidth = MinecraftClient.getInstance().textRenderer.getWidth(newMessage) + 6;
+					b.setWidth(newWidth);
+					b.setX(((HandledScreenAccessor) screen).getX() - newWidth - 6);
+					b.setTooltip(Tooltip.of(Text.translatable(nowDisabled ? "skyblocker.ui.tooltipToggle.disabled" : "skyblocker.ui.tooltipToggle.enabled")));
+				})
+				.dimensions(x, y, width, height)
+				.tooltip(Tooltip.of(Text.translatable(disabled ? "skyblocker.ui.tooltipToggle.disabled" : "skyblocker.ui.tooltipToggle.enabled")))
+				.build();
+
+		Screens.getButtons(screen).add(button);
 	}
 
 	/**
@@ -93,7 +148,7 @@ public class TooltipManager {
 	 */
 	@Deprecated
 	public static List<Text> addToTooltip(@Nullable Slot focusedSlot, ItemStack stack, List<Text> lines) {
-		if (!Utils.isOnSkyblock()) return lines;
+		if (!Utils.isOnSkyblock() || disabledForCurrentScreen) return lines;
 		for (TooltipAdder adder : currentScreenAdders) {
 			adder.addToTooltip(focusedSlot, stack, lines);
 		}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1069,6 +1069,8 @@
   "skyblocker.config.uiAndVisuals.showEquipmentInInventory": "Show Equipment in Inventory",
   "skyblocker.config.uiAndVisuals.showConfigButton": "Show Config Button",
   "skyblocker.config.uiAndVisuals.showConfigButton.@Tooltip": "Adds a button in the skyblock menu to open the Skyblocker config.",
+  "skyblocker.config.uiAndVisuals.showTooltipToggleButton": "Show Tooltip Toggle Button",
+  "skyblocker.config.uiAndVisuals.showTooltipToggleButton.@Tooltip": "Adds a button in container screens to toggle tooltips for that container.",
 
   "skyblocker.config.uiAndVisuals.smoothAOTE": "Smooth AOTE",
   "skyblocker.config.uiAndVisuals.smoothAOTE.@Tooltip": "Smooths out teleporting with right click teleport abilities.",
@@ -1541,6 +1543,10 @@
   "skyblocker.armorCustomization.titleSecret": "Pimp Your Armor",
 
   "skyblocker.chat.confirmationPromptNotification": "Click anywhere on screen within 60 seconds to accept the prompt.",
+
+  "skyblocker.ui.tooltipToggle.button": "Tooltips",
+  "skyblocker.ui.tooltipToggle.disabled": "Tooltips Disabled",
+  "skyblocker.ui.tooltipToggle.enabled": "Tooltips Enabled",
 
   "emi.category.skyblocker.skyblock_crafting": "Crafting (Skyblock)",
   "emi.category.skyblocker.skyblock_forge": "Dwarven Forge (Skyblock)"


### PR DESCRIPTION
Adds a new button to tile containers to that hides tooltips for that container. For certain containers, especially those with solvers the tool tips impair visibility over the rest of the slots.

Adds an option to show / hide the button. The utility still functions regardless but allows the UI to be cleaner after whatever container has been added.

<img width="1016" height="685" alt="Screenshot 2025-07-11 092917" src="https://github.com/user-attachments/assets/2b612c27-66f0-4842-afd4-4cacb95ec011" />
<img width="1001" height="595" alt="Screenshot 2025-07-11 092920" src="https://github.com/user-attachments/assets/8aba5fc7-971e-41e4-868a-23a30d5451c1" />
