### PR TITLE
Fix Bestiary Regex

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 
 public class BestiaryLevelAdder extends SimpleSlotTextAdder {
 	//^[\w -']+ (?<level>[IVXLCDM]+)$
-	private static final Pattern BESTIARY = Pattern.compile("^[\\w -']+ (?<level>[IVXLCDM]+)$");
+	private static final Pattern BESTIARY = Pattern.compile("^[\\w '-]+ (?<level>[IVXLCDM]+)$");
 	private static final ConfigInformation CONFIG_INFORMATION = new ConfigInformation(
 			"bestiary_level",
 			"skyblocker.config.uiAndVisuals.slotText.bestiaryLevel"

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/BestiaryLevelAdder.java
@@ -16,7 +16,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class BestiaryLevelAdder extends SimpleSlotTextAdder {
-	//^[\w -']+ (?<level>[IVXLCDM]+)$
+	//^[\w '-]+ (?<level>[IVXLCDM]+)$
 	private static final Pattern BESTIARY = Pattern.compile("^[\\w '-]+ (?<level>[IVXLCDM]+)$");
 	private static final ConfigInformation CONFIG_INFORMATION = new ConfigInformation(
 			"bestiary_level",


### PR DESCRIPTION
Fixes a typo in the regex causing the - character to be treated as a metacharacter for character ranges instead of a literal character to match for
Due to how regex is formatted, a - in character selection brackets [] must be at the beginning or the end of the list of characters to match for if you want to match the literal character