### PR TITLE
fixes skyblocker settings button tooltip

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/SkyblockerConfigManager.java
+++ b/src/main/java/de/hysky/skyblocker/config/SkyblockerConfigManager.java
@@ -53,7 +53,7 @@ public class SkyblockerConfigManager {
 				Screens.getButtons(screen).add(ButtonWidget
 						.builder(Text.literal("\uD83D\uDD27"), buttonWidget -> client.setScreen(createGUI(screen)))
 						.dimensions(((HandledScreenAccessor) genericContainerScreen).getX() + ((HandledScreenAccessor) genericContainerScreen).getBackgroundWidth() - 16, ((HandledScreenAccessor) genericContainerScreen).getY() + 4, 12, 12)
-						.tooltip(Tooltip.of(Text.translatable("skyblocker.config.title")))
+						.tooltip(Tooltip.of(Text.translatable("skyblocker.config.title", Text.translatable("skyblocker.config.title.settings"))))
 						.build());
 			}
 		});

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -38,6 +38,7 @@
   "skyblocker.skyblockerScreen": "Skyblocker Main Screen",
 
   "skyblocker.config.title": "Skyblocker %s",
+  "skyblocker.config.title.settings": "Settings",
 
   "skyblocker.config.shortcutToKeybindsSettings": "Edit Keybind",
   "skyblocker.config.shortcutToKeybindsSettings.@Text": "Keybinds Menu",


### PR DESCRIPTION
Before 
<img width="350" height="246" alt="image" src="https://github.com/user-attachments/assets/745d5e7d-3dfe-42b4-8432-3dbe8b49a94f" />
The settings button text got broken. It again says `Skyblocker Settings` now