### PR TITLE
Fix Attribute Shards

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/hunting/Attributes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/hunting/Attributes.java
@@ -43,6 +43,8 @@ public class Attributes {
 	public static Attribute getAttributeFromItemName(ComponentHolder stack) {
 		if (!stack.contains(DataComponentTypes.CUSTOM_NAME)) return null;
 		String name = stack.get(DataComponentTypes.CUSTOM_NAME).getString();
+		name = name.replace(" Shard", ""); // Shards outside the hunting box now have "Shard" in their item name.
+		name = name.replace("BUY ", "").replace("SELL ", ""); // Bazaar Buy/Sell orders
 
 		for (Attribute attribute : attributes) {
 			if (attribute.shardName().equals(name)) return attribute;


### PR DESCRIPTION
With the 0.23.3 SkyBlock update, attribute shard items now have "Shard" appended to their name.