### PR TITLE
Fix ModernUI compatibility

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/ModernUICompatibility.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/ModernUICompatibility.java
@@ -1,0 +1,95 @@
+package de.hysky.skyblocker.compatibility;
+
+import com.mojang.logging.LogUtils;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.text.OrderedText;
+import net.minecraft.text.Text;
+import org.joml.Matrix3x2fStack;
+import org.slf4j.Logger;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class ModernUICompatibility {
+	private static final Logger LOGGER = LogUtils.getLogger();
+	public static final boolean MODERNUI_ENABLED = FabricLoader.getInstance().isModLoaded("modernui");
+
+	private static boolean isTextEngineEnabled() {
+		if (!MODERNUI_ENABLED) return false;
+		MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+		Class<?> clazz;
+		try {
+			clazz = Class.forName("icyllis.modernui.mc.ModernUIMod");
+		} catch (ClassNotFoundException e) {
+			LOGGER.error("[Skyblocker ModernUI Compat] Could not find icyllis.modernui.mc.ModernUIMod", e);
+			return true;
+		}
+		try {
+			MethodHandle methodHandle = lookup.findStatic(
+					clazz,
+					"isTextEngineEnabled",
+					MethodType.methodType(boolean.class));
+			return Boolean.TRUE.equals(methodHandle.invoke());
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			LOGGER.error("[Skyblocker ModernUI Compat] Could not find isTextEngineEnabled method", e);
+			return true;
+		} catch (Throwable e) {
+			LOGGER.error("[Skyblocker ModernUI Compat] Could not invoke isTextEngineEnabled", e);
+			return true;
+		}
+	}
+
+	// text engine changes require game reboot so it's good enough to check only once
+	private static final boolean IS_TEXT_ENGINE_ENABLED = isTextEngineEnabled();
+
+	public static boolean drawOutlinedText(DrawContext context, Text text, int x, int y, int color, int outlineColor) {
+		if (!IS_TEXT_ENGINE_ENABLED) return false;
+
+		final float offset = 0.5f; // default value of ModernTextRenderer.sOutlineOffset
+
+		TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
+		OrderedText outlineText = Text.literal(text.getString()).asOrderedText(); // make a copy with no styles
+		Matrix3x2fStack pose = context.getMatrices();
+
+		// https://github.com/BloCamLimb/ModernUI-MC/blob/3.12.0.4/common/src/main/java/icyllis/modernui/mc/text/mixin/MixinContextualBar.java
+		pose.pushMatrix()
+				.translate(offset, 0);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+		pose.pushMatrix()
+				.translate(offset, offset);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+		pose.pushMatrix()
+				.translate(offset, -offset);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+		pose.pushMatrix()
+				.translate(-offset, 0);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+		pose.pushMatrix()
+				.translate(-offset, offset);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+		pose.pushMatrix()
+				.translate(-offset, -offset);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+		pose.pushMatrix()
+				.translate(0, offset);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+		pose.pushMatrix()
+				.translate(0, -offset);
+		context.drawText(textRenderer, outlineText, x, y, outlineColor, false);
+		pose.popMatrix();
+
+		context.drawText(textRenderer, text.asOrderedText(), x, y, color, false);
+		return true;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
@@ -180,7 +180,7 @@ public class StatusBar implements Widget, Drawable, Element, Selectable {
 		int color = transparency((textColor == null ? colors[0] : textColor).getRGB());
 		int outlineColor = transparency(Colors.BLACK);
 
-		HudHelper.drawOutlinedText(context, Text.of(text).asOrderedText(), x, y, color, outlineColor);
+		HudHelper.drawOutlinedText(context, Text.of(text), x, y, color, outlineColor);
 	}
 
 	public void renderCursor(DrawContext context, int mouseX, int mouseY, float delta) {

--- a/src/main/java/de/hysky/skyblocker/utils/render/HudHelper.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/HudHelper.java
@@ -1,12 +1,7 @@
 package de.hysky.skyblocker.utils.render;
 
-import java.awt.Color;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.joml.Matrix3x2f;
-
 import de.hysky.skyblocker.compatibility.CaxtonCompatibility;
+import de.hysky.skyblocker.compatibility.ModernUICompatibility;
 import de.hysky.skyblocker.utils.render.gui.state.EquipmentGuiElementRenderState;
 import de.hysky.skyblocker.utils.render.gui.state.HorizontalGradientGuiElementRenderState;
 import de.hysky.skyblocker.utils.render.gui.state.OutlinedTextGuiElementRenderState;
@@ -23,9 +18,14 @@ import net.minecraft.client.util.DefaultSkinHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.equipment.EquipmentAsset;
 import net.minecraft.registry.RegistryKey;
-import net.minecraft.text.OrderedText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ColorHelper;
+import org.joml.Matrix3x2f;
+
+import java.awt.*;
+import java.util.Optional;
+import java.util.UUID;
 
 public class HudHelper {
 	private static final MinecraftClient CLIENT = MinecraftClient.getInstance();
@@ -56,10 +56,11 @@ public class HudHelper {
 		context.state.addSpecialElement(renderState);
 	}
 
-	public static void drawOutlinedText(DrawContext context, OrderedText text, int x, int y, int color, int outlineColor) {
-		if (CaxtonCompatibility.drawOutlinedText(context, text, x, y, color, outlineColor)) return;
+	public static void drawOutlinedText(DrawContext context, Text text, int x, int y, int color, int outlineColor) {
+		if (CaxtonCompatibility.drawOutlinedText(context, text.asOrderedText(), x, y, color, outlineColor)) return;
+		if (ModernUICompatibility.drawOutlinedText(context, text, x, y, color, outlineColor)) return;
 
-		OutlinedTextGuiElementRenderState renderState = new OutlinedTextGuiElementRenderState(CLIENT.textRenderer, text, new Matrix3x2f(context.getMatrices()), x, y, color, outlineColor, false, context.scissorStack.peekLast());
+		OutlinedTextGuiElementRenderState renderState = new OutlinedTextGuiElementRenderState(CLIENT.textRenderer, text.asOrderedText(), new Matrix3x2f(context.getMatrices()), x, y, color, outlineColor, false, context.scissorStack.peekLast());
 		context.state.addText(renderState);
 	}
 


### PR DESCRIPTION
The current outlined text implementation breaks compatibility with ModernUI and crashes the game with ModernUI.

<details>

<summary>Crash Log</summary>

```
java.lang.ClassCastException: class de.hysky.skyblocker.utils.render.gui.state.OutlinedTextGuiElementRenderState$OutlineGlyphDrawable cannot be cast to class icyllis.modernui.mc.text.ModernPreparedText (de.hysky.skyblocker.utils.render.gui.state.OutlinedTextGuiElementRenderState$OutlineGlyphDrawable and icyllis.modernui.mc.text.ModernPreparedText are in unnamed module of loader 'knot' @5c7fa833)
	at knot/net.minecraft.class_11228.md5852df$modernui$lambda$prepareText$0$0(class_11228.java:1262) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11246.method_71069(class_11246.java:207) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11246.method_71061(class_11246.java:258) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11246.method_71061(class_11246.java:260) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11246.method_71074(class_11246.java:250) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11246.method_71068(class_11246.java:203) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11228.method_70891(class_11228.java:1259) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11228.method_71290(class_11228.java:207) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_11228.method_70890(class_11228.java:170) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_757.method_3192(class_757.java:587) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_310.method_1523(class_310.java:1361) ~[client-intermediary.jar:?]
	at knot/net.minecraft.class_310.method_1514(class_310.java:947) [client-intermediary.jar:?]
	at knot/net.minecraft.client.main.Main.main(Main.java:265) [client-intermediary.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:506) [fabric-loader-0.17.2.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72) [fabric-loader-0.17.2.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.17.2.jar:?]
```

</details>

ModernUI implemented an advanced font engine and changed some of the vanilla logic of handling text render states. Their code and mixins are based on the premise that `TextGuiElementRenderState` is a final class, but our code breaks this by the use of access widener. They have claimed they won't be fixing this issue, so a simple compatibility workaround is needed to implement a fallback rendering logic.

The final effect is as follows:

<img width="1196" height="193" alt="image" src="https://github.com/user-attachments/assets/0caf02ae-1c37-4b19-862d-15325350465e" />
