### PR TITLE
Add Call Maddox Prompts

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/SlayersCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/SlayersCategory.java
@@ -92,6 +92,27 @@ public class SlayersCategory {
 						.action(screen -> MinecraftClient.getInstance().setScreen(new WidgetsConfigurationScreen(Location.HUB, SlayerHudWidget.getInstance().getInternalID(), screen)))
 						.build())
 
+				.group(OptionGroup.createBuilder()
+						.name(Text.translatable("skyblocker.config.slayer.callMaddox"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.slayer.callMaddox.sendMessageOnFail"))
+								.description(Text.translatable("skyblocker.config.slayer.callMaddox.sendMessageOnFail.@Tooltip"))
+								.binding(defaults.slayers.callMaddox.sendMessageOnFail,
+										() -> config.slayers.callMaddox.sendMessageOnFail,
+										newValue -> config.slayers.callMaddox.sendMessageOnFail = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.slayer.callMaddox.sendMessageOnKill"))
+								.description(Text.translatable("skyblocker.config.slayer.callMaddox.sendMessageOnFail.@Tooltip")) // Same tooltip as above
+								.binding(defaults.slayers.callMaddox.sendMessageOnKill,
+										() -> config.slayers.callMaddox.sendMessageOnKill,
+										newValue -> config.slayers.callMaddox.sendMessageOnKill = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.build())
+
 				//Enderman Slayer
 				.group(OptionGroup.createBuilder()
 						.name(Text.translatable("skyblocker.config.slayer.endermanSlayer"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/SlayersConfig.java
@@ -26,11 +26,19 @@ public class SlayersConfig {
 
 	public boolean enableHud = true;
 
+	public CallMaddox callMaddox = new CallMaddox();
+
 	public EndermanSlayer endermanSlayer = new EndermanSlayer();
 
 	public VampireSlayer vampireSlayer = new VampireSlayer();
 
 	public BlazeSlayer blazeSlayer = new BlazeSlayer();
+
+	public static class CallMaddox {
+		public boolean sendMessageOnFail = true;
+
+		public boolean sendMessageOnKill = false;
+	}
 
 	public static class EndermanSlayer {
 		public boolean enableYangGlyphsNotification = true;

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/CallMaddox.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/CallMaddox.java
@@ -1,0 +1,34 @@
+package de.hysky.skyblocker.skyblock.slayers;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.Constants;
+import de.hysky.skyblocker.utils.Utils;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.Text;
+
+public class CallMaddox {
+	private static void sendMessage() {
+		ClientPlayerEntity player = MinecraftClient.getInstance().player;
+		if (player == null) return;
+
+		Text text = Constants.PREFIX.get().append(Text.translatable("skyblocker.slayer.callMaddox.message"))
+				.styled(style -> style.withClickEvent(new ClickEvent.RunCommand("/call slayer")));
+
+		player.sendMessage(text, false);
+	}
+
+	// This is also called when the slayer is cancelled.
+	public static void onSlayerFailed() {
+		if (!SkyblockerConfigManager.get().slayers.callMaddox.sendMessageOnFail) return;
+		if (Utils.isInTheRift()) return;
+		sendMessage();
+	}
+
+	public static void onBossKilled() {
+		if (!SkyblockerConfigManager.get().slayers.callMaddox.sendMessageOnKill) return;
+		if (Utils.isInTheRift()) return;
+		sendMessage();
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerManager.java
@@ -83,6 +83,7 @@ public class SlayerManager {
 			case "Your Slayer Quest has been cancelled!", "SLAYER QUEST FAILED!" -> {
 				slayerQuest = null;
 				bossFight = null;
+				CallMaddox.onSlayerFailed();
 				return true;
 			}
 			case "SLAYER QUEST STARTED!" -> {
@@ -94,12 +95,15 @@ public class SlayerManager {
 				if (slayerQuest != null && bossFight != null) {
 					bossFight.slain = true;
 					SlayerTimer.onBossDeath(bossFight.bossSpawnTime);
+					CallMaddox.onBossKilled();
 				}
 				return true;
 			}
 			case "SLAYER QUEST COMPLETE!" -> {
-				if (slayerQuest != null && bossFight != null && !bossFight.slain)
+				if (slayerQuest != null && bossFight != null && !bossFight.slain) {
 					SlayerTimer.onBossDeath(bossFight.bossSpawnTime);
+					CallMaddox.onBossKilled();
+				}
 				bossFight = null;
 				return true;
 			}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -873,6 +873,11 @@
 
   "skyblocker.config.slayer": "Slayers",
 
+  "skyblocker.config.slayer.callMaddox": "Call Maddox",
+  "skyblocker.config.slayer.callMaddox.sendMessageOnFail": "Send Message on Slayer Boss Failed",
+  "skyblocker.config.slayer.callMaddox.sendMessageOnFail.@Tooltip": "Sends a message that can be clicked to quickly call Maddox the Slayer.",
+  "skyblocker.config.slayer.callMaddox.sendMessageOnKill": "Send Message on Slayer Boss Kill",
+
   "skyblocker.config.slayer.enableHud": "Slayer HUD",
   "skyblocker.config.slayer.enableHud.@Tooltip": "You may have to do 1 boss before all HUD elements show",
 
@@ -1396,6 +1401,7 @@
   "skyblocker.slayer.personalBest": "PERSONAL BEST!",
   "skyblocker.slayer.previousPB": "Your previous Personal Best was %s.",
   "skyblocker.slayer.slainTime": "Slayer has been killed in %s!",
+  "skyblocker.slayer.callMaddox.message": "Click here to call Maddox the Slayer!",
 
   "skyblocker.waypoints.config": "Waypoints Config",
   "skyblocker.waypoints.newGroup": "New Waypoint Group",


### PR DESCRIPTION
Adds a prompt in chat to call Maddox on slayer kill and on slayer fail or cancelling a slayer quest.
(The last 2 are grouped due to how the SlayerManager works)
Closes #1626 

Cancelling the Slayer Quest:
<img width="573" height="64" alt="image" src="https://github.com/user-attachments/assets/f46dadd6-7194-42bb-914f-1d192d96834f" />

On Slayer Kill (useful if you don't have auto-slayer but have an Abiphone):
<img width="570" height="139" alt="image" src="https://github.com/user-attachments/assets/d03b2a95-5d78-48e5-92c8-45cb08b1b1f7" />


