### PR TITLE
Add Sellable Dungeon Items Highlighter

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -52,6 +52,14 @@ public class DungeonsCategory {
 						.controller(ConfigUtils.createBooleanController())
 						.build())
 				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter"))
+						.description(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip"))
+						.binding(defaults.dungeons.sellableItemsHighlighter,
+								() -> config.dungeons.sellableItemsHighlighter,
+								newValue -> config.dungeons.sellableItemsHighlighter = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
+				.option(Option.<Boolean>createBuilder()
 						.name(Text.translatable("skyblocker.config.dungeons.playerSecretsTracker"))
 						.description(Text.translatable("skyblocker.config.dungeons.playerSecretsTracker.@Tooltip"))
 						.binding(defaults.dungeons.playerSecretsTracker,
@@ -121,14 +129,6 @@ public class DungeonsCategory {
 						.binding(defaults.dungeons.bloodCampHelper,
 								() -> config.dungeons.bloodCampHelper,
 								newValue -> config.dungeons.bloodCampHelper = newValue)
-						.controller(ConfigUtils.createBooleanController())
-						.build())
-				.option(Option.<Boolean>createBuilder()
-						.name(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter"))
-						.description(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip"))
-						.binding(defaults.dungeons.sellableItemsHighlighter,
-								() -> config.dungeons.sellableItemsHighlighter,
-								newValue -> config.dungeons.sellableItemsHighlighter = newValue)
 						.controller(ConfigUtils.createBooleanController())
 						.build())
 

--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -123,6 +123,14 @@ public class DungeonsCategory {
 								newValue -> config.dungeons.bloodCampHelper = newValue)
 						.controller(ConfigUtils.createBooleanController())
 						.build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter"))
+						.description(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip"))
+						.binding(defaults.dungeons.sellableItemHighlighter,
+								() -> config.dungeons.sellableItemHighlighter,
+								newValue -> config.dungeons.sellableItemHighlighter = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
 
 				// Map
 				.group(OptionGroup.createBuilder()

--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -126,9 +126,9 @@ public class DungeonsCategory {
 				.option(Option.<Boolean>createBuilder()
 						.name(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter"))
 						.description(Text.translatable("skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip"))
-						.binding(defaults.dungeons.sellableItemHighlighter,
-								() -> config.dungeons.sellableItemHighlighter,
-								newValue -> config.dungeons.sellableItemHighlighter = newValue)
+						.binding(defaults.dungeons.sellableItemsHighlighter,
+								() -> config.dungeons.sellableItemsHighlighter,
+								newValue -> config.dungeons.sellableItemsHighlighter = newValue)
 						.controller(ConfigUtils.createBooleanController())
 						.build())
 

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -31,6 +31,8 @@ public class DungeonsConfig {
 
 	public boolean hideSoulweaverSkulls = false;
 
+	public boolean sellableItemHighlighter = true;
+
 	public DungeonMap dungeonMap = new DungeonMap();
 
 	public SpiritLeapOverlay leapOverlay = new SpiritLeapOverlay();

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -13,6 +13,8 @@ public class DungeonsConfig {
 
 	public boolean salvageHelper = true;
 
+	public boolean sellableItemsHighlighter = true;
+
 	public boolean bloodCampHelper = false;
 
 	public boolean playerSecretsTracker = false;
@@ -30,8 +32,6 @@ public class DungeonsConfig {
 	public boolean dungeonSplits = false;
 
 	public boolean hideSoulweaverSkulls = false;
-
-	public boolean sellableItemsHighlighter = true;
 
 	public DungeonMap dungeonMap = new DungeonMap();
 

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -31,7 +31,7 @@ public class DungeonsConfig {
 
 	public boolean hideSoulweaverSkulls = false;
 
-	public boolean sellableItemHighlighter = true;
+	public boolean sellableItemsHighlighter = true;
 
 	public DungeonMap dungeonMap = new DungeonMap();
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/SalvageHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/SalvageHelper.java
@@ -28,7 +28,7 @@ public class SalvageHelper extends SimpleContainerSolver implements ContainerAnd
 		return slots.int2ObjectEntrySet().stream()
 				.filter(entry -> ItemUtils.getLoreLineIfContainsMatch(entry.getValue(), DUNGEON_SALVAGABLE) != null)
 				.filter(entry -> isPriceWithinRange(entry.getValue()))
-				.map(entry -> ColorHighlight.green(entry.getIntKey()))
+				.map(entry -> ColorHighlight.yellow(entry.getIntKey()))
 				.toList();
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/SellableItemsHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/SellableItemsHighlighter.java
@@ -1,0 +1,51 @@
+package de.hysky.skyblocker.skyblock.dungeon;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.container.ContainerAndInventorySolver;
+import de.hysky.skyblocker.utils.container.SimpleContainerSolver;
+import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+import java.util.Set;
+
+public class SellableItemsHighlighter extends SimpleContainerSolver implements ContainerAndInventorySolver {
+	private static final Set<String> ITEM_IDS = Set.of(
+			"DEFUSE_KIT",
+			"TRAINING_WEIGHTS",
+			"DUNGEON_LORE_PAPER",
+			"REVIVE_STONE"
+	);
+
+	private static final Set<String> POTION_ITEM_NAMES = Set.of(
+            "Healing VIII Splash Potion" // todo: check if need to also add without roman numeral
+    );
+
+	public SellableItemsHighlighter() {
+		super("^(Ophelia|Booster Cookie)$");
+	}
+
+	@Override
+	public List<ColorHighlight> getColors(Int2ObjectMap<ItemStack> slots) {
+		return slots.int2ObjectEntrySet().stream()
+				.filter(entry -> entry.getIntKey() > 54 && entry.getIntKey() < 81) // Only inventory slots
+				.filter(entry -> isValidItem(entry.getValue())) // Match Skyblock Id
+				.map(entry -> ColorHighlight.yellow(entry.getIntKey()))
+				.toList();
+	}
+
+	private boolean isValidItem(ItemStack stack) {
+		String skyblockId = stack.getSkyblockId();
+		if (skyblockId.equals("POTION")) {
+			String displayName = stack.getName().getString();
+			return POTION_ITEM_NAMES.stream().anyMatch(displayName::contains);
+		}
+		return ITEM_IDS.stream().anyMatch(skyblockId::equals);
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return SkyblockerConfigManager.get().dungeons.sellableItemHighlighter;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/SellableItemsHighlighter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/SellableItemsHighlighter.java
@@ -46,6 +46,6 @@ public class SellableItemsHighlighter extends SimpleContainerSolver implements C
 
 	@Override
 	public boolean isEnabled() {
-		return SkyblockerConfigManager.get().dungeons.sellableItemHighlighter;
+		return SkyblockerConfigManager.get().dungeons.sellableItemsHighlighter;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
@@ -8,6 +8,7 @@ import de.hysky.skyblocker.skyblock.accessories.newyearcakes.NewYearCakesHelper;
 import de.hysky.skyblocker.skyblock.auction.CopyUnderbidPrice;
 import de.hysky.skyblocker.skyblock.bazaar.ReorderHelper;
 import de.hysky.skyblocker.skyblock.chocolatefactory.ChocolateFactorySolver;
+import de.hysky.skyblocker.skyblock.dungeon.SellableItemsHighlighter;
 import de.hysky.skyblocker.skyblock.galatea.TunerSolver;
 import de.hysky.skyblocker.skyblock.dungeon.CroesusHelper;
 import de.hysky.skyblocker.skyblock.dungeon.CroesusProfit;
@@ -65,7 +66,8 @@ public class ContainerSolverManager {
 			new FossilSolver(),
 			SameColorTerminal.INSTANCE,
 			new CopyUnderbidPrice(),
-			new HuntingBoxHelper()
+			new HuntingBoxHelper(),
+			new SellableItemsHighlighter()
 	};
 	private static ContainerSolver currentSolver = null;
 	private static List<ColorHighlight> highlights;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -220,7 +220,7 @@
   "skyblocker.config.dungeons.salvageHelper": "Salvage Helper",
   "skyblocker.config.dungeons.salvageHelper.@Tooltip": "Highlights items picked up in dungeons that can be salvaged.",
 
-  "skyblocker.config.dungeons.sellableItemsHighlighter": "Highlight Sellable Items",
+  "skyblocker.config.dungeons.sellableItemsHighlighter": "Sellable Items Highlighter",
   "skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip": "Highlights items picked up in Dungeons that can be sold to NPC.",
 
   "skyblocker.config.dungeons.bloodCampHelper": "Blood Camp Helper",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -221,7 +221,7 @@
   "skyblocker.config.dungeons.salvageHelper.@Tooltip": "Highlights items picked up in dungeons that can be salvaged.",
 
   "skyblocker.config.dungeons.sellableItemsHighlighter": "Highlight Sellable Items",
-  "skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip": "Highlights items picked up in dungeons that can be sold to NPC Shops or the Booster Cookie menu.",
+  "skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip": "Highlights items picked up in Dungeons that can be sold to NPC.",
 
   "skyblocker.config.dungeons.bloodCampHelper": "Blood Camp Helper",
   "skyblocker.config.dungeons.bloodCampHelper.@Tooltip": "Predicts mob movement in the Blood Room to assist camping.",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -220,6 +220,9 @@
   "skyblocker.config.dungeons.salvageHelper": "Salvage Helper",
   "skyblocker.config.dungeons.salvageHelper.@Tooltip": "Highlights items picked up in dungeons that can be salvaged.",
 
+  "skyblocker.config.dungeons.sellableItemsHighlighter": "Highlight Sellable Items",
+  "skyblocker.config.dungeons.sellableItemsHighlighter.@Tooltip": "Highlights items picked up in dungeons that can be sold to NPC Shops or the Booster Cookie menu.",
+
   "skyblocker.config.dungeons.bloodCampHelper": "Blood Camp Helper",
   "skyblocker.config.dungeons.bloodCampHelper.@Tooltip": "Predicts mob movement in the Blood Room to assist camping.",
 


### PR DESCRIPTION
Highlights commonly picked-up dungeon items in the inventory when the Booster Cookie menu or Ophelia's shop is opened, so they can be sold more quickly.

Not sure if there are more items that I need to add. 

<img width="342" height="351" alt="image" src="https://github.com/user-attachments/assets/1359397e-24b9-4e0b-a56c-65feb11d64d1" />
