### PR TITLE
Update config backup

### DIFF
--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -458,6 +458,7 @@
   "skyblocker.config.general.backup.manage": "Manage Backups...",
   "skyblocker.config.general.backup.title": "Config Backups",
   "skyblocker.config.general.backup.restore": "Restore",
+  "skyblocker.config.general.backup.restore.error": "Failed to restore backup",
   "skyblocker.config.general.backup.confirm.title": "Restore Backup",
   "skyblocker.config.general.backup.confirm.text": "Restore backup %s? This will overwrite your current config.",
 


### PR DESCRIPTION
Add diff indicators to the scroll bar.  
Fixed crash when pressing arrow keys on the backups list widget.  
Fixed non-existent lang entry.  
<img width="966" height="620" alt="Screenshot of config backups screen with diff indicators on the scroll bar" src="https://github.com/user-attachments/assets/186eecc1-1270-424f-b137-57171a06fbfe" />
