### PR TITLE
Disable Chat Rule if Regex Pattern is invalid

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRule.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRule.java
@@ -217,6 +217,8 @@ public class ChatRule {
 	}
 
 	private void compilePattern(String filterText) {
+		if (pattern != null) return;
+
 		try {
 			this.pattern = Pattern.compile(filterText);
 		} catch (PatternSyntaxException ex) {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -613,6 +613,7 @@
   "skyblocker.config.chat.chatRules.screen.ruleScreen.sounds.pling": "Pling",
   "skyblocker.config.chat.chatRules.screen.ruleScreen.sounds.zombie": "Zombie",
   "skyblocker.config.chat.chatRules.screen.ruleScreen.true": "True",
+  "skyblocker.config.chat.chatRules.invalidRegex": "Your chat rule '%s' has an invalid regex pattern and has been disabled!",
   "skyblocker.config.chat.waypoints.display": "Click to display waypoint at x: %d y: %d z: %d",
   "skyblocker.config.chat.waypoints.displayed": "Displayed temporary waypoint at x: %d y: %d z: %d %s",
 


### PR DESCRIPTION
Fixes Network Protocol Error disconnect if an enabled chat rule has an invalid regex pattern.

Also, makes it so that a chat rule only compiles its regex pattern once (unless changed).