### PR TITLE
Fix museum donation status false positives

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/MuseumTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/MuseumTooltip.java
@@ -4,7 +4,6 @@ import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
 import de.hysky.skyblocker.skyblock.museum.MuseumItemCache;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;


### PR DESCRIPTION
Removed the check for the `donated_museum` NBT tag. As previously discussed in the SkyHanni Discord, this NBT tag is simply an indicator of "hey, this item is co-op soulbound because it was donated to the museum at some point in its lifetime". It is not a reliable indicator of actual donation status for two reasons:
- It persists through item upgrades, even if you haven't donated the upgraded version of the item yet.
- If you are playing in a co-op, members can exchange items between each other and donate the same item individually so all of them get the XP, without having to get separate copies of items just for the museum. But since `donated_museum` is a property of the item, all members will have it as "true" even if they personally haven't donated that item to their museum yet.
  - Of course, only one of them can have the same copy of an item physically *in* the museum at a time, but there is essentially no downside to borrowing items from the museum, especially now that rewards aren't based on museum value anymore.