### PR TITLE
Fix protected item dropping in dungeon

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerEntityMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientPlayerEntityMixin.java
@@ -5,6 +5,7 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.UIAndVisualsConfig;
 import de.hysky.skyblocker.skyblock.auction.AuctionViewScreen;
 import de.hysky.skyblocker.skyblock.auction.EditBidPopup;
+import de.hysky.skyblocker.skyblock.dungeon.DungeonScore;
 import de.hysky.skyblocker.skyblock.dungeon.partyfinder.PartyFinderScreen;
 import de.hysky.skyblocker.skyblock.item.HotbarSlotLock;
 import de.hysky.skyblocker.skyblock.item.ItemProtection;
@@ -41,7 +42,7 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
     @Inject(method = "dropSelectedItem", at = @At("HEAD"), cancellable = true)
     public void skyblocker$dropSelectedItem(CallbackInfoReturnable<Boolean> cir) {
         if (Utils.isOnSkyblock() && (ItemProtection.isItemProtected(this.getMainHandStack()) || HotbarSlotLock.isLocked(this.getInventory().getSelectedSlot()))
-                && (!SkyblockerConfigManager.get().dungeons.allowDroppingProtectedItems || !Utils.isInDungeons())) {
+                && (!SkyblockerConfigManager.get().dungeons.allowDroppingProtectedItems || !DungeonScore.isDungeonStarted())) {
             cir.setReturnValue(false);
         }
     }


### PR DESCRIPTION
This fixes #1665.

BTW I'm wondering:

https://github.com/SkyblockerMod/Skyblocker/blob/d8ea7868327f2f7847ae56a46922ce0f33c13ec6/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonManager.java#L757-L759

Why are we actually triggering the event on [the second line of Mort's dialogue](https://wiki.hypixel.net/Mort#Dialogue:~:text=You%20should%20find%20it%20useful%20if%20you%20get%20lost.), not the first?
Was that intended to wait for some modules to be ready?
It doesn't matter but I just want the item dropping to be available ASAP.