### PR TITLE
Condense Crystal Hollows WebSocket Waypoints Initial Messages

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CrystalsLocationsManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/CrystalsLocationsManager.java
@@ -343,7 +343,7 @@ public class CrystalsLocationsManager {
     }
 
 	public static void receiveInitialWaypointsFromSocket(List<CrystalsWaypointMessage> waypoints) {
-		MutableText allWaypointsReceived = Text.empty();
+		MutableText allWaypointsReceived = Text.translatable("skyblocker.webSocket.receivedCrystalsWaypoint.bulkTooltipTitle").append("\n");
 		for (CrystalsWaypointMessage waypoint : waypoints) {
 			CrystalsLocationsManager.addCustomWaypointFromSocket(waypoint.location(), waypoint.coordinates(), false);
 

--- a/src/main/java/de/hysky/skyblocker/utils/ws/message/CrystalsWaypointMessage.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ws/message/CrystalsWaypointMessage.java
@@ -25,17 +25,14 @@ public record CrystalsWaypointMessage(CrystalHollowsLocationsCategory location, 
 			case Type.RESPONSE -> {
 				CrystalsWaypointMessage waypoint = CODEC.parse(message.get()).getOrThrow();
 
-				RenderHelper.runOnRenderThread(() -> CrystalsLocationsManager.addCustomWaypointFromSocket(waypoint.location(), waypoint.coordinates()));
+				RenderHelper.runOnRenderThread(() -> CrystalsLocationsManager.addCustomWaypointFromSocket(waypoint.location(), waypoint.coordinates(), true));
 			}
 
 			case Type.INITIAL_MESSAGE -> {
 				List<CrystalsWaypointMessage> waypoints = LIST_CODEC.parse(message.get()).getOrThrow();
 
-				RenderHelper.runOnRenderThread(() -> {
-					for (CrystalsWaypointMessage waypoint : waypoints) {
-						CrystalsLocationsManager.addCustomWaypointFromSocket(waypoint.location(), waypoint.coordinates());
-					}
-				});
+				if (waypoints.isEmpty()) return;
+				RenderHelper.runOnRenderThread(() -> CrystalsLocationsManager.receiveInitialWaypointsFromSocket(waypoints));
 			}
 
 			default -> {}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1366,6 +1366,7 @@
   "skyblocker.api.token.noProfileKeys": "Failed to get your profile keys! Some features of the mod may not work temporarily :( (Has your game been open for more than 24 hours?). To reactivate these features, restart the game.",
 
   "skyblocker.webSocket.receivedCrystalsWaypoint": "Received a waypoint to %s from the Skyblocker WebSocket.",
+  "skyblocker.webSocket.receivedCrystalsWaypoint.bulk": "Received %s waypoint(s) from the Skyblocker WebSocket!",
 
   "skyblocker.exotic.crystal": "CRYSTAL",
   "skyblocker.exotic.fairy": "FAIRY",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1366,6 +1366,7 @@
   "skyblocker.api.token.noProfileKeys": "Failed to get your profile keys! Some features of the mod may not work temporarily :( (Has your game been open for more than 24 hours?). To reactivate these features, restart the game.",
 
   "skyblocker.webSocket.receivedCrystalsWaypoint": "Received a waypoint to %s from the Skyblocker WebSocket.",
+  "skyblocker.webSocket.receivedCrystalsWaypoint.bulkTooltipTitle": "Waypoints Received:",
   "skyblocker.webSocket.receivedCrystalsWaypoint.bulk": "Received %s waypoint(s) from the Skyblocker WebSocket!",
 
   "skyblocker.exotic.crystal": "CRYSTAL",


### PR DESCRIPTION
When joining a CH server, it sometimes floods the chat with a lot of messages.

This will condense it into one message - to see what locations were received, the message can be hovered.
<img width="605" height="46" alt="image" src="https://github.com/user-attachments/assets/405081f1-72a2-49b1-9ded-cd9694cdf5da" />

<img width="249" height="114" alt="image" src="https://github.com/user-attachments/assets/4eab3238-c2f8-4ce4-8cba-0d073b584e79" />

btw, is there a better way to add a new line to text other than `.append("\n")` 😭
