### PR TITLE
Allow moving Powder Mining Tracker Widget

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/PowderMiningTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/PowderMiningTracker.java
@@ -15,17 +15,10 @@ import it.unimi.dsi.fastutil.doubles.DoubleBooleanPair;
 import it.unimi.dsi.fastutil.objects.*;
 import it.unimi.dsi.fastutil.objects.Object2IntMap.Entry;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.ChatHud;
-import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
-import net.minecraft.util.Colors;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
@@ -42,7 +35,6 @@ import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.lit
 public final class PowderMiningTracker extends AbstractProfitTracker {
 	public static final PowderMiningTracker INSTANCE = new PowderMiningTracker();
 	private static final Logger LOGGER = LoggerFactory.getLogger("Skyblocker Powder Mining Tracker");
-	private static final Identifier POWDER_MINING_TRACKER = Identifier.of(SkyblockerMod.NAMESPACE, "powder_mining_tracker");
 	private static final Object2ObjectArrayMap<String, String> NAME2ID_MAP = new Object2ObjectArrayMap<>(50);
 
 	/**
@@ -79,7 +71,6 @@ public final class PowderMiningTracker extends AbstractProfitTracker {
 	@Init
 	public static void init() {
 		ChatEvents.RECEIVE_STRING.register(INSTANCE::onChatMessage);
-		HudElementRegistry.attachElementAfter(VanillaHudElements.STATUS_EFFECTS, POWDER_MINING_TRACKER, PowderMiningTracker::render);
 		ItemPriceUpdateEvent.ON_PRICE_UPDATE.register(INSTANCE::onPriceUpdate);
 
 		INSTANCE.allRewards.init();
@@ -319,16 +310,11 @@ public final class PowderMiningTracker extends AbstractProfitTracker {
 		return NAME2ID_MAP.getOrDefault(itemName, "");
 	}
 
-	// TODO: Make this a hud widget without the background (optional), needs to be moveable
-	private static void render(DrawContext context, RenderTickCounter tickCounter) {
-		if (Utils.getLocation() != Location.CRYSTAL_HOLLOWS || !INSTANCE.isEnabled()) return;
-		int y = MinecraftClient.getInstance().getWindow().getScaledHeight() / 2 - 100;
-		var set = INSTANCE.shownRewards.object2IntEntrySet();
-		for (Entry<Text> entry : set) {
-			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, entry.getKey(), 5, y, Colors.WHITE);
-			context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.of(Formatters.INTEGER_NUMBERS.format(entry.getIntValue())), 10 + MinecraftClient.getInstance().textRenderer.getWidth(entry.getKey()), y, Colors.WHITE);
-			y += 10;
-		}
-		context.drawTextWithShadow(MinecraftClient.getInstance().textRenderer, Text.translatable("skyblocker.powderTracker.profit", Formatters.DOUBLE_NUMBERS.format(INSTANCE.profit)).formatted(Formatting.GOLD), 5, y + 10, Colors.WHITE);
+	public static double getProfit() {
+		return INSTANCE.profit;
+	}
+
+	public static Object2IntMap<Text> getShownRewards() {
+		return INSTANCE.shownRewards;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/PowderMiningWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/PowderMiningWidget.java
@@ -2,7 +2,6 @@ package de.hysky.skyblocker.skyblock.dwarven.profittrackers;
 
 import de.hysky.skyblocker.annotations.RegisterWidget;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
-import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
 import de.hysky.skyblocker.skyblock.tabhud.widget.HudWidget;
 import de.hysky.skyblocker.utils.Formatters;
 import de.hysky.skyblocker.utils.Location;
@@ -27,19 +26,27 @@ public class PowderMiningWidget extends HudWidget {
 	@Override
 	public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
 		var set = PowderMiningTracker.getShownRewards().object2IntEntrySet();
-		if (CLIENT.currentScreen instanceof WidgetsConfigurationScreen) {
-			if (!set.isEmpty() && this.w == 0) {
-				calculateWidgetSize();
-			}
+		if (set.isEmpty()) {
+			setDimensions(0, 0);
+			return;
 		}
 
-		int newY = y;
+		int tempY = y;
+		int maxWidth = 0;
+
 		for (Object2IntMap.Entry<Text> entry : set) {
-			context.drawTextWithShadow(CLIENT.textRenderer, entry.getKey(), x, newY, Colors.WHITE);
-			context.drawTextWithShadow(CLIENT.textRenderer, Text.of(Formatters.INTEGER_NUMBERS.format(entry.getIntValue())), x + 5 + CLIENT.textRenderer.getWidth(entry.getKey()), newY, Colors.WHITE);
-			newY += 10;
+			Text price = Text.literal(Formatters.INTEGER_NUMBERS.format(entry.getIntValue())).withColor(Colors.WHITE);
+			Text text = entry.getKey().copy().append(" ").append(price);
+			context.drawTextWithShadow(CLIENT.textRenderer, text, x, tempY, Colors.WHITE);
+
+			tempY += 10;
+			int width = CLIENT.textRenderer.getWidth(text);
+			if (width > maxWidth) maxWidth = width;
 		}
-		context.drawTextWithShadow(CLIENT.textRenderer, Text.translatable("skyblocker.powderTracker.profit", Formatters.DOUBLE_NUMBERS.format(PowderMiningTracker.getProfit())).formatted(Formatting.GOLD), x, newY + 10, Colors.WHITE);
+		tempY += 10;
+		context.drawTextWithShadow(CLIENT.textRenderer, Text.translatable("skyblocker.powderTracker.profit", Formatters.DOUBLE_NUMBERS.format(PowderMiningTracker.getProfit())).formatted(Formatting.GOLD), x, tempY, Colors.WHITE);
+
+		setDimensions(maxWidth, tempY - y + 10);
 	}
 
 
@@ -61,29 +68,7 @@ public class PowderMiningWidget extends HudWidget {
 	}
 
 	@Override
-	public void update() {
-	}
-
-	private void calculateWidgetSize() {
-		var set = PowderMiningTracker.getShownRewards().object2IntEntrySet();
-		if (set.isEmpty()) {
-			this.w = 0;
-			this.h = 0;
-			return;
-		}
-
-		int maxWidth = 0;
-		for (Object2IntMap.Entry<Text> entry : set) {
-			Text valueText = Text.of(Formatters.INTEGER_NUMBERS.format(entry.getIntValue()));
-			Text line = entry.getKey().copy().append(valueText);
-			int lineWidth = CLIENT.textRenderer.getWidth(line) + 5;
-			if (lineWidth > maxWidth) {
-				maxWidth = lineWidth;
-			}
-		}
-		this.w = maxWidth;
-		this.h = 10 * (set.size() + 2);
-	}
+	public void update() {}
 
 	@Override
 	public Text getDisplayName() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/PowderMiningWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/PowderMiningWidget.java
@@ -1,0 +1,92 @@
+package de.hysky.skyblocker.skyblock.dwarven.profittrackers;
+
+import de.hysky.skyblocker.annotations.RegisterWidget;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
+import de.hysky.skyblocker.skyblock.tabhud.widget.HudWidget;
+import de.hysky.skyblocker.utils.Formatters;
+import de.hysky.skyblocker.utils.Location;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
+import net.minecraft.util.Formatting;
+
+import java.util.Set;
+
+@RegisterWidget
+public class PowderMiningWidget extends HudWidget {
+	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
+	private static final Set<Location> LOCATIONS = Set.of(Location.CRYSTAL_HOLLOWS);
+
+	public PowderMiningWidget() {
+		super("powder_mining_tracker");
+	}
+
+	@Override
+	public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+		var set = PowderMiningTracker.getShownRewards().object2IntEntrySet();
+		if (CLIENT.currentScreen instanceof WidgetsConfigurationScreen) {
+			if (!set.isEmpty() && this.w == 0) {
+				calculateWidgetSize();
+			}
+		}
+
+		int newY = y;
+		for (Object2IntMap.Entry<Text> entry : set) {
+			context.drawTextWithShadow(CLIENT.textRenderer, entry.getKey(), x, newY, Colors.WHITE);
+			context.drawTextWithShadow(CLIENT.textRenderer, Text.of(Formatters.INTEGER_NUMBERS.format(entry.getIntValue())), x + 5 + CLIENT.textRenderer.getWidth(entry.getKey()), newY, Colors.WHITE);
+			newY += 10;
+		}
+		context.drawTextWithShadow(CLIENT.textRenderer, Text.translatable("skyblocker.powderTracker.profit", Formatters.DOUBLE_NUMBERS.format(PowderMiningTracker.getProfit())).formatted(Formatting.GOLD), x, newY + 10, Colors.WHITE);
+	}
+
+
+	@Override
+	public Set<Location> availableLocations() {
+		return LOCATIONS;
+	}
+
+	@Override
+	public void setEnabledIn(Location location, boolean enabled) {
+		if (!LOCATIONS.contains(location)) return;
+		SkyblockerConfigManager.get().mining.crystalHollows.enablePowderTracker = enabled;
+	}
+
+	@Override
+	public boolean isEnabledIn(Location location) {
+		if (!LOCATIONS.contains(location)) return false;
+		return SkyblockerConfigManager.get().mining.crystalHollows.enablePowderTracker;
+	}
+
+	@Override
+	public void update() {
+	}
+
+	private void calculateWidgetSize() {
+		var set = PowderMiningTracker.getShownRewards().object2IntEntrySet();
+		if (set.isEmpty()) {
+			this.w = 0;
+			this.h = 0;
+			return;
+		}
+
+		int maxWidth = 0;
+		for (Object2IntMap.Entry<Text> entry : set) {
+			Text valueText = Text.of(Formatters.INTEGER_NUMBERS.format(entry.getIntValue()));
+			Text line = entry.getKey().copy().append(valueText);
+			int lineWidth = CLIENT.textRenderer.getWidth(line) + 5;
+			if (lineWidth > maxWidth) {
+				maxWidth = lineWidth;
+			}
+		}
+		this.w = maxWidth;
+		this.h = 10 * (set.size() + 2);
+	}
+
+	@Override
+	public Text getDisplayName() {
+		return Text.translatable("skyblocker.powderTracker");
+	}
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1542,6 +1542,7 @@
   "skyblocker.corpseTracker.emptyHistory": "Your corpse history list is empty :(",
   "skyblocker.corpseTracker.historyReset": "Corpse profit history has been reset for the current profile.",
 
+  "skyblocker.powderTracker": "Powder Mining Tracker",
   "skyblocker.powderTracker.historyReset": "Powder mining tracker has been reset for the current profile.",
   "skyblocker.powderTracker.profit": "Profit: %s Coins",
   "skyblocker.powderTracker.emptyHistory": "Your powder mining rewards list is empty :(",


### PR DESCRIPTION
Separates the widget from the Powder Mining Tracker and makes it into an actual widget, allowing it to be moved like other widgets.

<img width="361" height="284" alt="image" src="https://github.com/user-attachments/assets/1c8e6af4-18c8-4fcd-b5f2-648c1b6add13" />
