### PR TITLE
Fix Party Leader being wrong in Fancy Party Finder

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyEntry.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyEntry.java
@@ -65,7 +65,7 @@ public class PartyEntry extends ElementListWidget.Entry<PartyEntry> {
     Text lockReason = Text.empty();
 
 
-    public PartyEntry(List<Text> tooltips, PartyFinderScreen screen, int slotID) {
+    public PartyEntry(Text title, List<Text> tooltips, PartyFinderScreen screen, int slotID) {
         this.screen = screen;
         this.slotID = slotID;
 
@@ -74,7 +74,6 @@ public class PartyEntry extends ElementListWidget.Entry<PartyEntry> {
         //System.out.println(tooltips);
 
         MinecraftClient client = MinecraftClient.getInstance();
-        Text title = tooltips.getFirst();
         String partyHost = title.getString().split("'s")[0];
 
         int membersIndex = -1;
@@ -301,7 +300,7 @@ public class PartyEntry extends ElementListWidget.Entry<PartyEntry> {
     public static class NoParties extends PartyEntry {
 
         public NoParties() {
-            super(List.of(), null, -1);
+            super(Text.empty(), List.of(), null, -1);
         }
 
         @Override
@@ -320,8 +319,8 @@ public class PartyEntry extends ElementListWidget.Entry<PartyEntry> {
         public static final Text DE_LIST_TEXT = Text.translatable("skyblocker.partyFinder.deList");
         public static final Text YOUR_PARTY_TEXT = Text.translatable("skyblocker.partyFinder.yourParty");
 
-        public YourParty(List<Text> tooltips, PartyFinderScreen screen, int deListSlotId) {
-            super(tooltips, screen, deListSlotId);
+        public YourParty(Text title, List<Text> tooltips, PartyFinderScreen screen, int deListSlotId) {
+            super(title, tooltips, screen, deListSlotId);
         }
 
         @Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
@@ -18,6 +18,7 @@ import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.toast.SystemToast;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.UpdateSignC2SPacket;
 import net.minecraft.screen.GenericContainerScreenHandler;
@@ -38,217 +39,217 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public class PartyFinderScreen extends Screen {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(PartyFinderScreen.class);
-    protected static final Identifier BACKGROUND_TEXTURE = Identifier.ofVanilla("social_interactions/background");
-    protected static final Identifier SEARCH_ICON_TEXTURE = Identifier.ofVanilla("icon/search");
-    protected static final Text SEARCH_TEXT = Text.translatable("gui.socialInteractions.search_hint").formatted(Formatting.ITALIC).formatted(Formatting.GRAY);
-    public static boolean isInKuudraPartyFinder = false;
+	protected static final Logger LOGGER = LoggerFactory.getLogger(PartyFinderScreen.class);
+	protected static final Identifier BACKGROUND_TEXTURE = Identifier.ofVanilla("social_interactions/background");
+	protected static final Identifier SEARCH_ICON_TEXTURE = Identifier.ofVanilla("icon/search");
+	protected static final Text SEARCH_TEXT = Text.translatable("gui.socialInteractions.search_hint").formatted(Formatting.ITALIC).formatted(Formatting.GRAY);
+	public static boolean isInKuudraPartyFinder = false;
 
-    public static boolean DEBUG = false;
-    public static final List<String> possibleInventoryNames = List.of(
-            "party finder",
-            "search settings",
-            "select floor",
-            "select type",
-            "class level range",
-            "dungeon level range",
-            "sort"
-    );
+	public static boolean DEBUG = false;
+	public static final List<String> possibleInventoryNames = List.of(
+			"party finder",
+			"search settings",
+			"select floor",
+			"select type",
+			"class level range",
+			"dungeon level range",
+			"sort"
+	);
 
-    public GenericContainerScreenHandler getHandler() {
-        return handler;
-    }
+	public GenericContainerScreenHandler getHandler() {
+		return handler;
+	}
 
-    private Text name;
-    private GenericContainerScreenHandler handler;
-    private final PlayerInventory inventory;
-    private Page currentPage;
-    public PartyEntryListWidget partyEntryListWidget;
+	private Text name;
+	private GenericContainerScreenHandler handler;
+	private final PlayerInventory inventory;
+	private Page currentPage;
+	public PartyEntryListWidget partyEntryListWidget;
 
-    public FinderSettingsContainer getSettingsContainer() {
-        return settingsContainer;
-    }
+	public FinderSettingsContainer getSettingsContainer() {
+		return settingsContainer;
+	}
 
-    private FinderSettingsContainer settingsContainer;
+	private FinderSettingsContainer settingsContainer;
 
-    private int refreshSlotId = -1;
+	private int refreshSlotId = -1;
 
-    private TextFieldWidget searchField;
-    private ButtonWidget refreshButton;
+	private TextFieldWidget searchField;
+	private ButtonWidget refreshButton;
 
-    private ButtonWidget previousPageButton;
-    private int prevPageSlotId = -1;
+	private ButtonWidget previousPageButton;
+	private int prevPageSlotId = -1;
 
-    private ButtonWidget nextPageButton;
-    private int nextPageSlotId = -1;
+	private ButtonWidget nextPageButton;
+	private int nextPageSlotId = -1;
 
-    protected ButtonWidget partyFinderButton;
-    protected int partyButtonSlotId = -1;
+	protected ButtonWidget partyFinderButton;
+	protected int partyButtonSlotId = -1;
 
-    private ButtonWidget settingsButton;
-    private int settingsButtonSlotId = -1;
+	private ButtonWidget settingsButton;
+	private int settingsButtonSlotId = -1;
 
-    private ButtonWidget createPartyButton;
-    private int createPartyButtonSlotId = -1;
+	private ButtonWidget createPartyButton;
+	private int createPartyButtonSlotId = -1;
 
-    private boolean dirty = false;
-    private long dirtiedTime;
+	private boolean dirty = false;
+	private long dirtiedTime;
 
-    public void markDirty() {
-        if (sign != null) return;
-        dirtiedTime = System.currentTimeMillis();
-        dirty = true;
-    }
+	public void markDirty() {
+		if (sign != null) return;
+		dirtiedTime = System.currentTimeMillis();
+		dirty = true;
+	}
 
-    private boolean waitingForServer = false;
+	private boolean waitingForServer = false;
 
-    public static Map<String, PropertyMap> floorIconsNormal = null;
-    public static Map<String, PropertyMap> floorIconsMaster = null;
+	public static Map<String, PropertyMap> floorIconsNormal = null;
+	public static Map<String, PropertyMap> floorIconsMaster = null;
 
-    @Init
-    public static void initClass() {
-        ClientLifecycleEvents.CLIENT_STARTED.register(client -> {
-            //Checking when this is loaded probably isn't necessary as the maps are always null checked
-            CompletableFuture.runAsync(() -> {
-                floorIconsNormal = new HashMap<>();
-                floorIconsMaster = new HashMap<>();
-                try (BufferedReader skullTextureReader = client.getResourceManager().openAsReader(Identifier.of(SkyblockerMod.NAMESPACE, "dungeons/catacombs/floorskulls.json"))) {
-                    JsonObject json = SkyblockerMod.GSON.fromJson(skullTextureReader, JsonObject.class);
-                    json.getAsJsonObject("normal").asMap().forEach((s, tex) -> floorIconsNormal.put(s, ItemUtils.propertyMapWithTexture(tex.getAsString())));
-                    json.getAsJsonObject("master").asMap().forEach((s, tex) -> floorIconsMaster.put(s, ItemUtils.propertyMapWithTexture(tex.getAsString())));
-                    LOGGER.debug("[Skyblocker] Dungeons floor skull textures json loaded");
-                } catch (Exception e) {
-                    LOGGER.error("[Skyblocker] Failed to load dungeons floor skull textures json", e);
-                }
-            });
-        });
-    }
+	@Init
+	public static void initClass() {
+		ClientLifecycleEvents.CLIENT_STARTED.register(client -> {
+			//Checking when this is loaded probably isn't necessary as the maps are always null checked
+			CompletableFuture.runAsync(() -> {
+				floorIconsNormal = new HashMap<>();
+				floorIconsMaster = new HashMap<>();
+				try (BufferedReader skullTextureReader = client.getResourceManager().openAsReader(Identifier.of(SkyblockerMod.NAMESPACE, "dungeons/catacombs/floorskulls.json"))) {
+					JsonObject json = SkyblockerMod.GSON.fromJson(skullTextureReader, JsonObject.class);
+					json.getAsJsonObject("normal").asMap().forEach((s, tex) -> floorIconsNormal.put(s, ItemUtils.propertyMapWithTexture(tex.getAsString())));
+					json.getAsJsonObject("master").asMap().forEach((s, tex) -> floorIconsMaster.put(s, ItemUtils.propertyMapWithTexture(tex.getAsString())));
+					LOGGER.debug("[Skyblocker] Dungeons floor skull textures json loaded");
+				} catch (Exception e) {
+					LOGGER.error("[Skyblocker] Failed to load dungeons floor skull textures json", e);
+				}
+			});
+		});
+	}
 
-    public PartyFinderScreen(GenericContainerScreenHandler handler, PlayerInventory inventory, Text title) {
-        super(title);
-        this.handler = handler;
-        this.inventory = inventory;
-        name = title;
-    }
+	public PartyFinderScreen(GenericContainerScreenHandler handler, PlayerInventory inventory, Text title) {
+		super(title);
+		this.handler = handler;
+		this.inventory = inventory;
+		name = title;
+	}
 
-    @Override
-    protected void init() {
-        super.init();
-        int topRowButtonsHeight = 20;
+	@Override
+	protected void init() {
+		super.init();
+		int topRowButtonsHeight = 20;
 
-        // Entry list widget, pretty much every position is based on this guy since it centers automagically
-        int widget_height = (int) (this.height * 0.8);
-        int entryListTopY = Math.max(43, (int) (height * 0.1));
-        this.partyEntryListWidget = new PartyEntryListWidget(client, width, widget_height, entryListTopY, 68);
+		// Entry list widget, pretty much every position is based on this guy since it centers automagically
+		int widget_height = (int) (this.height * 0.8);
+		int entryListTopY = Math.max(43, (int) (height * 0.1));
+		this.partyEntryListWidget = new PartyEntryListWidget(client, width, widget_height, entryListTopY, 68);
 
-        // Search field
-        this.searchField = new TextFieldWidget(textRenderer, partyEntryListWidget.getRowLeft() + 12, entryListTopY - 12, partyEntryListWidget.getRowWidth() - 12 * 3 - 6, 12, Text.literal("Search..."));
-        searchField.setPlaceholder(SEARCH_TEXT);
-        searchField.setChangedListener(s -> partyEntryListWidget.setSearch(s));
-        // Refresh button
-        refreshButton = ButtonWidget.builder(Text.literal("⟳").setStyle(Style.EMPTY.withColor(Formatting.GREEN)), (a) -> {
-                    if (refreshSlotId != -1) {
-                        clickAndWaitForServer(refreshSlotId);
-                    }
-                })
-                .position(searchField.getX() + searchField.getWidth() + 12 * 2, searchField.getY())
-                .size(12, 12).build();
-        refreshButton.active = false;
+		// Search field
+		this.searchField = new TextFieldWidget(textRenderer, partyEntryListWidget.getRowLeft() + 12, entryListTopY - 12, partyEntryListWidget.getRowWidth() - 12 * 3 - 6, 12, Text.literal("Search..."));
+		searchField.setPlaceholder(SEARCH_TEXT);
+		searchField.setChangedListener(s -> partyEntryListWidget.setSearch(s));
+		// Refresh button
+		refreshButton = ButtonWidget.builder(Text.literal("⟳").setStyle(Style.EMPTY.withColor(Formatting.GREEN)), (a) -> {
+					if (refreshSlotId != -1) {
+						clickAndWaitForServer(refreshSlotId);
+					}
+				})
+				.position(searchField.getX() + searchField.getWidth() + 12 * 2, searchField.getY())
+				.size(12, 12).build();
+		refreshButton.active = false;
 
-        // Prev and next page buttons
-        previousPageButton = ButtonWidget.builder(Text.literal("←"), (a) -> {
-                    if (prevPageSlotId != -1) {
-                        clickAndWaitForServer(prevPageSlotId);
-                    }
-                })
-                .position(searchField.getX() + searchField.getWidth(), searchField.getY())
-                .size(12, 12).build();
-        previousPageButton.active = false;
-        nextPageButton = ButtonWidget.builder(Text.literal("→"), (a) -> {
-                    if (nextPageSlotId != -1) {
-                        clickAndWaitForServer(nextPageSlotId);
-                    }
-                })
-                .position(searchField.getX() + searchField.getWidth() + 12, searchField.getY())
-                .size(12, 12).build();
-        nextPageButton.active = false;
+		// Prev and next page buttons
+		previousPageButton = ButtonWidget.builder(Text.literal("←"), (a) -> {
+					if (prevPageSlotId != -1) {
+						clickAndWaitForServer(prevPageSlotId);
+					}
+				})
+				.position(searchField.getX() + searchField.getWidth(), searchField.getY())
+				.size(12, 12).build();
+		previousPageButton.active = false;
+		nextPageButton = ButtonWidget.builder(Text.literal("→"), (a) -> {
+					if (nextPageSlotId != -1) {
+						clickAndWaitForServer(nextPageSlotId);
+					}
+				})
+				.position(searchField.getX() + searchField.getWidth() + 12, searchField.getY())
+				.size(12, 12).build();
+		nextPageButton.active = false;
 
-        // Settings container
-        if (this.settingsContainer == null) this.settingsContainer = new FinderSettingsContainer(partyEntryListWidget.getRowLeft(), entryListTopY - 12, widget_height + 12);
-        else settingsContainer.setDimensionsAndPosition(partyEntryListWidget.getRowWidth() - 2, widget_height + 12, partyEntryListWidget.getRowLeft(), entryListTopY - 12);
-
-
-        // Buttons at the top
-        int searchButtonMargin = 2;
-        int searchButtonWidth = (partyEntryListWidget.getRowWidth() + 6) / 3 - 2 * searchButtonMargin;
+		// Settings container
+		if (this.settingsContainer == null) this.settingsContainer = new FinderSettingsContainer(partyEntryListWidget.getRowLeft(), entryListTopY - 12, widget_height + 12);
+		else settingsContainer.setDimensionsAndPosition(partyEntryListWidget.getRowWidth() - 2, widget_height + 12, partyEntryListWidget.getRowLeft(), entryListTopY - 12);
 
 
-        partyFinderButton = ButtonWidget.builder(Text.translatable("skyblocker.partyFinder.tabs.partyFinder"), (a) -> {
-                    if (partyButtonSlotId != -1) {
-                        setCurrentPage(Page.FINDER);
-                        clickAndWaitForServer(partyButtonSlotId);
-                    }
-                })
-                .position(partyEntryListWidget.getRowLeft(), entryListTopY - 39)
-                .size(searchButtonWidth + searchButtonMargin, topRowButtonsHeight).build();
-
-        settingsButton = ButtonWidget.builder(Text.translatable("skyblocker.partyFinder.tabs.searchSettings"), (a) -> {
-                    if (settingsButtonSlotId != -1) {
-                        setCurrentPage(Page.SETTINGS);
-                        clickAndWaitForServer(settingsButtonSlotId);
-                    }
-                })
-                .position(partyEntryListWidget.getRowLeft() + searchButtonWidth + 3 * searchButtonMargin, entryListTopY - 39)
-                .size(searchButtonWidth, topRowButtonsHeight).build();
-
-        createPartyButton = ButtonWidget.builder(Text.translatable("skyblocker.partyFinder.tabs.createParty"), (a) -> {
-                    if (createPartyButtonSlotId != -1) {
-                        clickAndWaitForServer(createPartyButtonSlotId);
-                    }
-                })
-                .position(partyEntryListWidget.getRowLeft() + searchButtonWidth * 2 + 5 * searchButtonMargin, entryListTopY - 39)
-                .size(searchButtonWidth, topRowButtonsHeight).build();
-        createPartyButton.active = false;
+		// Buttons at the top
+		int searchButtonMargin = 2;
+		int searchButtonWidth = (partyEntryListWidget.getRowWidth() + 6) / 3 - 2 * searchButtonMargin;
 
 
-        addDrawableChild(partyEntryListWidget);
-        addDrawableChild(searchField);
-        addDrawableChild(refreshButton);
-        addDrawableChild(previousPageButton);
-        addDrawableChild(nextPageButton);
-        addDrawableChild(partyFinderButton);
-        addDrawableChild(settingsButton);
-        addDrawableChild(createPartyButton);
-        addDrawableChild(settingsContainer);
+		partyFinderButton = ButtonWidget.builder(Text.translatable("skyblocker.partyFinder.tabs.partyFinder"), (a) -> {
+					if (partyButtonSlotId != -1) {
+						setCurrentPage(Page.FINDER);
+						clickAndWaitForServer(partyButtonSlotId);
+					}
+				})
+				.position(partyEntryListWidget.getRowLeft(), entryListTopY - 39)
+				.size(searchButtonWidth + searchButtonMargin, topRowButtonsHeight).build();
+
+		settingsButton = ButtonWidget.builder(Text.translatable("skyblocker.partyFinder.tabs.searchSettings"), (a) -> {
+					if (settingsButtonSlotId != -1) {
+						setCurrentPage(Page.SETTINGS);
+						clickAndWaitForServer(settingsButtonSlotId);
+					}
+				})
+				.position(partyEntryListWidget.getRowLeft() + searchButtonWidth + 3 * searchButtonMargin, entryListTopY - 39)
+				.size(searchButtonWidth, topRowButtonsHeight).build();
+
+		createPartyButton = ButtonWidget.builder(Text.translatable("skyblocker.partyFinder.tabs.createParty"), (a) -> {
+					if (createPartyButtonSlotId != -1) {
+						clickAndWaitForServer(createPartyButtonSlotId);
+					}
+				})
+				.position(partyEntryListWidget.getRowLeft() + searchButtonWidth * 2 + 5 * searchButtonMargin, entryListTopY - 39)
+				.size(searchButtonWidth, topRowButtonsHeight).build();
+		createPartyButton.active = false;
+
+
+		addDrawableChild(partyEntryListWidget);
+		addDrawableChild(searchField);
+		addDrawableChild(refreshButton);
+		addDrawableChild(previousPageButton);
+		addDrawableChild(nextPageButton);
+		addDrawableChild(partyFinderButton);
+		addDrawableChild(settingsButton);
+		addDrawableChild(createPartyButton);
+		addDrawableChild(settingsContainer);
 		if (Debug.debugEnabled()) {
 			addDrawableChild(ButtonWidget.builder(Text.of("DEBUG"), (a) -> DEBUG = !DEBUG).dimensions(width - 40, 0, 40, 20).build());
 		}
 
-        dirtiedTime = System.currentTimeMillis();
+		dirtiedTime = System.currentTimeMillis();
 
 
-        // Used when resizing
-        setCurrentPage(currentPage);
+		// Used when resizing
+		setCurrentPage(currentPage);
 
-        if (currentPage != Page.SIGN) update();
-    }
+		if (currentPage != Page.SIGN) update();
+	}
 
-    @Override
-    public boolean shouldPause() {
-        return false;
-    }
+	@Override
+	public boolean shouldPause() {
+		return false;
+	}
 
-    @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+	@Override
+	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
 		if (!settingsContainer.canInteract(null)) {
 			context.fill(0, 0, width, height, 0x40000000);
 		}
-        super.render(context, mouseX, mouseY, delta);
+		super.render(context, mouseX, mouseY, delta);
 
-        if (searchField.visible) {
-            context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SEARCH_ICON_TEXTURE, partyEntryListWidget.getRowLeft() + 1, searchField.getY() + 1, 10, 10);
-        }
-        if (DEBUG) {
+		if (searchField.visible) {
+			context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SEARCH_ICON_TEXTURE, partyEntryListWidget.getRowLeft() + 1, searchField.getY() + 1, 10, 10);
+		}
+		if (DEBUG) {
 			context.drawText(textRenderer, currentPage.toString(), 0, 0, Colors.WHITE, true);
 			context.drawText(textRenderer, "Truly a party finder", 20, 20, Colors.WHITE, true);
 			if (sign != null) {
@@ -261,210 +262,218 @@ public class PartyFinderScreen extends Screen {
 					context.drawItem(handler.slots.get(i).getStack(), (i % 9) * 16, (i / 9) * 16);
 				}
 			}
-        }
-        if (isWaitingForServer()) {
-            String s = "Waiting for server...";
-            context.drawText(textRenderer, s, this.width - textRenderer.getWidth(s) - 5, this.height - textRenderer.fontHeight - 2, Colors.WHITE, true);
-        }
-    }
+		}
+		if (isWaitingForServer()) {
+			String s = "Waiting for server...";
+			context.drawText(textRenderer, s, this.width - textRenderer.getWidth(s) - 5, this.height - textRenderer.fontHeight - 2, Colors.WHITE, true);
+		}
+	}
 
-    @Override
-    public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
+	@Override
+	public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
 		this.renderInGameBackground(context);
-        int i = partyEntryListWidget.getRowWidth() + 16 + 6;
-        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, BACKGROUND_TEXTURE, partyEntryListWidget.getRowLeft() - 8, partyEntryListWidget.getY() - 12 - 8, i, partyEntryListWidget.getBottom() - partyEntryListWidget.getY() + 16 + 12);
-    }
+		int i = partyEntryListWidget.getRowWidth() + 16 + 6;
+		context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, BACKGROUND_TEXTURE, partyEntryListWidget.getRowLeft() - 8, partyEntryListWidget.getY() - 12 - 8, i, partyEntryListWidget.getBottom() - partyEntryListWidget.getY() + 16 + 12);
+	}
 
-    @Override
-    public void close() {
-        assert this.client != null;
-        assert this.client.player != null;
-        if (currentPage != Page.SIGN)
-            this.client.player.closeHandledScreen();
-        else {
-            ClientPlayNetworkHandler networkHandler = this.client.getNetworkHandler();
-            if (networkHandler != null && sign != null) {
-                List<String> originalText = Arrays.stream(sign.getText(signFront).getMessages(true)).map(Text::getString).toList();
-                networkHandler.sendPacket(new UpdateSignC2SPacket(sign.getPos(), signFront, originalText.getFirst(), originalText.get(1), originalText.get(2), originalText.get(3)));
-            }
-        }
-        super.close();
-    }
+	@Override
+	public void close() {
+		assert this.client != null;
+		assert this.client.player != null;
+		if (currentPage != Page.SIGN)
+			this.client.player.closeHandledScreen();
+		else {
+			ClientPlayNetworkHandler networkHandler = this.client.getNetworkHandler();
+			if (networkHandler != null && sign != null) {
+				List<String> originalText = Arrays.stream(sign.getText(signFront).getMessages(true)).map(Text::getString).toList();
+				networkHandler.sendPacket(new UpdateSignC2SPacket(sign.getPos(), signFront, originalText.getFirst(), originalText.get(1), originalText.get(2), originalText.get(3)));
+			}
+		}
+		super.close();
+	}
 
-    public void setCurrentPage(Page page) {
-        this.currentPage = page;
-        if (page == Page.FINDER) {
-            partyEntryListWidget.visible = true;
+	public void setCurrentPage(Page page) {
+		this.currentPage = page;
+		if (page == Page.FINDER) {
+			partyEntryListWidget.visible = true;
 
-            partyFinderButton.active = false;
-            partyFinderButton.setMessage(partyFinderButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(true)));
-            settingsButton.active = true;
-            settingsButton.setMessage(settingsButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(false)));
-            createPartyButton.active = true;
+			partyFinderButton.active = false;
+			partyFinderButton.setMessage(partyFinderButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(true)));
+			settingsButton.active = true;
+			settingsButton.setMessage(settingsButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(false)));
+			createPartyButton.active = true;
 
-            searchField.active = true;
-            searchField.visible = true;
-            settingsContainer.setVisible(false);
-            refreshButton.visible = true;
-            previousPageButton.visible = true;
-            nextPageButton.visible = true;
-        } else if (page == Page.SETTINGS || page == Page.SIGN) {
-            partyEntryListWidget.visible = false;
+			searchField.active = true;
+			searchField.visible = true;
+			settingsContainer.setVisible(false);
+			refreshButton.visible = true;
+			previousPageButton.visible = true;
+			nextPageButton.visible = true;
+		} else if (page == Page.SETTINGS || page == Page.SIGN) {
+			partyEntryListWidget.visible = false;
 
-            partyFinderButton.active = page != Page.SIGN;
-            partyFinderButton.setMessage(partyFinderButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(false)));
-            settingsButton.active = false;
-            settingsButton.setMessage(settingsButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(true)));
-            createPartyButton.active = false;
+			partyFinderButton.active = page != Page.SIGN;
+			partyFinderButton.setMessage(partyFinderButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(false)));
+			settingsButton.active = false;
+			settingsButton.setMessage(settingsButton.getMessage().copy().setStyle(Style.EMPTY.withUnderline(true)));
+			createPartyButton.active = false;
 
-            searchField.active = false;
-            searchField.visible = false;
-            settingsContainer.setVisible(true);
-            refreshButton.visible = false;
-            previousPageButton.visible = false;
-            nextPageButton.visible = false;
-        }
-    }
+			searchField.active = false;
+			searchField.visible = false;
+			settingsContainer.setVisible(true);
+			refreshButton.visible = false;
+			previousPageButton.visible = false;
+			nextPageButton.visible = false;
+		}
+	}
 
-    // Called when the handler object/title gets changed
-    public void updateHandler(GenericContainerScreenHandler handler, Text name) {
-        this.handler = handler;
-        this.name = name;
+	// Called when the handler object/title gets changed
+	public void updateHandler(GenericContainerScreenHandler handler, Text name) {
+		this.handler = handler;
+		this.name = name;
 		closedSign();
-        markDirty();
-    }
+		markDirty();
+	}
 
-    public boolean isSignFront() {
-        return signFront;
-    }
+	public boolean isSignFront() {
+		return signFront;
+	}
 
-    public @Nullable SignBlockEntity getSign() {
-        return sign;
-    }
+	public @Nullable SignBlockEntity getSign() {
+		return sign;
+	}
 
-    private boolean signFront = true;
-    private @Nullable SignBlockEntity sign = null;
+	private boolean signFront = true;
+	private @Nullable SignBlockEntity sign = null;
 
-    public void updateSign(SignBlockEntity sign, boolean front) {
-        setCurrentPage(Page.SIGN);
-        signFront = front;
-        this.sign = sign;
-        waitingForServer = false;
-        if (!settingsContainer.handleSign(sign, front)) abort();
-    }
+	public void updateSign(SignBlockEntity sign, boolean front) {
+		setCurrentPage(Page.SIGN);
+		signFront = front;
+		this.sign = sign;
+		waitingForServer = false;
+		if (!settingsContainer.handleSign(sign, front)) abort();
+	}
 
 	public void closedSign() {
 		this.sign = null;
 	}
 
-    public void update() {
-        dirty = false;
-        waitingForServer = false;
-        String titleText = name.getString();
-        if (titleText.contains("Party Finder")) {
-            updatePartyFinderPage();
-        } else {
-            if (currentPage != Page.SETTINGS) setCurrentPage(Page.SETTINGS);
-            if (!this.settingsContainer.handle(this, titleText)) {
-                abort();
-            }
-        }
+	public void update() {
+		dirty = false;
+		waitingForServer = false;
+		String titleText = name.getString();
+		if (titleText.contains("Party Finder")) {
+			updatePartyFinderPage();
+		} else {
+			if (currentPage != Page.SETTINGS) setCurrentPage(Page.SETTINGS);
+			if (!this.settingsContainer.handle(this, titleText)) {
+				abort();
+			}
+		}
+	}
 
-    }
+	private void updatePartyFinderPage() {
+		previousPageButton.active = false;
+		nextPageButton.active = false;
+		List<PartyEntry> parties = new ArrayList<>();
+		ItemStack yourPartyStack = null;
 
-    private void updatePartyFinderPage() {
-        previousPageButton.active = false;
-        nextPageButton.active = false;
-        List<PartyEntry> parties = new ArrayList<>();
-        if (currentPage != Page.FINDER) setCurrentPage(Page.FINDER);
-        if (handler.slots.stream().anyMatch(slot -> slot.hasStack() && slot.getStack().isOf(Items.BEDROCK))) {
-            parties.add(new PartyEntry.NoParties());
-        } else {
-            for (Slot slot : handler.slots) {
-                if (slot.id > (handler.getRows() - 1) * 9 - 1 || !slot.hasStack()) continue;
-                if (slot.getStack().isOf(Items.PLAYER_HEAD)) {
-                    assert this.client != null;
-                    parties.add(new PartyEntry(ItemUtils.getLore(slot.getStack()), this, slot.id));
-                } else if (slot.getStack().isOf(Items.ARROW) && slot.getStack().getName().getString().toLowerCase(Locale.ENGLISH).contains("previous")) {
-                    prevPageSlotId = slot.id;
-                    previousPageButton.active = true;
-                } else if (slot.getStack().isOf(Items.ARROW) && slot.getStack().getName().getString().toLowerCase(Locale.ENGLISH).contains("next")) {
-                    nextPageSlotId = slot.id;
-                    nextPageButton.active = true;
-                }
-            }
-        }
-        int deListSlotId = -1;
-        List<Text> tooltips = null;
-        for (int i = (handler.getRows() - 1) * 9; i < handler.getRows() * 9; i++) {
-            Slot slot = handler.slots.get(i);
-            if (!slot.hasStack()) continue;
-            if (slot.getStack().isOf(Items.EMERALD_BLOCK)) {
-                refreshSlotId = slot.id;
-                refreshButton.active = true;
-            } else if (slot.getStack().isOf(Items.REDSTONE_BLOCK)) {
-                createPartyButtonSlotId = slot.id;
-                createPartyButton.active = true;
-            } else if (slot.getStack().isOf(Items.NETHER_STAR)) {
-                settingsButtonSlotId = slot.id;
-                if (DEBUG)
-                    settingsButton.setMessage(settingsButton.getMessage().copy().append(Text.of(" " + settingsButtonSlotId)));
-            } else if (slot.getStack().isOf(Items.BOOKSHELF)) {
-                deListSlotId = slot.id;
-            } else if (slot.getStack().isOf(Items.PLAYER_HEAD)) {
-                assert this.client != null;
-                tooltips = new ArrayList<>(ItemUtils.getLore(slot.getStack()));
-            }
-        }
-        if (tooltips != null) {
-            //LOGGER.info("Your Party tooltips");
-            //tooltips.forEach(text -> LOGGER.info(text.toString()));
-            if (deListSlotId != -1) {
-                // Such a wacky thing lol
-                tooltips.set(0, Text.literal(MinecraftClient.getInstance().getSession().getUsername() + "'s party"));
-            }
-            parties.add(new PartyEntry.YourParty(tooltips, this, deListSlotId));
-        }
-        this.partyEntryListWidget.setEntries(parties);
-        //List<ItemStack> temp = handler.slots.stream().map(Slot::getStack).toList();//for (int i = 0; i < temp.size(); i++) System.out.println(i + " " + temp.get(i).toString() + " " + temp.get(i).getName().getString());
+		if (currentPage != Page.FINDER) setCurrentPage(Page.FINDER);
+		if (handler.slots.stream().anyMatch(slot -> slot.hasStack() && slot.getStack().isOf(Items.BEDROCK))) {
+			parties.add(new PartyEntry.NoParties());
+		} else {
+			for (Slot slot : handler.slots) {
+				if (slot.id > (handler.getRows() - 1) * 9 - 1 || !slot.hasStack()) continue;
+				ItemStack stack = slot.getStack();
+				if (stack.isOf(Items.PLAYER_HEAD)) {
+					assert this.client != null && this.client.player != null;
+					// sometimes, it shows your party in the search before it does in the bottom right, but it'll show the delist button??
+					if (stack.getName().getString().startsWith(client.player.getName().getString())) {
+						yourPartyStack = stack;
+						continue;
+					}
+					parties.add(new PartyEntry(stack.getName(), ItemUtils.getLore(stack), this, slot.id));
+				} else if (stack.isOf(Items.ARROW) && stack.getName().getString().toLowerCase(Locale.ENGLISH).contains("previous")) {
+					prevPageSlotId = slot.id;
+					previousPageButton.active = true;
+				} else if (stack.isOf(Items.ARROW) && stack.getName().getString().toLowerCase(Locale.ENGLISH).contains("next")) {
+					nextPageSlotId = slot.id;
+					nextPageButton.active = true;
+				}
+			}
+		}
 
-    }
+		int deListSlotId = -1;
+		for (int i = (handler.getRows() - 1) * 9; i < handler.getRows() * 9; i++) {
+			Slot slot = handler.slots.get(i);
+			if (!slot.hasStack()) continue;
+			if (slot.getStack().isOf(Items.EMERALD_BLOCK)) {
+				refreshSlotId = slot.id;
+				refreshButton.active = true;
+			} else if (slot.getStack().isOf(Items.REDSTONE_BLOCK)) {
+				createPartyButtonSlotId = slot.id;
+				createPartyButton.active = true;
+			} else if (slot.getStack().isOf(Items.NETHER_STAR)) {
+				settingsButtonSlotId = slot.id;
+				if (DEBUG)
+					settingsButton.setMessage(settingsButton.getMessage().copy().append(Text.of(" " + settingsButtonSlotId)));
+			} else if (slot.getStack().isOf(Items.BOOKSHELF)) {
+				deListSlotId = slot.id;
+			} else if (slot.getStack().isOf(Items.PLAYER_HEAD)) {
+				assert this.client != null;
+				yourPartyStack = slot.getStack();
+			}
+		}
 
-    private boolean aborted = false;
+		if (yourPartyStack != null) {
+			//LOGGER.info("Your Party tooltips");
+			//tooltips.forEach(text -> LOGGER.info(text.toString()));
+			Text title = yourPartyStack.getName();
+			if (deListSlotId != -1) {
+				// Such a wacky thing lol
+				title = Text.literal(MinecraftClient.getInstance().getSession().getUsername() + "'s party");
+			}
+			parties.add(new PartyEntry.YourParty(title, ItemUtils.getLore(yourPartyStack), this, deListSlotId));
+		}
+		this.partyEntryListWidget.setEntries(parties);
+		//List<ItemStack> temp = handler.slots.stream().map(Slot::getStack).toList();//for (int i = 0; i < temp.size(); i++) System.out.println(i + " " + temp.get(i).toString() + " " + temp.get(i).getName().getString());
+	}
 
-    public boolean isAborted() {
-        return aborted;
-    }
+	private boolean aborted = false;
 
-    public void abort() {
-        assert this.client != null;
-        if (currentPage == Page.SIGN) {
-            assert this.client.player != null;
-            this.client.player.openEditSignScreen(sign, signFront);
-        } else this.client.setScreen(new GenericContainerScreen(handler, inventory, title));
-        this.client.getToastManager().add(new SystemToast(SystemToast.Type.PERIODIC_NOTIFICATION, Text.translatable("skyblocker.partyFinder.error.name"), Text.translatable("skyblocker.partyFinder.error.message")));
-        aborted = true;
-    }
+	public boolean isAborted() {
+		return aborted;
+	}
 
-    @Override
-    public void removed() {
-        assert this.client != null;
-        if (this.client.player == null || aborted || currentPage == Page.SIGN) {
-            return;
-        }
-        this.handler.onClosed(this.client.player);
-    }
+	public void abort() {
+		assert this.client != null;
+		if (currentPage == Page.SIGN) {
+			assert this.client.player != null;
+			this.client.player.openEditSignScreen(sign, signFront);
+		} else this.client.setScreen(new GenericContainerScreen(handler, inventory, title));
+		this.client.getToastManager().add(new SystemToast(SystemToast.Type.PERIODIC_NOTIFICATION, Text.translatable("skyblocker.partyFinder.error.name"), Text.translatable("skyblocker.partyFinder.error.message")));
+		aborted = true;
+	}
 
-    @Override
-    public final void tick() {
-        super.tick();
-        // Slight delay to make sure all slots are received, because they are most of the time sent one at a time
-        if (dirty && System.currentTimeMillis() - dirtiedTime > 60) update();
-        assert this.client != null && this.client.player != null;
-        if (!this.client.player.isAlive() || this.client.player.isRemoved() && currentPage != Page.SIGN) {
-            this.client.player.closeHandledScreen();
-        }
-    }
+	@Override
+	public void removed() {
+		assert this.client != null;
+		if (this.client.player == null || aborted || currentPage == Page.SIGN) {
+			return;
+		}
+		this.handler.onClosed(this.client.player);
+	}
+
+	@Override
+	public final void tick() {
+		super.tick();
+		// Slight delay to make sure all slots are received, because they are most of the time sent one at a time
+		if (dirty && System.currentTimeMillis() - dirtiedTime > 60) update();
+		assert this.client != null && this.client.player != null;
+		if (!this.client.player.isAlive() || this.client.player.isRemoved() && currentPage != Page.SIGN) {
+			this.client.player.closeHandledScreen();
+		}
+	}
 
 	@Override
 	public boolean mouseClicked(double mouseX, double mouseY, int button) {
@@ -475,25 +484,25 @@ public class PartyFinderScreen extends Screen {
 	}
 
 	public void clickAndWaitForServer(int slotID) {
-        //System.out.println("hey");
-        assert client != null;
-        assert client.interactionManager != null;
-        client.interactionManager.clickSlot(handler.syncId, slotID, 0, SlotActionType.PICKUP, client.player);
-        waitingForServer = true;
-    }
+		//System.out.println("hey");
+		assert client != null;
+		assert client.interactionManager != null;
+		client.interactionManager.clickSlot(handler.syncId, slotID, 0, SlotActionType.PICKUP, client.player);
+		waitingForServer = true;
+	}
 
-    public boolean isWaitingForServer() {
-        return waitingForServer;
-    }
+	public boolean isWaitingForServer() {
+		return waitingForServer;
+	}
 
-    public @NotNull MinecraftClient getClient() {
-        assert this.client != null;
-        return this.client;
-    }
+	public @NotNull MinecraftClient getClient() {
+		assert this.client != null;
+		return this.client;
+	}
 
-    public enum Page {
-        FINDER,
-        SETTINGS,
-        SIGN
-    }
+	public enum Page {
+		FINDER,
+		SETTINGS,
+		SIGN
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
@@ -435,8 +435,6 @@ public class PartyFinderScreen extends Screen {
 		}
 
 		if (yourPartyStack != null) {
-			//LOGGER.info("Your Party tooltips");
-			//tooltips.forEach(text -> LOGGER.info(text.toString()));
 			Text title = yourPartyStack.getName();
 			if (deListSlotId != -1) {
 				// Such a wacky thing lol
@@ -448,7 +446,6 @@ public class PartyFinderScreen extends Screen {
 			parties.add(new PartyEntry.YourParty(title, ItemUtils.getLore(yourPartyStack), this, deListSlotId));
 		}
 		this.partyEntryListWidget.setEntries(parties);
-		//List<ItemStack> temp = handler.slots.stream().map(Slot::getStack).toList();//for (int i = 0; i < temp.size(); i++) System.out.println(i + " " + temp.get(i).toString() + " " + temp.get(i).getName().getString());
 	}
 
 	private boolean aborted = false;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
@@ -385,7 +385,7 @@ public class PartyFinderScreen extends Screen {
 				if (slot.id > (handler.getRows() - 1) * 9 - 1 || !slot.hasStack()) continue;
 				ItemStack stack = slot.getStack();
 				if (stack.isOf(Items.PLAYER_HEAD)) {
-					assert this.client != null && this.client.player != null;
+					assert this.client != null;
 					parties.add(new PartyEntry(stack.getName(), ItemUtils.getLore(stack), this, slot.id));
 				} else if (stack.isOf(Items.ARROW) && stack.getName().getString().toLowerCase(Locale.ENGLISH).contains("previous")) {
 					prevPageSlotId = slot.id;


### PR DESCRIPTION
Fixes the party leader not being detected from the item, resulting in a random player showing up as party leader.

Also, fixes your party showing up twice and sometimes not being delistable.