### PR TITLE
Reload Recipes After the Item Repository Has Finished Loading

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
@@ -69,7 +69,7 @@ public class ItemRepository {
 
 		SynchronizeRecipesS2CPacket packet = new SynchronizeRecipesS2CPacket(Map.of(), CuttingRecipeDisplay.Grouping.empty());
 		try {
-			client.getNetworkHandler().onSynchronizeRecipes(packet);
+			client.execute(() -> client.getNetworkHandler().onSynchronizeRecipes(packet));
 		} catch (Exception e) {
 			LOGGER.info("[Skyblocker Item Repo] recipe sync error", e);
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
@@ -7,7 +7,6 @@ import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockForgeRecipe;
 import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockRecipe;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.NEURepoManager;
-import de.hysky.skyblocker.utils.Utils;
 import io.github.moulberry.repo.data.NEUCraftingRecipe;
 import io.github.moulberry.repo.data.NEUForgeRecipe;
 import io.github.moulberry.repo.data.NEUItem;
@@ -62,13 +61,11 @@ public class ItemRepository {
 
 	/**
 	 * Load the recipes manually because Hypixel doesn't send any vanilla recipes to the client.
-	 * This also reloads REI to include the Skyblock items.
+	 * This also reloads REI to include the Skyblock items when the items are done loading.
 	 */
 	private static void handleRecipeSynchronization() {
-		if (!itemsImported || !filesImported) return;
-
 		MinecraftClient client = MinecraftClient.getInstance();
-		if (client.world == null || client.getNetworkHandler() == null || !Utils.isOnSkyblock()) return;
+		if (client.world == null || client.getNetworkHandler() == null) return;
 
 		SynchronizeRecipesS2CPacket packet = new SynchronizeRecipesS2CPacket(Map.of(), CuttingRecipeDisplay.Grouping.empty());
 		try {

--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
@@ -1,18 +1,23 @@
 package de.hysky.skyblocker.skyblock.itemlist;
 
 import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockCraftingRecipe;
 import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockForgeRecipe;
 import de.hysky.skyblocker.skyblock.itemlist.recipes.SkyblockRecipe;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.NEURepoManager;
+import de.hysky.skyblocker.utils.Utils;
 import io.github.moulberry.repo.data.NEUCraftingRecipe;
 import io.github.moulberry.repo.data.NEUForgeRecipe;
 import io.github.moulberry.repo.data.NEUItem;
 import io.github.moulberry.repo.data.NEURecipe;
 import io.github.moulberry.repo.util.NEUId;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.network.packet.s2c.play.SynchronizeRecipesS2CPacket;
+import net.minecraft.recipe.display.CuttingRecipeDisplay;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +56,26 @@ public class ItemRepository {
 		NEURepoManager.runAsyncAfterLoad(ItemStackBuilder::loadPetNums);
 		NEURepoManager.runAsyncAfterLoad(ItemRepository::importItemFiles);
 		NEURepoManager.runAsyncAfterLoad(ItemRepository::loadBazaarStocks);
+		runAsyncAfterImport(ItemRepository::handleRecipeSynchronization);
+		SkyblockEvents.JOIN.register(ItemRepository::handleRecipeSynchronization);
+	}
+
+	/**
+	 * Load the recipes manually because Hypixel doesn't send any vanilla recipes to the client.
+	 * This also reloads REI to include the Skyblock items.
+	 */
+	private static void handleRecipeSynchronization() {
+		if (!itemsImported || !filesImported) return;
+
+		MinecraftClient client = MinecraftClient.getInstance();
+		if (client.world == null || client.getNetworkHandler() == null || !Utils.isOnSkyblock()) return;
+
+		SynchronizeRecipesS2CPacket packet = new SynchronizeRecipesS2CPacket(Map.of(), CuttingRecipeDisplay.Grouping.empty());
+		try {
+			client.getNetworkHandler().onSynchronizeRecipes(packet);
+		} catch (Exception e) {
+			LOGGER.info("[Skyblocker Item Repo] recipe sync error", e);
+		}
 	}
 
 	private static void importItemFiles() {
@@ -140,11 +165,6 @@ public class ItemRepository {
 
 	public static boolean filesImported() {
 		return filesImported;
-	}
-
-	public static void setFilesImported() {
-		itemsImported = false;
-		filesImported = false;
 	}
 
 	public static List<ItemStack> getItems() {

--- a/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Multimaps;
 import com.mojang.brigadier.Command;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
-import de.hysky.skyblocker.events.SkyblockEvents;
 import de.hysky.skyblocker.utils.scheduler.Scheduler;
 import io.github.moulberry.repo.NEUConstants;
 import io.github.moulberry.repo.NEURecipeCache;
@@ -19,8 +18,6 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.network.packet.s2c.play.SynchronizeRecipesS2CPacket;
-import net.minecraft.recipe.display.CuttingRecipeDisplay;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import org.apache.commons.lang3.function.Consumers;
@@ -89,26 +86,9 @@ public class NEURepoManager {
 						}))
 				)
 		);
-		SkyblockEvents.JOIN.register(NEURepoManager::handleRecipeSynchronization);
-		runAsyncAfterLoad(NEURepoManager::loadNameToNEUItemMap); // Loads the NEUItem name cache after the repository is laoded.
+		runAsyncAfterLoad(NEURepoManager::loadNameToNEUItemMap); // Loads the NEUItem name cache after the repository is loaded.
 	}
 
-	/**
-	 * load the recipe manually because Hypixel doesn't send any vanilla recipes to the client
-	 */
-	private static void handleRecipeSynchronization() {
-		MinecraftClient client = MinecraftClient.getInstance();
-		if (client.world != null && client.getNetworkHandler() != null) {
-			//FIXME not sure if we even need this - depends on how REI, EMI, and JEI adapt to the changes
-			SynchronizeRecipesS2CPacket packet = new SynchronizeRecipesS2CPacket(Map.of(), CuttingRecipeDisplay.Grouping.empty());
-
-			try {
-				client.getNetworkHandler().onSynchronizeRecipes(packet);
-			} catch (Exception e) {
-				LOGGER.info("[Skyblocker NEU Repo] recipe sync error", e);
-			}
-		}
-	}
 
 	public static boolean isLoading() {
 		return REPO_LOADING != null && !REPO_LOADING.isDone();


### PR DESCRIPTION
Moves `handleRecipeSynchronization()` from NEURepoManager to ItemRepository and adds an after reload callback to it. 
Not sure if this should be moved into its own separate file instead since there's already a lot in ItemRepository.

This makes it so that REI will reload after the NEU Repo and Item Repository are loaded, so you don't have to manually reload it.