### PR TITLE
Add more shortcuts

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/Shortcuts.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/Shortcuts.java
@@ -122,7 +122,7 @@ public class Shortcuts {
 		commands.put("/ce", "/call elizabeth");
 		commands.put("/co", "/call odger");
 		commands.put("/ck", "/call kat");
-		commands.put("/cs", "/call maddox");//call slayer
+		commands.put("/cs", "/call maddox"); //call slayer
 
 		// Social
 		commandArgs.put("/fr", "/friend");
@@ -130,7 +130,7 @@ public class Shortcuts {
 		commandArgs.put("/pj", "/party join");
 		commandArgs.put("/pa", "/party accept");
 		commandArgs.put("/pc", "/party chat");
-		commandArgs.put("/ptr", "/party transfer");//pt is for playtime
+		commandArgs.put("/ptr", "/party transfer"); //pt is for playtime
 		commands.put("/pd", "/party disband");
 		commands.put("/pl", "/party leave");
 		commands.put("/pll", "/party list");
@@ -151,7 +151,7 @@ public class Shortcuts {
 		commands.put("/wcs", "/warp castle");
 		commands.put("/wd", "/warp deep");
 		commands.put("/wda", "/warp da");
-		commands.put("/wdd", "/warp drag");//wdr is for watchdog report
+		commands.put("/wdd", "/warp drag"); //wdr is for watchdog report
 		commands.put("/wde", "/warp desert");
 		commands.put("/wdt", "/warp dragontail");
 		commands.put("/we", "/warp end");


### PR DESCRIPTION
I use a QWERTY keyboard. I try to choose the letters for the abbreviations based on the characters I would subconsciously type when typing the full path.

Some shortcuts that don't follow this rule are usually because there are duplicate parameters or they can be entered quickly by double-clicking.

Most warp commands start with "w" to limit them to the same level, so that the auto-complete function does not provide too much warp commands.

By listing these commands, even if the user does not like the shortcuts, they can quickly change it without having to look up the specific command to enter.