### PR TITLE
Fix unknown found fairy soul locations resetting other found fairy souls

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/waypoint/FairySouls.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/waypoint/FairySouls.java
@@ -81,7 +81,7 @@ public class FairySouls {
                     for (Map.Entry<String, JsonElement> foundFairiesForLocationJson : foundFairiesForProfileJson.getValue().getAsJsonObject().asMap().entrySet()) {
                         Map<BlockPos, ProfileAwareWaypoint> fairiesForLocation = fairySouls.get(foundFairiesForLocationJson.getKey());
                         for (JsonElement foundFairy : foundFairiesForLocationJson.getValue().getAsJsonArray().asList()) {
-							@Nullable ProfileAwareWaypoint waypoint = fairiesForLocation.get(PosUtils.parsePosString(foundFairy.getAsString()));
+							ProfileAwareWaypoint waypoint = fairiesForLocation.get(PosUtils.parsePosString(foundFairy.getAsString()));
 							if (waypoint == null) {
 								LOGGER.warn("[Skyblocker] Ignored found fairy soul at {}", foundFairy.getAsString());
 							} else {


### PR DESCRIPTION
After the NEU repository was updated (I was using a very outdated fork for reasons that I don't remember), most of my fairy soul progress was reset. Restoring the `found_fairy_souls.json` file from a backup would also not work. It turns out that the mod was failing to load all found fairy soul locations after encountering a location that it didn't recognise, which can happen normally when fairy souls are moved. This PR makes it so that unknown locations are skipped instead of throwing an exception, and prints a warning in the console.

Note that a test is failing (`testToSkyblocker()`) after I made these changes. Everything is working fine for me, so I assumed that this was harmless. I don't understand how this test works, so if you could please look into it or let me know how to do it I would greatly appreciate. Thanks!

This might fix #1623 

Before:
<img width="1724" height="350" alt="image" src="https://github.com/user-attachments/assets/24178757-21ee-4666-ba8e-d200fa84c233" />
<img width="1185" height="750" alt="image" src="https://github.com/user-attachments/assets/573384d3-0174-4038-aca2-14109d1bb869" />

After (note that there's now only a waypoint for the fairy soul that was moved, from #1272 ):
<img width="1218" height="298" alt="image" src="https://github.com/user-attachments/assets/4e56c9be-c594-42df-ad2e-c066c7ef758c" />
<img width="1097" height="680" alt="image" src="https://github.com/user-attachments/assets/29e6bac0-e322-4d84-b4a8-7aa304c66be8" />
<img width="1093" height="679" alt="image" src="https://github.com/user-attachments/assets/ab452033-55d6-4cef-a2d2-a8efa8fa6bdb" />

