### PR TITLE
Livid color line indicator

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -376,6 +376,14 @@ public class DungeonsCategory {
 								.controller(ConfigUtils.createBooleanController())
 								.build())
 						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorLineIndicator"))
+								.description(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorLineIndicator.@Tooltip"))
+								.binding(defaults.dungeons.livid.enableLividColorLineIndicator,
+										() -> config.dungeons.livid.enableLividColorLineIndicator,
+										newValue -> config.dungeons.livid.enableLividColorLineIndicator = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
 								.name(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorTitle"))
 								.description(Text.translatable("skyblocker.config.dungeons.livid.enableLividColorTitle.@Tooltip"))
 								.binding(defaults.dungeons.livid.enableLividColorTitle,

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -133,6 +133,8 @@ public class DungeonsConfig {
 
 		public boolean enableLividColorBoundingBox = true;
 
+		public boolean enableLividColorLineIndicator = true;
+
 		public boolean enableLividColorText = true;
 
 		public boolean enableLividColorTitle = true;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -158,6 +158,8 @@
   "skyblocker.config.dungeons.livid.enableLividColorGlow.@Tooltip": "Applies the glowing effect to the correct Livid in F5/M5.",
   "skyblocker.config.dungeons.livid.enableLividColorBoundingBox": "Enable Livid Color Bounding Box",
   "skyblocker.config.dungeons.livid.enableLividColorBoundingBox.@Tooltip": "Shows a bounding box on the correct Livid in F5/M5.",
+  "skyblocker.config.dungeons.livid.enableLividColorLineIndicator": "Enable Livid Color Line Indicator",
+  "skyblocker.config.dungeons.livid.enableLividColorLineIndicator.@Tooltip": "Renders a line connecting the crosshair to the correct Livid in F5/M5.",
   "skyblocker.config.dungeons.livid.enableLividColorTitle": "Enable Livid Color Title",
   "skyblocker.config.dungeons.livid.enableLividColorTitle.@Tooltip": "Display the Livid color as a title during the boss fight.",
   "skyblocker.config.dungeons.livid.enableLividColorText": "Send Livid Color in Chat",


### PR DESCRIPTION
Add an option to draw a line from cursor to the correct Livid in F5/M5. Helps bld ppl like me. 😖

<img width="1943" height="1023" alt="2025-09-22_02 52 20" src="https://github.com/user-attachments/assets/b5a9bce1-9786-43dc-b04c-0af61b28a93c" />

Also compatible with custom Livid color:

<img width="896" height="656" alt="2025-09-22_02 53 47" src="https://github.com/user-attachments/assets/52807af8-f8c8-4fac-abbd-12372d452a7d" />
