### PR TITLE
New Location For Eliza Emissary

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MiningLocationLabel.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/MiningLocationLabel.java
@@ -92,7 +92,7 @@ public class MiningLocationLabel extends DistancedNamedWaypoint {
         RAMPARTS_QUARRY(new BlockPos(-72, 153, -10)),
         UPPER_MINES(new BlockPos(-132, 174, -50)),
         ROYAL_MINES(new BlockPos(171, 150, 31)),
-        DWARVEN_VILLAGE(new BlockPos(-37, 200, -92)),
+        DWARVEN_VILLAGE(new BlockPos(-37, 200, -131)),
         DWARVEN_MINES(new BlockPos(89, 198, -92));
 
         private final BlockPos location;


### PR DESCRIPTION
DWARVEN_VILLAGE emissary has moved. Seen screenshots. However, I think its worth moving the waypoints for emissaries to .5 _above_ where they are located and handle the BlockPos int to float conversion for a better experience. Unsure if this is an existing issue or something I can tackle, just let me know.

Before:
<img width="1007" height="839" alt="beforeeliza" src="https://github.com/user-attachments/assets/1e066a19-4eb8-492d-971c-5b6b16efd9a9" />

After:
<img width="1207" height="981" alt="aftereliza" src="https://github.com/user-attachments/assets/315421e7-78a9-4c7e-9f43-c50082c6dc91" />
