### PR TITLE
Fix Garden Plots Widget tooltips being offset (on 1.21.6+)

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
@@ -282,7 +282,7 @@ public class GardenPlotsWidget extends ContainerWidget {
 										Text.empty(),
 										TP_TEXT
 								);
-				context.drawTooltip(textRenderer, tooltip, mouseX - getX(), mouseY - getY());
+				context.drawTooltip(textRenderer, tooltip, mouseX, mouseY);
 			}
 		}
 


### PR DESCRIPTION
before
<img width="1314" height="579" alt="image" src="https://github.com/user-attachments/assets/b233e00f-fd81-4ba3-9751-652312a108e0" />
