### PR TITLE
Fix Puzzles Regex Not Matching if Username is Missing

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
@@ -41,7 +41,7 @@ public class DungeonScore {
 	private static final Pattern FLOOR_PATTERN = Pattern.compile(".*?(?=T)The Catacombs \\((?<floor>[EFM]\\D*\\d*)\\)");
 	//Playerlist patterns
 	private static final Pattern SECRETS_PATTERN = Pattern.compile("Secrets Found: (?<secper>\\d+\\.?\\d*)%");
-	private static final Pattern PUZZLES_PATTERN = Pattern.compile(".+?(?=:): \\[(?<state>.)](?: \\((\\w+)?\\))?");
+	private static final Pattern PUZZLES_PATTERN = Pattern.compile(".+?(?=:): \\[(?<state>.)](?: \\(\\w*\\))?");
 	private static final Pattern PUZZLE_COUNT_PATTERN = Pattern.compile("Puzzles: \\((?<count>\\d+)\\)");
 	private static final Pattern CRYPTS_PATTERN = Pattern.compile("Crypts: (?<crypts>\\d+)");
 	private static final Pattern COMPLETED_ROOMS_PATTERN = Pattern.compile(" *Completed Rooms: (?<rooms>\\d+)");


### PR DESCRIPTION
The Quiz Puzzle scoreboard entry does not show the username of the player who failed the puzzle.
<img width="278" height="95" alt="image" src="https://github.com/user-attachments/assets/0cd370b3-1890-4e1b-ab85-148a342e9ece" />

Fixes this:
`[Render thread/ERROR] (Skyblocker Regex) no match: "Quiz: [✖] ()" against ".+?(?=:): \[(?<state>.)](?: \(\w+\))?"`