### PR TITLE
Change halfBarColor to FFFF00

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -382,7 +382,7 @@ public class UIAndVisualsConfig {
 
 		public Color fullBarColor = new Color(0x00FF00);
 
-		public Color halfBarColor = new Color(0xFF4600);
+		public Color halfBarColor = new Color(0xFFFF00);
 
 		public Color emptyBarColor = new Color(0xFF0000);
 	}


### PR DESCRIPTION
FF4600 is very unbalanced, causing the health bar to turn red too early (at 50% health remaining).

Before:
<img width="777" height="497" alt="图片" src="https://github.com/user-attachments/assets/9170c727-8358-48af-b9ce-5e51204b6a28" />

After:
<img width="908" height="467" alt="图片" src="https://github.com/user-attachments/assets/4f5c0560-0189-416d-9aa1-46c5e2e35c4e" />
