### PR TITLE
terminal left click to middle

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -439,6 +439,14 @@ public class DungeonsCategory {
 										newValue -> config.dungeons.terminals.blockIncorrectClicks = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Text.translatable("skyblocker.config.dungeons.terminals.middleClick"))
+								.description(Text.translatable("skyblocker.config.dungeons.terminals.middleClick.@Tooltip"))
+								.binding(defaults.dungeons.terminals.middleClick,
+										() -> config.dungeons.terminals.middleClick,
+										newValue -> config.dungeons.terminals.middleClick = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.build())
 
 				// Devices (F7/M7)

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -150,6 +150,8 @@ public class DungeonsConfig {
 		public boolean solveStartsWith = true;
 
 		public boolean blockIncorrectClicks = false;
+
+		public boolean middleClick = false;
 	}
 
 	public static class Devices {

--- a/src/main/java/de/hysky/skyblocker/skyblock/bazaar/ReorderHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/bazaar/ReorderHelper.java
@@ -35,7 +35,7 @@ public class ReorderHelper extends SimpleContainerSolver implements TooltipAdder
 	}
 
 	@Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
 		//   V This part is so that it short-circuits if not necessary
 		if ((slot == 11 || slot == 13) && stack.isOf(Items.GREEN_TERRACOTTA) && InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow().getHandle(), GLFW.GLFW_KEY_LEFT_CONTROL)) {
 			Matcher matcher;
@@ -44,10 +44,10 @@ public class ReorderHelper extends SimpleContainerSolver implements TooltipAdder
 			else matcher = ItemUtils.getLoreLineIfContainsMatch(stack, BUY_PATTERN);
 			if (matcher != null) {
 				MinecraftClient.getInstance().keyboard.setClipboard(matcher.group(1).replace(",", ""));
-				return false;
+				return SlotClickResult.ALLOW;
 			}
 		}
-		return false;
+		return SlotClickResult.ALLOW;
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/ColorTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/ColorTerminal.java
@@ -58,12 +58,12 @@ public final class ColorTerminal extends SimpleContainerSolver implements Termin
     }
 
     @Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
         if (stack.hasGlint() || !targetColor.equals(itemColor.get(stack.getItem()))) {
-            return shouldBlockIncorrectClicks();
+            return blockOrClick();
         }
 
-        return false;
+        return allow();
     }
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/LightsOnTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/LightsOnTerminal.java
@@ -31,7 +31,7 @@ public final class LightsOnTerminal extends SimpleContainerSolver implements Ter
 	}
 
 	@Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
-		return stack.isOf(Items.LIME_STAINED_GLASS_PANE);
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+		return stack.isOf(Items.LIME_STAINED_GLASS_PANE) ? SlotClickResult.CANCEL : allow();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/OrderTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/OrderTerminal.java
@@ -57,13 +57,13 @@ public final class OrderTerminal extends SimpleContainerSolver implements Termin
     }
 
     @Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
-        if (stack == null || stack.isEmpty()) return false;
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+        if (stack == null || stack.isEmpty()) return allow();
 
         if (!stack.isOf(Items.RED_STAINED_GLASS_PANE) || stack.getCount() != currentNum + 1) {
-            return shouldBlockIncorrectClicks();
+            return blockOrClick();
         }
 
-        return false;
+        return allow();
     }
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/SameColorTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/SameColorTerminal.java
@@ -96,23 +96,23 @@ public final class SameColorTerminal extends SimpleContainerSolver implements Te
 	}
 
 	@Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
 		if (clickMap.containsKey(slot)) {
 			int clicks = clickMap.get(slot);
 
 			if (clicks == 0) {
-				return shouldBlockIncorrectClicks();
+				return blockOrClick();
 			} else {
 				boolean positive = Integer.signum(clicks) == 1;
 				//Require that positive moves use left click, and negative moves use right click
 				boolean usingCorrectButton = (positive && button == GLFW.GLFW_MOUSE_BUTTON_LEFT) || (!positive && button == GLFW.GLFW_MOUSE_BUTTON_RIGHT);
 
 				if (!usingCorrectButton) {
-					return shouldBlockIncorrectClicks();
+					return blockOrClick();
 				}
 			}
 		}
-		return false;
+		return allow();
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/StartsWithTerminal.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/StartsWithTerminal.java
@@ -53,10 +53,10 @@ public final class StartsWithTerminal extends SimpleContainerSolver implements T
 	}
 
 	@Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
 		//Some random glass pane was clicked or something
 		//Block clicks for this because these slots are replaced with air items
-		if (!trackedItemStates.containsKey(slot) || stack == null || stack.isEmpty()) return shouldBlockIncorrectClicks();
+		if (!trackedItemStates.containsKey(slot) || stack == null || stack.isEmpty()) return blockOrClick();
 
 		ItemState state = trackedItemStates.get(slot);
 		String prefix = groups[0];
@@ -72,10 +72,10 @@ public final class StartsWithTerminal extends SimpleContainerSolver implements T
 			trackedItemStates.put(slot, state.click());
 			lastKnownScreenId = screenId;
 		} else {
-			return shouldBlockIncorrectClicks();
+			return blockOrClick();
 		}
 
-		return false;
+		return allow();
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/TerminalSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/terminal/TerminalSolver.java
@@ -1,9 +1,22 @@
 package de.hysky.skyblocker.skyblock.dungeon.terminal;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.container.ContainerSolver;
 
 public sealed interface TerminalSolver permits ColorTerminal, LightsOnTerminal, OrderTerminal, SameColorTerminal, StartsWithTerminal {
 	default boolean shouldBlockIncorrectClicks() {
 		return SkyblockerConfigManager.get().dungeons.terminals.blockIncorrectClicks;
+	}
+
+	default boolean shouldMiddleClick() {
+		return SkyblockerConfigManager.get().dungeons.terminals.middleClick;
+	}
+
+	default ContainerSolver.SlotClickResult allow() {
+		return shouldMiddleClick() ? ContainerSolver.SlotClickResult.ALLOW_MIDDLE_CLICK : ContainerSolver.SlotClickResult.ALLOW;
+	}
+
+	default ContainerSolver.SlotClickResult blockOrClick() {
+		return shouldBlockIncorrectClicks() ? ContainerSolver.SlotClickResult.CANCEL : allow();
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/ChronomatronSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/ChronomatronSolver.java
@@ -129,7 +129,7 @@ public final class ChronomatronSolver extends ExperimentSolver implements Screen
 	 * Increments {@link #chronomatronCurrentOrdinal} if the item clicked matches the item at {@link #chronomatronCurrentOrdinal the current index} in the chain.
 	 */
 	@Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
 		if (getState() == State.SHOW) {
 			Item item = chronomatronSlots.get(chronomatronCurrentOrdinal);
 			if ((stack.isOf(item) || ChronomatronSolver.TERRACOTTA_TO_GLASS.get(stack.getItem()) == item)) {
@@ -137,7 +137,7 @@ public final class ChronomatronSolver extends ExperimentSolver implements Screen
 					setState(ExperimentSolver.State.END);
 				}
 			} else {
-				return shouldBlockIncorrectClicks();
+				return shouldBlockIncorrectClicks() ? SlotClickResult.CANCEL : SlotClickResult.ALLOW;
 			}
 		}
 		return super.onClickSlot(slot, stack, screenId, button);

--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/SuperpairsSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/SuperpairsSolver.java
@@ -97,7 +97,7 @@ public final class SuperpairsSolver extends ExperimentSolver {
 	}
 
 	@Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
 		if (getState() == State.SHOW) {
 			this.superpairsPrevClickedSlot = slot;
 			this.superpairsCurrentSlot = ItemStack.EMPTY;

--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
@@ -107,7 +107,7 @@ public final class UltrasequencerSolver extends ExperimentSolver {
 	 */
 	@SuppressWarnings("JavadocReference")
 	@Override
-	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+	public SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
 		if (getState() == State.SHOW) {
 			if (slot == ultrasequencerNextSlot) {
 				int count = getSlots().get(ultrasequencerNextSlot).getCount() + 1;
@@ -117,7 +117,7 @@ public final class UltrasequencerSolver extends ExperimentSolver {
 						.map(Int2ObjectMap.Entry::getIntKey)
 						.ifPresent(nextSlot -> this.ultrasequencerNextSlot = nextSlot);
 			} else {
-				return shouldBlockIncorrectClicks();
+				return shouldBlockIncorrectClicks() ? SlotClickResult.CANCEL : SlotClickResult.ALLOW;
 			}
 		}
 		return super.onClickSlot(slot, stack, screenId, button);

--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/TunerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/TunerSolver.java
@@ -158,11 +158,11 @@ public class TunerSolver extends SimpleContainerSolver implements SlotTextAdder 
 	 * multiple times.
 	 */
 	@Override
-	public boolean onClickSlot(int slotId, ItemStack stack, int screenId, int button) {
-		if (!SkyblockerConfigManager.get().foraging.galatea.enableTunerSolver) return false;
-		if (!isInMenu) return false;
+	public SlotClickResult onClickSlot(int slotId, ItemStack stack, int screenId, int button) {
+		if (!SkyblockerConfigManager.get().foraging.galatea.enableTunerSolver) return SlotClickResult.ALLOW;
+		if (!isInMenu) return SlotClickResult.ALLOW;
 
-		if (button != 0 && button != 1) return false;
+		if (button != 0 && button != 1) return SlotClickResult.ALLOW;
 
 		int delta = button == 0 ? -1 : 1;
 
@@ -173,7 +173,7 @@ public class TunerSolver extends SimpleContainerSolver implements SlotTextAdder 
 		} else if (pitchSolved && slotId == 50) {
 			pitchClicks = updateClicks(pitchClicks, PITCH_CYCLE.length, delta);
 		}
-		return false;
+		return SlotClickResult.ALLOW;
 	}
 
 	/**

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolver.java
@@ -41,10 +41,12 @@ public interface ContainerSolver extends ContainerMatcher, Resettable {
 	/**
 	 * Called when the slot is clicked.
 	 *
-	 * @return {@code true} if the click should be canceled, {@code false} otherwise. Defaults to {@code false} if not overridden.
+	 * @return {@link SlotClickResult#CANCEL} if the click should be blocked.<br>
+	 * {@link SlotClickResult#ALLOW} if it shouldn't.<br>
+	 * {@link SlotClickResult#ALLOW_MIDDLE_CLICK} if the left click should be turned into a middle click (ignored if {@code button} isn't {@code 0}).
 	 */
-	default boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
-		return false;
+	default SlotClickResult onClickSlot(int slot, ItemStack stack, int screenId, int button) {
+		return SlotClickResult.ALLOW;
 	}
 
 	static void trimEdges(Int2ObjectMap<ItemStack> slots, int rows) {
@@ -56,5 +58,11 @@ public interface ContainerSolver extends ContainerMatcher, Resettable {
 			slots.remove(i);
 			slots.remove((rows - 1) * 9 + i);
 		}
+	}
+
+	enum SlotClickResult {
+		CANCEL,
+		ALLOW,
+		ALLOW_MIDDLE_CLICK
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolverManager.java
@@ -137,8 +137,9 @@ public class ContainerSolverManager {
 	/**
 	 * @return Whether the click should be disallowed.
 	 */
-	public static boolean onSlotClick(int slot, ItemStack stack, int button) {
-		return currentSolver != null && currentSolver.onClickSlot(slot, stack, screenId, button);
+	public static ContainerSolver.SlotClickResult onSlotClick(int slot, ItemStack stack, int button) {
+		if (currentSolver == null) return ContainerSolver.SlotClickResult.ALLOW;
+		return currentSolver.onClickSlot(slot, stack, screenId, button);
 	}
 
 	public static void onDraw(DrawContext context, HandledScreen<GenericContainerScreenHandler> handledScreen, List<Slot> slots) {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -262,6 +262,8 @@
 
   "skyblocker.config.dungeons.terminals": "Terminal Solvers (F7/M7)",
   "skyblocker.config.dungeons.terminals.blockIncorrectClicks": "Block Incorrect Clicks",
+  "skyblocker.config.dungeons.terminals.middleClick": "Middle Clicks",
+  "skyblocker.config.dungeons.terminals.middleClick.@Tooltip": "Turns left clicks into middle clicks.",
   "skyblocker.config.dungeons.terminals.solveColor": "Solve Select Colored",
   "skyblocker.config.dungeons.terminals.solveOrder": "Solve Click In Order",
   "skyblocker.config.dungeons.terminals.solveStartsWith": "Solve Starts With",


### PR DESCRIPTION
Not sure if this is the best way to implement it.
I implemented it by changing the return value of `ContainerSolver#onSlotClick` from a bool to a `SlotClickResult` enum, that cancels, allows the click or allow the click and turns it into a middle click.
Untested cuz dungeons