### PR TITLE
More precise crystal waypoints when clicking or killing NPCs (Odawa, …

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MiningLocationLabel.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MiningLocationLabel.java
@@ -7,10 +7,9 @@ import net.minecraft.text.Text;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.StringIdentifiable;
 import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
-
-import javax.annotation.Nullable;
 
 public class MiningLocationLabel extends DistancedNamedWaypoint {
     private final Category category;
@@ -162,10 +161,10 @@ public class MiningLocationLabel extends DistancedNamedWaypoint {
     }
 
     /**
-     * enum for the different waypoints used int the crystals hud each with a {@link CrystalHollowsLocationsCategory#name} and associated {@link CrystalHollowsLocationsCategory#color}
+     * Enum for the different waypoints used in the crystals hud each with a {@link CrystalHollowsLocationsCategory#name} and associated {@link CrystalHollowsLocationsCategory#color}.
      */
     public enum CrystalHollowsLocationsCategory implements Category, StringIdentifiable {
-        UNKNOWN("Unknown", Color.WHITE, null, 0), //used when a location is known but what's at the location is not known
+        UNKNOWN("Unknown", Color.WHITE), // Used when a location is known but what's at the location is not known
         // These waypoints are verified by interacting with the corresponding NPC (e.g., by clicking on Odawa)
         JUNGLE_TEMPLE("Jungle Temple", new Color(DyeColor.PURPLE.getSignColor()), "Kalhuiki Door Guardian", 10),
         LOST_PRECURSOR_CITY("Lost Precursor City", Color.CYAN, "Professor Robot", 8),
@@ -173,25 +172,29 @@ public class MiningLocationLabel extends DistancedNamedWaypoint {
         ODAWA("Odawa", Color.MAGENTA, "Odawa", 8),
         CORLEONE("Corleone", Color.WHITE, "Boss Corleone", 20),
         KEY_GUARDIAN("Key Guardian", Color.LIGHT_GRAY, "Key Guardian", 10),
-        // Look for chat message containing npcName (crystal name)
+        // Look for chat messages containing the crystal name
         KHAZAD_DUM("Khazad-dûm", Color.YELLOW, "    Topaz Crystal", 20),
         GOBLIN_QUEENS_DEN("Goblin Queen's Den", new Color(DyeColor.ORANGE.getSignColor()), "    Amber Crystal", 20),
         MINES_OF_DIVAN("Mines of Divan", Color.GREEN, "    Jade Crystal", 20),
         // These cannot be found automatically yet.
-        FAIRY_GROTTO("Fairy Grotto", Color.PINK, null, 0),
-        DRAGONS_LAIR("Dragon's Lair", Color.BLACK, null, 0);
+        FAIRY_GROTTO("Fairy Grotto", Color.PINK),
+        DRAGONS_LAIR("Dragon's Lair", Color.BLACK);
 
         public static final Codec<CrystalHollowsLocationsCategory> CODEC = StringIdentifiable.createBasicCodec(CrystalHollowsLocationsCategory::values);
 
         public final Color color;
-        private final @Nullable String name;
-        private final String npcName;
+        private final String name;
+        private final @Nullable String identifyingText;
         private final int searchRadius;
 
-        CrystalHollowsLocationsCategory(String name, Color color, String npcName, int searchRadius) {
+        CrystalHollowsLocationsCategory(String name, Color color) {
+            this(name, color, null, 0);
+        }
+
+        CrystalHollowsLocationsCategory(String name, Color color, @Nullable String identifyingText, int searchRadius) {
             this.name = name;
             this.color = color;
-            this.npcName = npcName;
+            this.identifyingText = identifyingText;
             this.searchRadius = searchRadius;
         }
 
@@ -205,8 +208,8 @@ public class MiningLocationLabel extends DistancedNamedWaypoint {
             return this.color.getRGB();
         }
 
-        public @Nullable String getNpcName() {
-            return this.npcName;
+        public @Nullable String getIdentifyingText() {
+            return this.identifyingText;
         }
 
         public int getSearchRadius() {
@@ -218,12 +221,11 @@ public class MiningLocationLabel extends DistancedNamedWaypoint {
             return name();
         }
 
-        // npcName search
-        public static CrystalHollowsLocationsCategory findNpcNameBySubstring(String query) {
+        public static CrystalHollowsLocationsCategory fromContainsIdentifyingText(String query) {
             if (query == null || query.isBlank()) return null;
 
             for (CrystalHollowsLocationsCategory c : values()) {
-                if (c.npcName != null && !c.npcName.isBlank() && query.contains(c.npcName)) {
+                if (c.identifyingText != null && !c.identifyingText.isBlank() && query.contains(c.identifyingText)) {
                     return c;
                 }
             }


### PR DESCRIPTION
Most locations are detected by listening for NPC interactions (clicks). We also check that an existing waypoint isn't already nearby (I manually tuned the optimal searchRadius).

For Khazad-dûm, Goblin Queen’s Den, and Mines of Divan, we still rely on chat messages that announce obtaining the Crystal (same as before).

I profiled it and didn’t notice any impact on performance.