### PR TITLE
Exclude certain search signs from showing Input Calculator

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/SignEditScreenMixin.java
@@ -122,6 +122,6 @@ public abstract class SignEditScreenMixin extends Screen {
 
 	@Unique
 	private boolean isInputSign() {
-		return (messages[1].equals(INPUT_SIGN_MARKER) && !isInputSearchSign()) || messages[1].equals(ALT_INPUT_SIGN_MARKER) || messages[1].equals(BAZAAR_FLIP_MARKER);
+		return messages[1].equals(INPUT_SIGN_MARKER) && !isInputSearchSign() || messages[1].equals(ALT_INPUT_SIGN_MARKER) || messages[1].equals(BAZAAR_FLIP_MARKER);
 	}
 }


### PR DESCRIPTION
Exclude /recipes and /shards search signs from showing input calculator