### PR TITLE
Update WaterboardOneFlow.java

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/waterboard/WaterboardOneFlow.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/waterboard/WaterboardOneFlow.java
@@ -451,12 +451,12 @@ public class WaterboardOneFlow extends DungeonPuzzle {
 				if (nextLever != null) {
 					RenderHelper.renderLineFromCursor(context,
 							room.relativeToActual(nextLever.leverPos).toCenterPos(),
-							ColorUtils.getFloatComponents(DyeColor.LIME), 1f, 2f);
+							ColorUtils.getFloatComponents(DyeColor.LIME), 1f, 4f);
 					if (nextNextLever != null) {
 						RenderHelper.renderLinesFromPoints(context, new Vec3d[]{
 								room.relativeToActual(nextLever.leverPos).toCenterPos(),
 								room.relativeToActual(nextNextLever.leverPos).toCenterPos()
-						}, ColorUtils.getFloatComponents(DyeColor.WHITE), 0.5f, 1f, true);
+						}, ColorUtils.getFloatComponents(DyeColor.WHITE), 1f, 2f, true);
 					}
 				}
 


### PR DESCRIPTION
Increase this value to make it closer to the width of most lines in vanilla and mod, such as mob highlight, livid indicator and **high contrast block outline**. The width should not be lower than vanilla block outline, at least I think so...

Before:
<img width="835" height="444" alt="before" src="https://github.com/user-attachments/assets/4f5d8e55-6ba4-485c-82e1-a1074852c231" />

After:
<img width="1920" height="1080" alt="wb1" src="https://github.com/user-attachments/assets/a0157407-e47e-4ae0-a14e-28ca9ad9c377" />
<img width="1920" height="1081" alt="wb2" src="https://github.com/user-attachments/assets/348a860d-85ee-460c-96df-f4dc582a2a49" />


