### PR TITLE
REI /viewrecipe Crafting, Skyblock Info Display 

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockTransferHandler.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockTransferHandler.java
@@ -1,0 +1,54 @@
+package de.hysky.skyblocker.compatibility.rei;
+
+import de.hysky.skyblocker.compatibility.rei.info.SkyblockInfoCategory;
+import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockCraftingRecipe;
+import de.hysky.skyblocker.utils.NEURepoManager;
+import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
+import io.github.moulberry.repo.data.NEUCraftingRecipe;
+import io.github.moulberry.repo.data.NEUForgeRecipe;
+import me.shedaniel.rei.api.client.registry.transfer.TransferHandler;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.entry.EntryStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+
+public class SkyblockTransferHandler implements TransferHandler {
+	// This determines if the plus button should be active
+	@Override
+	public ApplicabilityResult checkApplicable(Context context) {
+		// Only work on our displays
+		CategoryIdentifier<?> identifier = context.getDisplay().getCategoryIdentifier();
+		if (identifier != CategoryIdentifier.of(SkyblockCraftingRecipe.IDENTIFIER) && identifier != CategoryIdentifier.of(SkyblockInfoCategory.IDENTIFIER))
+			return ApplicabilityResult.createNotApplicable();
+
+		EntryIngredient ingredient = context.getDisplay().getOutputEntries().getFirst();
+		EntryStack<?> entryStack = ingredient.getFirst();
+		if (!(entryStack.getValue() instanceof ItemStack itemStack))
+			return ApplicabilityResult.createNotApplicable();
+
+		// Not applicable if it has 0 recipes, or no crafting/forge recipe
+		String neuId = itemStack.getNeuName();
+		if (!NEURepoManager.getRecipes().containsKey(neuId) || NEURepoManager.getRecipes().get(neuId).stream().noneMatch(recipe -> recipe instanceof NEUCraftingRecipe || recipe instanceof NEUForgeRecipe))
+			return ApplicabilityResult.createApplicableWithError(Text.translatable("skyblocker.rei.transfer.noRecipe"));
+
+		return ApplicabilityResult.createApplicable();
+
+	}
+
+	// This is run every tick
+	// When the plus button is pressed context.isActuallyCrafting() becomes true
+	@Override
+	public Result handle(Context context) {
+		EntryIngredient ingredient = context.getDisplay().getOutputEntries().getFirst();
+		EntryStack<?> entryStack = ingredient.getFirst();
+		if (!(entryStack.getValue() instanceof ItemStack itemStack)) return Result.createNotApplicable();
+		if (!context.isActuallyCrafting()) return Result.createSuccessful();
+
+		String skyblockId = itemStack.getSkyblockId();
+		MessageScheduler.INSTANCE.sendMessageAfterCooldown("/viewrecipe " + skyblockId, false);
+		// TODO: The user must look in chat to see if /viewrecipe fails, maybe add a check if it has been a few ticks after pressing
+		//  (and the menu hasn't closed), return an Error result.
+		return Result.createSuccessful();
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockTransferHandler.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockTransferHandler.java
@@ -6,7 +6,6 @@ import de.hysky.skyblocker.utils.NEURepoManager;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import io.github.moulberry.repo.data.NEUCraftingRecipe;
-import io.github.moulberry.repo.data.NEUForgeRecipe;
 import me.shedaniel.rei.api.client.registry.transfer.TransferHandler;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
@@ -37,7 +36,7 @@ public class SkyblockTransferHandler implements TransferHandler {
 
 		// Not applicable if it has 0 recipes, or no crafting/forge recipe
 		String neuId = itemStack.getNeuName();
-		if (!NEURepoManager.getRecipes().containsKey(neuId) || NEURepoManager.getRecipes().get(neuId).stream().noneMatch(recipe -> recipe instanceof NEUCraftingRecipe || recipe instanceof NEUForgeRecipe))
+		if (!NEURepoManager.getRecipes().containsKey(neuId) || NEURepoManager.getRecipes().get(neuId).stream().noneMatch(recipe -> recipe instanceof NEUCraftingRecipe))
 			return ApplicabilityResult.createApplicableWithError(Text.translatable("skyblocker.rei.transfer.noRecipe"));
 
 		return ApplicabilityResult.createApplicable();

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockTransferHandler.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockTransferHandler.java
@@ -34,7 +34,7 @@ public class SkyblockTransferHandler implements TransferHandler {
 		if (!(entryStack.getValue() instanceof ItemStack itemStack))
 			return ApplicabilityResult.createNotApplicable();
 
-		// Not applicable if it has 0 recipes, or no crafting/forge recipe
+		// Not applicable if it has 0 recipes, or no crafting recipe
 		String neuId = itemStack.getNeuName();
 		if (!NEURepoManager.getRecipes().containsKey(neuId) || NEURepoManager.getRecipes().get(neuId).stream().noneMatch(recipe -> recipe instanceof NEUCraftingRecipe))
 			return ApplicabilityResult.createApplicableWithError(Text.translatable("skyblocker.rei.transfer.noRecipe"));

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -48,8 +48,10 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
     @Override
     public void registerDisplays(DisplayRegistry displayRegistry) {
         if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
-        displayRegistry.registerGlobalDisplayGenerator(new SkyblockRecipeDisplayGenerator());
-		displayRegistry.registerGlobalDisplayGenerator(new SkyblockInfoDisplayGenerator());
+		if (displayRegistry.getGlobalDisplayGenerators().stream().noneMatch(generator -> generator instanceof SkyblockRecipeDisplayGenerator))
+			displayRegistry.registerGlobalDisplayGenerator(new SkyblockRecipeDisplayGenerator());
+		if (displayRegistry.getGlobalDisplayGenerators().stream().noneMatch(generator -> generator instanceof SkyblockInfoDisplayGenerator))
+			displayRegistry.registerGlobalDisplayGenerator(new SkyblockInfoDisplayGenerator());
     }
 
     @Override

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -1,5 +1,9 @@
 package de.hysky.skyblocker.compatibility.rei;
 
+import de.hysky.skyblocker.compatibility.rei.info.SkyblockInfoCategory;
+import de.hysky.skyblocker.compatibility.rei.info.SkyblockInfoDisplayGenerator;
+import de.hysky.skyblocker.compatibility.rei.recipe.SkyblockRecipeCategory;
+import de.hysky.skyblocker.compatibility.rei.recipe.SkyblockRecipeDisplayGenerator;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.mixins.accessors.HandledScreenAccessor;
 import de.hysky.skyblocker.skyblock.garden.visitor.VisitorHelper;
@@ -15,6 +19,7 @@ import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
 import me.shedaniel.rei.api.client.registry.entry.EntryRegistry;
 import me.shedaniel.rei.api.client.registry.screen.ExclusionZones;
+import me.shedaniel.rei.api.client.registry.transfer.TransferHandlerRegistry;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.minecraft.client.gui.screen.Screen;
@@ -29,19 +34,22 @@ import java.util.List;
  */
 public class SkyblockerREIClientPlugin implements REIClientPlugin {
 
-    @Override
+	@Override
     public void registerCategories(CategoryRegistry categoryRegistry) {
         if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
         categoryRegistry.addWorkstations(CategoryIdentifier.of(SkyblockCraftingRecipe.IDENTIFIER), EntryStacks.of(Items.CRAFTING_TABLE));
         categoryRegistry.addWorkstations(CategoryIdentifier.of(SkyblockForgeRecipe.IDENTIFIER), EntryStacks.of(Items.ANVIL));
         categoryRegistry.add(new SkyblockRecipeCategory(SkyblockCraftingRecipe.IDENTIFIER, Text.translatable("emi.category.skyblocker.skyblock_crafting"), ItemUtils.getSkyblockerStack(), 73));
         categoryRegistry.add(new SkyblockRecipeCategory(SkyblockForgeRecipe.IDENTIFIER, Text.translatable("emi.category.skyblocker.skyblock_forge"), ItemUtils.getSkyblockerForgeStack(), 84));
+
+		categoryRegistry.add(new SkyblockInfoCategory());
     }
 
     @Override
     public void registerDisplays(DisplayRegistry displayRegistry) {
         if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
         displayRegistry.registerGlobalDisplayGenerator(new SkyblockRecipeDisplayGenerator());
+		displayRegistry.registerGlobalDisplayGenerator(new SkyblockInfoDisplayGenerator());
     }
 
     @Override
@@ -64,6 +72,12 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
             return VisitorHelper.getExclusionZones();
         });
     }
+
+	@Override
+	public void registerTransferHandlers(TransferHandlerRegistry registry) {
+		if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
+		registry.register(new SkyblockTransferHandler());
+	}
 
 	@Override
 	public double getPriority() {

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoCategory.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoCategory.java
@@ -4,6 +4,7 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.skyblock.item.ItemPrice;
 import de.hysky.skyblocker.skyblock.item.WikiLookup;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
+import de.hysky.skyblocker.utils.render.gui.AbstractCustomHypixelGUI;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import me.shedaniel.math.Point;
 import me.shedaniel.math.Rectangle;
@@ -16,6 +17,8 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryStack;
 import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -61,6 +64,11 @@ public class SkyblockInfoCategory implements DisplayCategory<SkyblockInfoDisplay
 		return btn;
 	}
 
+	private boolean checkScreen() {
+		Screen currentScreen = MinecraftClient.getInstance().currentScreen;
+		return currentScreen instanceof GenericContainerScreen || currentScreen instanceof AbstractCustomHypixelGUI<?>;
+	}
+
 	@Override
 	public List<Widget> setupDisplay(SkyblockInfoDisplay display, Rectangle bounds) {
 		List<Widget> widgets = new ArrayList<>();
@@ -78,9 +86,8 @@ public class SkyblockInfoCategory implements DisplayCategory<SkyblockInfoDisplay
 		layoutWidget.add(ButtonWidget.builder(Text.translatable("key.itemPriceLookup"), (button) -> {
 			ItemPrice.itemPriceLookup(player, itemStack);
 
-			// If this screen isn't replaced with the BZ or AH screen, show that the item could not be found.
 			Scheduler.INSTANCE.schedule(() -> {
-				if (button == null) return;
+				if (checkScreen()) return;
 				button.setMessage(Text.translatable("skyblocker.rei.skyblockInfo.failedToFind").withColor(RED_ERROR_COLOR));
 				button.active = false;
 			}, 10);

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoCategory.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoCategory.java
@@ -1,0 +1,107 @@
+package de.hysky.skyblocker.compatibility.rei.info;
+
+import de.hysky.skyblocker.SkyblockerMod;
+import de.hysky.skyblocker.skyblock.item.ItemPrice;
+import de.hysky.skyblocker.skyblock.item.WikiLookup;
+import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
+import de.hysky.skyblocker.utils.scheduler.Scheduler;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Slot;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.entry.EntryStack;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SkyblockInfoCategory implements DisplayCategory<SkyblockInfoDisplay> {
+	private static final int REI_SLOT_HEIGHT = 18;
+	private static final int OFFSET = 10;
+	private static final int RED_ERROR_COLOR = 0xFFFF5555;
+	private static final EntryStack<ItemStack> ICON = EntryStacks.of(new ItemStack(Items.CHEST));
+
+	public static final Identifier IDENTIFIER = Identifier.of(SkyblockerMod.NAMESPACE, "skyblock_info");
+
+	@Override
+	public CategoryIdentifier<? extends SkyblockInfoDisplay> getCategoryIdentifier() {
+		return CategoryIdentifier.of(IDENTIFIER);
+	}
+
+	@Override
+	public Text getTitle() {
+		return Text.translatable("emi.category.skyblocker.skyblock_info");
+	}
+
+	@Override
+	public Renderer getIcon() {
+		return ICON;
+	}
+
+	private ButtonWidget getWikiLookupButton(Text text, boolean isOfficial, ItemStack itemStack, ClientPlayerEntity player) {
+		ButtonWidget btn = ButtonWidget.builder(text, (button) -> WikiLookup.openWiki(itemStack, player, isOfficial)).build();
+
+		if (ItemRepository.getWikiLink(itemStack.getNeuName(), isOfficial) == null) {
+			btn.setMessage(btn.getMessage().copy().withColor(RED_ERROR_COLOR));
+			btn.active = false;
+		}
+
+		return btn;
+	}
+
+	@Override
+	public List<Widget> setupDisplay(SkyblockInfoDisplay display, Rectangle bounds) {
+		List<Widget> widgets = new ArrayList<>();
+		EntryStack<?> entryStack = display.getInputEntries().getFirst().getFirst();
+		if (!(entryStack.getValue() instanceof ItemStack itemStack)) return widgets;
+
+		widgets.add(Widgets.createRecipeBase(bounds));
+		Slot slot = Widgets.createSlot(new Point(bounds.getCenterX() - 9 + 1, bounds.y + 1 + OFFSET / 2)).entry(entryStack);
+		widgets.add(slot);
+
+		ClientPlayerEntity player = MinecraftClient.getInstance().player;
+		DirectionalLayoutWidget layoutWidget = DirectionalLayoutWidget.vertical();
+		layoutWidget.setPosition(bounds.x + OFFSET, bounds.y + OFFSET + REI_SLOT_HEIGHT);
+
+		layoutWidget.add(ButtonWidget.builder(Text.translatable("key.itemPriceLookup"), (button) -> {
+			ItemPrice.itemPriceLookup(player, itemStack);
+
+			// If this screen isn't replaced with the BZ or AH screen, show that the item could not be found.
+			Scheduler.INSTANCE.schedule(() -> {
+				if (button == null) return;
+				button.setMessage(Text.translatable("skyblocker.rei.skyblockInfo.failedToFind").withColor(RED_ERROR_COLOR));
+				button.active = false;
+			}, 10);
+		}).build());
+
+		layoutWidget.add(getWikiLookupButton(Text.translatable("key.wikiLookup.official"), true, itemStack, player));
+		layoutWidget.add(getWikiLookupButton(Text.translatable("key.wikiLookup.fandom"), false, itemStack, player));
+
+		layoutWidget.forEachChild(child -> widgets.add(Widgets.wrapVanillaWidget(child)));
+		layoutWidget.refreshPositions();
+
+		return widgets;
+	}
+
+	@Override
+	public int getDisplayHeight() {
+		return 3 * ButtonWidget.DEFAULT_HEIGHT + REI_SLOT_HEIGHT + 2 * OFFSET;
+	}
+
+	@Override
+	public int getDisplayWidth(SkyblockInfoDisplay display) {
+		return 150 + 20;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoDisplay.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoDisplay.java
@@ -1,0 +1,47 @@
+package de.hysky.skyblocker.compatibility.rei.info;
+
+import de.hysky.skyblocker.SkyblockerMod;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.display.DisplaySerializer;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+public class SkyblockInfoDisplay implements Display {
+	private final ItemStack displayItem;
+
+	public SkyblockInfoDisplay(ItemStack item) {
+		this.displayItem = item;
+	}
+
+	@Override
+	public List<EntryIngredient> getInputEntries() {
+		return List.of(EntryIngredient.of(EntryStacks.of(displayItem)));
+	}
+
+	@Override
+	public List<EntryIngredient> getOutputEntries() {
+		return List.of(EntryIngredient.of(EntryStacks.of(displayItem)));
+	}
+
+	@Override
+	public CategoryIdentifier<?> getCategoryIdentifier() {
+		return CategoryIdentifier.of(Identifier.of(SkyblockerMod.NAMESPACE, "skyblock_info"));
+	}
+
+	@Override
+	public Optional<Identifier> getDisplayLocation() {
+		return Optional.empty();
+	}
+
+	@Override
+	public @Nullable DisplaySerializer<? extends Display> getSerializer() {
+		return null;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoDisplayGenerator.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/info/SkyblockInfoDisplayGenerator.java
@@ -1,0 +1,23 @@
+package de.hysky.skyblocker.compatibility.rei.info;
+
+import me.shedaniel.rei.api.client.registry.display.DynamicDisplayGenerator;
+import me.shedaniel.rei.api.common.entry.EntryStack;
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+import java.util.Optional;
+
+public class SkyblockInfoDisplayGenerator implements DynamicDisplayGenerator<SkyblockInfoDisplay> {
+	@Override
+	public Optional<List<SkyblockInfoDisplay>> getRecipeFor(EntryStack<?> entry) {
+		if (!(entry.getValue() instanceof ItemStack entryStack)) return Optional.empty();
+		if (entryStack.getSkyblockId().isEmpty()) return Optional.empty();
+		entryStack.setCount(1);
+		return Optional.of(List.of(new SkyblockInfoDisplay(entryStack)));
+	}
+
+	@Override
+	public Optional<List<SkyblockInfoDisplay>> getUsageFor(EntryStack<?> entry) {
+		return getRecipeFor(entry);
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/recipe/SkyblockRecipeCategory.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/recipe/SkyblockRecipeCategory.java
@@ -1,4 +1,4 @@
-package de.hysky.skyblocker.compatibility.rei;
+package de.hysky.skyblocker.compatibility.rei.recipe;
 
 import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockRecipe;
 import me.shedaniel.math.Point;

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/recipe/SkyblockRecipeDisplay.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/recipe/SkyblockRecipeDisplay.java
@@ -1,4 +1,4 @@
-package de.hysky.skyblocker.compatibility.rei;
+package de.hysky.skyblocker.compatibility.rei.recipe;
 
 import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockRecipe;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/recipe/SkyblockRecipeDisplayGenerator.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/recipe/SkyblockRecipeDisplayGenerator.java
@@ -1,4 +1,4 @@
-package de.hysky.skyblocker.compatibility.rei;
+package de.hysky.skyblocker.compatibility.rei.recipe;
 
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import me.shedaniel.rei.api.client.registry.display.DynamicDisplayGenerator;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -13,7 +13,7 @@
   "key.wikiLookup.fandom": "Fandom Wiki Lookup",
   "key.itemProtection": "Protect Item",
   "key.skyblocker.slottext": "Slot Text",
-  "key.itemPriceLookup": "Bazaar Lookup",
+  "key.itemPriceLookup": "Item Lookup",
   "key.itemPriceRefresh": "Bazaar Refresh",
 
 
@@ -301,7 +301,7 @@
   "skyblocker.config.foraging.sweepOverlay.enableThrownAbilityOverlay.@Tooltip": "Highlights logs when using an axe's thrown ability.",
   "skyblocker.config.foraging.sweepOverlay.sweepOverlayColor": "Sweep Overlay Color",
   "skyblocker.config.foraging.sweepOverlay.sweepStatMissingMessage": "Sweep Missing: Add the Sweep stat to your player list with /tablist",
-  
+
   "skyblocker.config.foraging.hunting": "Hunting",
 
   "skyblocker.config.general": "General",
@@ -1543,5 +1543,8 @@
   "skyblocker.chat.confirmationPromptNotification": "Click anywhere on screen within 60 seconds to accept the prompt.",
 
   "emi.category.skyblocker.skyblock_crafting": "Crafting (Skyblock)",
-  "emi.category.skyblocker.skyblock_forge": "Dwarven Forge (Skyblock)"
+  "emi.category.skyblocker.skyblock_forge": "Dwarven Forge (Skyblock)",
+  "emi.category.skyblocker.skyblock_info": "Skyblock Info",
+  "skyblocker.rei.skyblockInfo.failedToFind": "Unable to find!",
+  "skyblocker.rei.transfer.noRecipe": "No SkyBlock recipe found!"
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -13,7 +13,7 @@
   "key.wikiLookup.fandom": "Fandom Wiki Lookup",
   "key.itemProtection": "Protect Item",
   "key.skyblocker.slottext": "Slot Text",
-  "key.itemPriceLookup": "Item Lookup",
+  "key.itemPriceLookup": "Item Price Lookup",
   "key.itemPriceRefresh": "Bazaar Refresh",
 
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1546,5 +1546,6 @@
   "emi.category.skyblocker.skyblock_forge": "Dwarven Forge (Skyblock)",
   "emi.category.skyblocker.skyblock_info": "Skyblock Info",
   "skyblocker.rei.skyblockInfo.failedToFind": "Unable to find!",
-  "skyblocker.rei.transfer.noRecipe": "No SkyBlock recipe found!"
+  "skyblocker.rei.transfer.noRecipe": "No Skyblock recipe found!",
+  "skyblocker.rei.transfer.failed": "Failed to open recipe!\nCheck chat for more info."
 }


### PR DESCRIPTION
Adds an additional category to REI to allow for Item Price Lookup and Wiki Lookup
Item: Figstone Axe
<img width="412" height="416" alt="image" src="https://github.com/user-attachments/assets/09bc7788-c6fd-42ad-adf0-1b30dc663e09" />
The wiki buttons are disabled if no wiki page is found.

The Plus button will now open the /viewrecipe page for that item if a recipe is found
Item: Figstone Axe
<img width="583" height="352" alt="image" src="https://github.com/user-attachments/assets/eac0e4ab-71f8-4fa7-8dc4-c6a60847a73f" />

If a recipe is not found, it looks like this instead
Item: Agatha's Coupon
<img width="722" height="375" alt="image" src="https://github.com/user-attachments/assets/52731669-8dcc-445d-84bb-34f933b641f2" />

+ Also resolves recipes showing up multiple times
