### PR TITLE
add waypoint type config to ender node helper

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/OtherLocationsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/OtherLocationsCategory.java
@@ -7,6 +7,7 @@ import de.hysky.skyblocker.skyblock.end.EndHudWidget;
 import de.hysky.skyblocker.skyblock.end.TheEnd;
 import de.hysky.skyblocker.skyblock.tabhud.config.WidgetsConfigurationScreen;
 import de.hysky.skyblocker.utils.Location;
+import de.hysky.skyblocker.utils.waypoint.Waypoint;
 import net.azureaaron.dandelion.systems.ButtonOption;
 import net.azureaaron.dandelion.systems.ConfigCategory;
 import net.azureaaron.dandelion.systems.Option;
@@ -112,6 +113,14 @@ public class OtherLocationsCategory {
 										() -> config.otherLocations.end.enableEnderNodeHelper,
 										newValue -> config.otherLocations.end.enableEnderNodeHelper = newValue)
 								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Waypoint.Type>createBuilder()
+								.name(Text.translatable("skyblocker.config.otherLocations.end.enderNodeWaypointType"))
+								.description(Text.translatable("skyblocker.config.uiAndVisuals.waypoints.waypointType.@Tooltip"))
+								.binding(defaults.otherLocations.end.enderNodeWaypointType,
+										() -> config.otherLocations.end.enderNodeWaypointType,
+										newValue -> config.otherLocations.end.enderNodeWaypointType = newValue)
+								.controller(ConfigUtils.createEnumController())
 								.build())
 						.option(Option.<Boolean>createBuilder()
 								.name(Text.translatable("skyblocker.config.otherLocations.end.hudEnabled"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/OtherLocationsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/OtherLocationsConfig.java
@@ -1,5 +1,7 @@
 package de.hysky.skyblocker.config.configs;
 
+import de.hysky.skyblocker.utils.waypoint.Waypoint;
+
 public class OtherLocationsConfig {
     public Barn barn = new Barn();
 
@@ -33,6 +35,8 @@ public class OtherLocationsConfig {
 
     public static class TheEnd {
         public boolean enableEnderNodeHelper = true;
+
+		public Waypoint.Type enderNodeWaypointType = Waypoint.Type.OUTLINED_HIGHLIGHT;
 
         public boolean hudEnabled = true;
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/end/EnderNodes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/end/EnderNodes.java
@@ -125,7 +125,7 @@ public class EnderNodes {
         private long lastConfirmed;
 
         private EnderNode(BlockPos pos) {
-            super(pos, () -> SkyblockerConfigManager.get().uiAndVisuals.waypoints.waypointType, ColorUtils.getFloatComponents(DyeColor.CYAN));
+            super(pos, () -> SkyblockerConfigManager.get().otherLocations.end.enderNodeWaypointType, ColorUtils.getFloatComponents(DyeColor.CYAN));
         }
 
         private void updateWaypoint() {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -864,6 +864,7 @@
 
   "skyblocker.config.otherLocations.end": "The End",
   "skyblocker.config.otherLocations.end.enableEnderNodeHelper": "Enable Ender Node Helper",
+  "skyblocker.config.otherLocations.end.enderNodeWaypointType": "Ender Node Waypoint Type",
   "skyblocker.config.otherLocations.end.hudEnabled": "HUD Enabled",
   "skyblocker.config.otherLocations.end.muteEndermanSounds": "Mute Enderman Sounds",
   "skyblocker.config.otherLocations.end.protectorLocationEnable": "Show Protector Location",


### PR DESCRIPTION
I think it makes more sense for it to be without a beam by default and separated from the general config