### PR TITLE
Fix: Setting Tooltip error

### DIFF
--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1031,7 +1031,7 @@
   "skyblocker.config.uiAndVisuals.healthBars.halfBarColor": "Half Health Bar Color",
   "skyblocker.config.uiAndVisuals.healthBars.halfBarColor.@Tooltip": "Color of health bar when mob is at half hp",
   "skyblocker.config.uiAndVisuals.healthBars.emptyBarColor": "Empty Health Bar Color",
-  "skyblocker.config.uiAndVisuals.healthBars.emptyBarColor.@Tooltip": "Color of health bar when mob is at full hp",
+  "skyblocker.config.uiAndVisuals.healthBars.emptyBarColor.@Tooltip": "Color of health bar when mob is at zero hp.",
 
   "skyblocker.config.uiAndVisuals.bazaarQuickQuantities": "Bazaar Quick Quantities",
   "skyblocker.config.uiAndVisuals.bazaarQuickQuantities.enabled": "Enabled",


### PR DESCRIPTION
Fix copy-paste error in emptyBarColor tooltip (skyblocker.config.uiAndVisuals.healthBars.emptyBarColor.@Tooltip).
