### PR TITLE
Only send Livid Color to party chat

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -104,7 +104,7 @@ public class LividColor {
                 .append(CONFIG.lividColorText.replaceAll("\\[color]", colorString))
                 .formatted(LividColor.color);
         if (CONFIG.enableLividColorText) {
-            MessageScheduler.INSTANCE.sendMessageAfterCooldown(message.getString(), false);
+            MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + message.getString(), false);
         }
         if (CONFIG.enableLividColorTitle) {
             client.inGameHud.setDefaultTitleFade();


### PR DESCRIPTION
A great shame was cast upon my family because the mod posted the livid color to my guild chat😭

Matches how it's done with the dungeon score messages