### PR TITLE
Makes progress components two decimals

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/component/ProgressComponent.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/component/ProgressComponent.java
@@ -65,7 +65,8 @@ class ProgressComponent extends Component {
 	 * @see Components#progressComponent(ItemStack, Text, float)
 	 */
 	ProgressComponent(@Nullable ItemStack ico, @Nullable Text description, float percent, int color) {
-		this(ico, description, Text.of(percent + "%"), percent, color);
+		// make sure percentages always have two decimals
+		this(ico, description, Text.of(String.format("%.2f%%", percent)), percent, color);
 	}
 
 	/**


### PR DESCRIPTION
Format percentages in progress components to two decimals. This keeps the width of the text the same.

I used the farminghud as an example.

Before:
<img width="359" height="85" alt="Screenshot 2025-10-07 121206" src="https://github.com/user-attachments/assets/32405dfa-966c-467d-a802-0f9f12d20bf9" />

After:
<img width="222" height="72" alt="fixedfarminglevel" src="https://github.com/user-attachments/assets/acad4d60-7f58-417d-a05c-43bb734a8750" />
