### PR TITLE
Fix Enchanted Books in REI Item List

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockItemComparator.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockItemComparator.java
@@ -1,0 +1,15 @@
+package de.hysky.skyblocker.compatibility.rei;
+
+import me.shedaniel.rei.api.common.entry.comparison.ComparisonContext;
+import me.shedaniel.rei.api.common.entry.comparison.EntryComparator;
+import net.minecraft.item.ItemStack;
+
+public class SkyblockItemComparator implements EntryComparator<ItemStack> {
+	@Override
+	public long hash(ComparisonContext context, ItemStack itemStack) {
+		if (itemStack.getNeuName().isEmpty()) {
+			return EntryComparator.noop().hash(context, itemStack);
+		}
+		return itemStack.getNeuName().hashCode();
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREICommonPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREICommonPlugin.java
@@ -1,0 +1,13 @@
+package de.hysky.skyblocker.compatibility.rei;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import me.shedaniel.rei.api.common.entry.comparison.ItemComparatorRegistry;
+import me.shedaniel.rei.api.common.plugins.REICommonPlugin;
+
+public class SkyblockerREICommonPlugin implements REICommonPlugin {
+	@Override
+	public void registerItemComparators(ItemComparatorRegistry registry) {
+		if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
+		registry.registerGlobal(new SkyblockItemComparator());
+	}
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,9 @@
     "rei_client": [
       "de.hysky.skyblocker.compatibility.rei.SkyblockerREIClientPlugin"
     ],
+    "rei_common": [
+      "de.hysky.skyblocker.compatibility.rei.SkyblockerREICommonPlugin"
+    ],
     "emi": [
       "de.hysky.skyblocker.compatibility.emi.SkyblockerEMIPlugin"
     ],


### PR DESCRIPTION
Finally took the time to see how to fix this.

Side note: You'll want to disable the REI Enchanted Book Collapsible Entry Category (REI Settings -> List -> Collapsible Categories: Configure). 
<img width="312" height="361" alt="image" src="https://github.com/user-attachments/assets/96958cc6-f24f-4084-a9f0-9cb0b32a39f6" />

~~When #1475 gets merged, I'll see if there's a way to disable it by default. Trying to avoid having to resolve merge conflicts.~~ 
There's not really a way to disable it for the user, and the only problem really is when searching for enchantments like "Protection", it'll group together "Fire Protection" and "Blast Protection" with it. This doesn't happen with the Skyblocker Collapsible Categories since it creates new categories for the enchantments.

