### PR TITLE
Fix builder wand block preview bug

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/BuildersWandPreview.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/BuildersWandPreview.java
@@ -50,7 +50,7 @@ public class BuildersWandPreview {
 		if (client.world == null) return;
 		BlockPos hitPos = hitResult.getBlockPos();
 		Direction side = hitResult.getSide();
-		if (!client.world.getBlockState(hitPos.mutableCopy().move(side)).isAir()) return;
+		if (!client.world.getBlockState(hitPos.offset(side)).isAir()) return;
 		BlockState state = client.world.getBlockState(hitPos);
 		for (BlockPos pos : findConnectedFaces(client.world, hitPos, side, state)) {
 			extractBlockPreview(collector, pos.offset(side), state);


### PR DESCRIPTION
Fixes by checking liquid offset block for air. Also fixes similar bug where the ruler tries to place with non full block in front.

https://github.com/SkyblockerMod/Skyblocker/issues/1887