### PR TITLE
Add DUNGEON_ENDED event

### DIFF
--- a/src/main/java/de/hysky/skyblocker/events/DungeonEvents.java
+++ b/src/main/java/de/hysky/skyblocker/events/DungeonEvents.java
@@ -25,6 +25,15 @@ public class DungeonEvents {
 		}
 	});
 
+	/**
+	 * Called after the dungeons run ends and the team score is being sent in chat.
+	 */
+	public static final Event<DungeonEnded> DUNGEON_ENDED = EventFactory.createArrayBacked(DungeonEnded.class, callbacks -> () -> {
+		for (DungeonEnded callback : callbacks) {
+			callback.onDungeonEnded();
+		}
+	});
+
 	public static final Event<RoomMatched> PUZZLE_MATCHED = EventFactory.createArrayBacked(RoomMatched.class, callbacks -> room -> {
 		for (RoomMatched callback : callbacks) {
 			callback.onRoomMatched(room);
@@ -50,6 +59,12 @@ public class DungeonEvents {
 	@FunctionalInterface
 	public interface DungeonStarted {
 		void onDungeonStarted();
+	}
+
+	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
+	public interface DungeonEnded {
+		void onDungeonEnded();
 	}
 
 	@Environment(EnvType.CLIENT)

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonMapLabels.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonMapLabels.java
@@ -35,6 +35,7 @@ public class DungeonMapLabels {
 	@Init
 	public static void init() {
 		ClientPlayConnectionEvents.JOIN.register((_n, _p, _c) -> DungeonMapLabels.clearLabels());
+		DungeonEvents.DUNGEON_ENDED.register(DungeonMapLabels::clearLabels);
 		DungeonEvents.ROOM_MATCHED.register(DungeonMapLabels::onRoomMatched);
 		Scheduler.INSTANCE.scheduleCyclic(() -> updateRoomNames(null), 20);
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
@@ -81,6 +81,7 @@ public class DungeonScore {
 		Scheduler.INSTANCE.scheduleCyclic(DungeonScore::tick, 20);
 		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> reset());
 		DungeonEvents.DUNGEON_STARTED.register(DungeonScore::onDungeonStart);
+		DungeonEvents.DUNGEON_ENDED.register(DungeonScore::reset);
 		ClientReceiveMessageEvents.ALLOW_GAME.register((message, overlay) -> {
 			if (overlay || !Utils.isInDungeons()) return true;
 			String str = message.getString();


### PR DESCRIPTION
Adds a new DUNGEON_ENDED event, used to:
+ Clear room labels,
+ Reset dungeon score,
+ Send secrets found messages

Also fixes the Secret Tracker messages not showing in chat (wasn't being done on the Render Thread)