### PR TITLE
Remove [SKYBLOCKER] Prefix from Livid Color Title

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/LividColor.java
@@ -15,7 +15,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.registry.Registries;
-import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
 
@@ -100,11 +100,9 @@ public class LividColor {
         LividColor.color = WOOL_TO_FORMATTING.get(color);
         String colorString = Registries.BLOCK.getId(color).getPath();
         colorString = colorString.substring(0, colorString.length() - 5).toUpperCase();
-        MutableText message = Constants.PREFIX.get()
-                .append(CONFIG.lividColorText.replaceAll("\\[color]", colorString))
-                .formatted(LividColor.color);
+        Text message = Text.literal(CONFIG.lividColorText.replaceAll("\\[color]", colorString)).formatted(LividColor.color);
         if (CONFIG.enableLividColorText) {
-            MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + message.getString(), false);
+            MessageScheduler.INSTANCE.sendMessageAfterCooldown("/pc " + Constants.PREFIX.get().append(message).getString(), false);
         }
         if (CONFIG.enableLividColorTitle) {
             client.inGameHud.setDefaultTitleFade();


### PR DESCRIPTION
#1492, but for the Livid Color title, the prefix remains for the chat message