### PR TITLE
Fix potential crash in GardenPlotsWidget

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java
@@ -105,7 +105,13 @@ public class GardenPlotsWidget extends ContainerWidget {
 						ItemStack stack = slot.getStack();
 						if (stack.isEmpty() || stack.isOf(Items.RED_STAINED_GLASS_PANE) || stack.isOf(Items.OAK_BUTTON) || stack.isOf(Items.BLACK_STAINED_GLASS_PANE))
 							continue;
-						gardenPlots[(i / 9) * 5 + (i % 9 - 2)] = new GardenPlot(stack.getItem(), stack.getName().getString().split("-", 2)[1].trim());
+						String name = stack.getName().getString();
+						String[] parts = name.split("-", 2);
+						if (parts.length < 2) {
+							LOGGER.warn("Invalid plot name: {}", name);
+							continue;
+						}
+						gardenPlots[(i / 9) * 5 + (i % 9 - 2)] = new GardenPlot(stack.getItem(), parts[1].trim());
 					}
 
 				});


### PR DESCRIPTION
I noticed a conflict with SkyHanni's Garden Plot Icon feature causing a crash. While SkyHanni is technically at fault here, incorrectly overriding the plot stack names, I believe this fix makes sense to include regardless—it prevents a game crash in case Hypixel changes something or another similar issue occurs.