### PR TITLE
Adjust abbreviation for Corruption enchantment

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EnchantmentLevelAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EnchantmentLevelAdder.java
@@ -50,7 +50,7 @@ public class EnchantmentLevelAdder extends SimpleSlotTextAdder {
 		ENCHANTMENT_ABBREVIATIONS.put("charm", "CM");
 		ENCHANTMENT_ABBREVIATIONS.put("cleave", "CL");
 		ENCHANTMENT_ABBREVIATIONS.put("compact", "CO");
-		ENCHANTMENT_ABBREVIATIONS.put("corruption", "CP");
+		ENCHANTMENT_ABBREVIATIONS.put("corruption", "CI");
 		ENCHANTMENT_ABBREVIATIONS.put("counter_strike", "CS");
 		ENCHANTMENT_ABBREVIATIONS.put("critical", "CR");
 		ENCHANTMENT_ABBREVIATIONS.put("cubism", "CU");


### PR DESCRIPTION
The old one has... unfortunate implications. This is the only other letter that isn't taken.