### PR TITLE
Left click becomes middle click wowi zowi

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -103,6 +103,7 @@
                             @text='Unique'
                             or @text='Inject'
                             or @text='ModifyArg'
+                            or @text='ModifyArgs'
                             or @text='ModifyExpressionValue'
                             or @text='ModifyReturnValue'
                             or @text='ModifyVariable'

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -103,7 +103,6 @@
                             @text='Unique'
                             or @text='Inject'
                             or @text='ModifyArg'
-                            or @text='ModifyArgs'
                             or @text='ModifyExpressionValue'
                             or @text='ModifyReturnValue'
                             or @text='ModifyVariable'

--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -66,6 +66,13 @@ public class GeneralCategory {
                                 newValue -> config.general.acceptReparty = newValue)
                         .controller(ConfigUtils.createBooleanController())
                         .build())
+				.option(Option.<Boolean>createBuilder()
+						.name(Text.translatable("skyblocker.config.general.guiMiddleClick"))
+						.binding(defaults.general.guiMiddleClick,
+								() -> config.general.guiMiddleClick,
+								newValue -> config.general.guiMiddleClick = newValue)
+						.controller(ConfigUtils.createBooleanController())
+						.build())
 				//Config Backups
 				.group(OptionGroup.createBuilder()
 						.name(Text.translatable("skyblocker.config.general.backup"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -19,6 +19,8 @@ public class GeneralConfig {
 
     public boolean acceptReparty = true;
 
+	public boolean guiMiddleClick = false;
+
 	public SpeedPresets speedPresets = new SpeedPresets();
 
     public Shortcuts shortcuts = new Shortcuts();

--- a/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HandledScreenMixin.java
@@ -51,11 +51,10 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 import java.util.List;
 import java.util.Optional;
@@ -385,6 +384,19 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
 			boolean disallowed = ContainerSolverManager.onSlotClick(slotId, stack, button);
 
 			if (disallowed) ci.cancel();
+		}
+	}
+
+	@ModifyArgs(
+			method = "onMouseClick(Lnet/minecraft/screen/slot/Slot;IILnet/minecraft/screen/slot/SlotActionType;)V",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;clickSlot(IIILnet/minecraft/screen/slot/SlotActionType;Lnet/minecraft/entity/player/PlayerEntity;)V")
+	)
+	private void skyblocker$guiMiddleClick(Args args) {
+		if (!Utils.isOnSkyblock() || !SkyblockerConfigManager.get().general.guiMiddleClick) return;
+		SlotActionType action = args.get(3);
+		if (action == SlotActionType.PICKUP) {
+			args.set(2, 0); // when pressing a key the button is 0, just for consistency.
+			args.set(3, SlotActionType.CLONE);
 		}
 	}
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -344,6 +344,8 @@
 
   "skyblocker.config.general.acceptReparty": "Auto accept Reparty",
 
+  "skyblocker.config.general.guiMiddleClick": "Replace left clicks with middle clicks",
+
   "skyblocker.config.general.hitbox": "Hitboxes",
   "skyblocker.config.general.hitbox.oldFarmlandHitbox": "Enable 1.8 farmland hitbox",
   "skyblocker.config.general.hitbox.oldLeverHitbox": "Enable 1.8 lever hitbox",


### PR DESCRIPTION
hopefully this doesn't suck.
Only middle clicks if:
- Left click
- The item you are clicking doesn't contain a skyblock ID
- you don't have an item in your cursor

hopefully this isn't a terrible place to inject. Maybe wrapping a specific `onMouseClick` in `mouseClicked` could be better. I dunno