### PR TITLE
Fix Better Party Finder Locked Text on 1.21.6+

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyEntry.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyEntry.java
@@ -256,7 +256,7 @@ public class PartyEntry extends ElementListWidget.Entry<PartyEntry> {
 			int textHeight = textRenderer.fontHeight;
 
 			// The locked text can sometimes overlap with player names, so a background is drawn to make keep it visible.
-			context.fill(-lockWidth / 2, -2, lockWidth / 2, textHeight, 0x7F000000); // Colors.DARK_GRAY with 1/2 alpha
+			context.fill(-lockWidth / 2, -2, lockWidth / 2, textHeight, 0x7F000000); // Colors.BLACK with 1/2 alpha
             context.drawCenteredTextWithShadow(textRenderer, lockReason, 0, 0, Colors.LIGHT_RED);
 
 			matrices.popMatrix();


### PR DESCRIPTION
<img width="696" height="316" alt="image" src="https://github.com/user-attachments/assets/6a8ddf54-7612-4b5c-b31a-221689bfffea" />
