### PR TITLE
Responsive smooth AOTE

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -6,7 +6,7 @@ import de.hysky.skyblocker.config.SkyblockerConfig;
 import de.hysky.skyblocker.config.configs.UIAndVisualsConfig;
 import de.hysky.skyblocker.skyblock.GyroOverlay;
 import de.hysky.skyblocker.skyblock.ItemPickupWidget;
-import de.hysky.skyblocker.skyblock.TeleportOverlay;
+import de.hysky.skyblocker.skyblock.teleport.TeleportOverlay;
 import de.hysky.skyblocker.skyblock.fancybars.StatusBarsConfigScreen;
 import de.hysky.skyblocker.skyblock.item.slottext.SlotTextManager;
 import de.hysky.skyblocker.skyblock.item.slottext.SlotTextMode;
@@ -473,6 +473,14 @@ public class UIAndVisualsCategory {
                         .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE"))
                         .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.@Tooltip"))
                         .collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.predictive"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.predictive.@Tooltip"))
+								.binding(defaults.uiAndVisuals.smoothAOTE.predictive,
+										() -> config.uiAndVisuals.smoothAOTE.predictive,
+										newValue -> config.uiAndVisuals.smoothAOTE.predictive = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
                         .option(Option.<Boolean>createBuilder()
                                 .name(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWeirdTransmission"))
                                 .description(Text.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWeirdTransmission.@Tooltip"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -298,6 +298,8 @@ public class UIAndVisualsConfig {
 	}
 
 	public static class SmoothAOTE {
+		public boolean predictive = false;
+
 		public boolean enableWeirdTransmission = false;
 
 		public boolean enableInstantTransmission = false;

--- a/src/main/java/de/hysky/skyblocker/mixins/CameraMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/CameraMixin.java
@@ -1,7 +1,9 @@
 package de.hysky.skyblocker.mixins;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-import de.hysky.skyblocker.skyblock.SmoothAOTE;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.teleport.PredictiveSmoothAOTE;
+import de.hysky.skyblocker.skyblock.teleport.ResponsiveSmoothAOTE;
 import net.minecraft.client.render.Camera;
 import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,11 +14,20 @@ public class CameraMixin {
 
     @ModifyReturnValue(method = "getPos", at = @At("RETURN"))
     private Vec3d skyblocker$onCameraUpdate(Vec3d original) {
-        Vec3d pos = SmoothAOTE.getInterpolatedPos();
-        if (pos != null) {
-            return pos;
-        }
+		if (SkyblockerConfigManager.get().uiAndVisuals.smoothAOTE.predictive){
+			Vec3d pos = PredictiveSmoothAOTE.getInterpolatedPos();
+			if (pos != null) {
+				return pos;
+			}
+		} else {
+			Vec3d pos = ResponsiveSmoothAOTE.getInterpolatedPos();
+			if (pos != null) {
+				return pos;
+			}
+		}
 
-        return original;
+
+
+		return original;
     }
 }

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayNetworkHandlerMixin.java
@@ -12,7 +12,7 @@ import de.hysky.skyblocker.events.ParticleEvents;
 import de.hysky.skyblocker.events.PlaySoundEvents;
 import de.hysky.skyblocker.skyblock.CompactDamage;
 import de.hysky.skyblocker.skyblock.HealthBars;
-import de.hysky.skyblocker.skyblock.SmoothAOTE;
+import de.hysky.skyblocker.skyblock.teleport.PredictiveSmoothAOTE;
 import de.hysky.skyblocker.skyblock.chocolatefactory.EggFinder;
 import de.hysky.skyblocker.skyblock.dungeon.DungeonScore;
 import de.hysky.skyblocker.skyblock.dungeon.puzzle.TeleportMaze;
@@ -26,6 +26,7 @@ import de.hysky.skyblocker.skyblock.galatea.TreeBreakProgressHud;
 import de.hysky.skyblocker.skyblock.slayers.SlayerManager;
 import de.hysky.skyblocker.skyblock.slayers.boss.demonlord.FirePillarAnnouncer;
 import de.hysky.skyblocker.skyblock.tabhud.util.PlayerListManager;
+import de.hysky.skyblocker.skyblock.teleport.ResponsiveSmoothAOTE;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientCommonNetworkHandler;
@@ -99,12 +100,13 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 	@Inject(method = "onPlayerPositionLook", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/util/thread/ThreadExecutor;)V", shift = At.Shift.AFTER))
 	private void skyblocker$beforeTeleport(PlayerPositionLookS2CPacket packet, CallbackInfo ci, @Share("playerBeforeTeleportBlockPos") LocalRef<BlockPos> beforeTeleport) {
 		beforeTeleport.set(client.player.getBlockPos().toImmutable());
+		ResponsiveSmoothAOTE.PlayerGoingToTeleport();
 	}
 
 	@Inject(method = "onPlayerPositionLook", at = @At(value = "RETURN"))
 	private void skyblocker$onTeleport(PlayerPositionLookS2CPacket packet, CallbackInfo ci, @Share("playerBeforeTeleportBlockPos") LocalRef<BlockPos> beforeTeleport) {
 		//player has been teleported by the server, tell the smooth AOTE this
-		SmoothAOTE.playerTeleported();
+		PredictiveSmoothAOTE.playerTeleported();
 
 		TeleportMaze.INSTANCE.onTeleport(client, beforeTeleport.get(), client.player.getBlockPos().toImmutable());
 	}
@@ -175,7 +177,7 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 		//make the f3+3 screen always send ping packets even when closed
 		//this is needed to make smooth AOTE work so check if its enabled
 		UIAndVisualsConfig.SmoothAOTE options = SkyblockerConfigManager.get().uiAndVisuals.smoothAOTE;
-		if (Utils.isOnSkyblock() && !SmoothAOTE.teleportDisabled && (options.enableWeirdTransmission || options.enableEtherTransmission || options.enableInstantTransmission || options.enableSinrecallTransmission || options.enableWitherImpact)) {
+		if (Utils.isOnSkyblock() && !PredictiveSmoothAOTE.teleportDisabled && (options.enableWeirdTransmission || options.enableEtherTransmission || options.enableInstantTransmission || options.enableSinrecallTransmission || options.enableWitherImpact)) {
 			return true;
 		}
 		return original;

--- a/src/main/java/de/hysky/skyblocker/mixins/PingMeasurerMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/PingMeasurerMixin.java
@@ -1,6 +1,6 @@
 package de.hysky.skyblocker.mixins;
 
-import de.hysky.skyblocker.skyblock.SmoothAOTE;
+import de.hysky.skyblocker.skyblock.teleport.PredictiveSmoothAOTE;
 import de.hysky.skyblocker.skyblock.crimson.dojo.DojoManager;
 import de.hysky.skyblocker.utils.Utils;
 import net.minecraft.client.network.PingMeasurer;
@@ -16,7 +16,7 @@ public class PingMeasurerMixin {
         if (Utils.isInCrimson()) {
             DojoManager.onPingResult(ping);
         }
-        SmoothAOTE.updatePing(ping);
+        PredictiveSmoothAOTE.updatePing(ping);
 
         return ping;
     }

--- a/src/main/java/de/hysky/skyblocker/skyblock/teleport/ResponsiveSmoothAOTE.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/teleport/ResponsiveSmoothAOTE.java
@@ -1,0 +1,56 @@
+package de.hysky.skyblocker.skyblock.teleport;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.ItemUtils;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.math.Vec3d;
+
+import static de.hysky.skyblocker.skyblock.teleport.PredictiveSmoothAOTE.getItemDistance;
+
+public class ResponsiveSmoothAOTE {
+	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
+
+	private static long startTime;
+	private static Vec3d lastPosition;
+	private static double lastProgress;
+
+	public static void PlayerGoingToTeleport() {
+		if (CLIENT.player == null) return;
+		//make sure teleport is enabled for held item
+		ItemStack heldItem = CLIENT.player.getMainHandStack();
+		String itemId = heldItem.getSkyblockId();
+		NbtCompound customData = ItemUtils.getCustomData(heldItem);
+		int distance = getItemDistance(itemId, customData);
+		if (distance == -1) {
+			return;
+		}
+		lastPosition = CLIENT.player.getEyePos();
+		lastProgress = 0;
+		startTime = System.currentTimeMillis();
+	}
+
+	public static Vec3d getInterpolatedPos() {
+		if (lastPosition == null || CLIENT.player == null) return null;
+		double progress = (double) (System.currentTimeMillis() - startTime) / SkyblockerConfigManager.get().uiAndVisuals.smoothAOTE.maximumAddedLag;
+		//end if finished
+		if (progress > 1) {
+			lastPosition = null;
+			lastProgress = 0;
+			return null;
+		}
+		//find vector between last position and current pos
+		Vec3d teleportVector = CLIENT.player.getEyePos().subtract(lastPosition);
+		double progressDiff = progress - lastProgress;
+		double relativeProgress = progressDiff / (1 - lastProgress);
+
+
+		//return interpolated pos
+		if (lastPosition == null) return null; // some who still a problem here
+		lastPosition = lastPosition.add(teleportVector.multiply(relativeProgress));
+		lastProgress = progress;
+		return lastPosition;
+
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/teleport/TeleportOverlay.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/teleport/TeleportOverlay.java
@@ -1,4 +1,4 @@
-package de.hysky.skyblocker.skyblock;
+package de.hysky.skyblocker.skyblock.teleport;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
@@ -76,7 +76,7 @@ public class TeleportOverlay {
     }
 
     /**
-     * Renders the teleport overlay with a given range. Uses {@link SmoothAOTE#raycast(int, Vec3d, Vec3d)} to predict the target
+     * Renders the teleport overlay with a given range. Uses {@link PredictiveSmoothAOTE#raycast(int, Vec3d, Vec3d)} to predict the target
      *
      * @implNote {@link MinecraftClient#player} and {@link MinecraftClient#world} must not be null when calling this method.
      */
@@ -87,7 +87,7 @@ public class TeleportOverlay {
 		float yaw = client.player.getYaw();
 		Vec3d look = client.player.getRotationVector(pitch, yaw);
 		Vec3d startPos = client.player.getPos().add(0, 1.62, 0);
-		Vec3d raycast = SmoothAOTE.raycast(range, look, startPos);
+		Vec3d raycast = PredictiveSmoothAOTE.raycast(range, look, startPos);
 
 		if (raycast != null) {
 			BlockPos target = BlockPos.ofFloored(startPos.add(raycast)).down();

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1125,6 +1125,8 @@
 
   "skyblocker.config.uiAndVisuals.smoothAOTE": "Smooth AOTE",
   "skyblocker.config.uiAndVisuals.smoothAOTE.@Tooltip": "Smooths out teleporting with right click teleport abilities.",
+  "skyblocker.config.uiAndVisuals.smoothAOTE.predictive": "Predictive Algorithm",
+  "skyblocker.config.uiAndVisuals.smoothAOTE.predictive.@Tooltip": "Predict where the teleport will end. This will decrease mean there is no added lag however it is sometimes wrong and can glitch out",
   "skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission": "Enable Ether Transmission",
   "skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission.@Tooltip": "For: Etherwarp Conduit and Ether Merged.",
   "skyblocker.config.uiAndVisuals.smoothAOTE.enableInstantTransmission": "Enable Instant Transmission",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1126,7 +1126,7 @@
   "skyblocker.config.uiAndVisuals.smoothAOTE": "Smooth AOTE",
   "skyblocker.config.uiAndVisuals.smoothAOTE.@Tooltip": "Smooths out teleporting with right click teleport abilities.",
   "skyblocker.config.uiAndVisuals.smoothAOTE.predictive": "Predictive Algorithm",
-  "skyblocker.config.uiAndVisuals.smoothAOTE.predictive.@Tooltip": "Predict where the teleport will end. This will decrease mean there is no added lag however it is sometimes wrong and can glitch out",
+  "skyblocker.config.uiAndVisuals.smoothAOTE.predictive.@Tooltip": "Predict where the teleport will end. This will mean there can be no added lag however it is sometimes wrong and can glitch out",
   "skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission": "Enable Ether Transmission",
   "skyblocker.config.uiAndVisuals.smoothAOTE.enableEtherTransmission.@Tooltip": "For: Etherwarp Conduit and Ether Merged.",
   "skyblocker.config.uiAndVisuals.smoothAOTE.enableInstantTransmission": "Enable Instant Transmission",


### PR DESCRIPTION
Fresh PR of  #1456. As it was messed up.

This adds an option to have the smooth teleport more like NEU and only smooth after we know where the teleport is going to end. This is now the default and people can enable the old predictive method if they want

