### PR TITLE
Fix parse separators in shard number

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/hunting/HuntingBoxHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/hunting/HuntingBoxHelper.java
@@ -6,6 +6,8 @@ import de.hysky.skyblocker.utils.container.ContainerSolver;
 import de.hysky.skyblocker.utils.container.SimpleContainerSolver;
 import de.hysky.skyblocker.utils.render.gui.ColorHighlight;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,11 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
 
 public class HuntingBoxHelper extends SimpleContainerSolver {
-	private static final Pattern OWNED_PATTERN = Pattern.compile("Owned: (\\d+) Shards?");
+	private static final Pattern OWNED_PATTERN = Pattern.compile("Owned: ([\\d,]+) Shards?");
 	private static final Pattern SYPHON_PATTERN = Pattern.compile("Syphon (\\d+) more to level up!");
 	private static final Logger LOGGER = LoggerFactory.getLogger(HuntingBoxHelper.class);
 
@@ -42,7 +42,7 @@ public class HuntingBoxHelper extends SimpleContainerSolver {
 				String text = line.getString();
 				if (owned == null) {
 					Matcher matcher = OWNED_PATTERN.matcher(text);
-					if (matcher.matches()) owned = matcher.group(1);
+					if (matcher.matches()) owned = matcher.group(1).replace(",", "");
 				} else {
 					Matcher matcher = SYPHON_PATTERN.matcher(text);
 					if (matcher.matches()) syphon = matcher.group(1);

--- a/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
@@ -80,7 +80,7 @@ public final class ItemUtils {
 	private static final Pattern STORED_PATTERN = Pattern.compile("Stored: ([\\d,]+)/\\S+");
 	private static final Pattern GEMSTONES_SACK_AMOUNT_PATTERN = Pattern.compile(" Amount: ([\\d,]+)");
 	private static final Pattern STASH_COUNT_PATTERN = Pattern.compile("x([\\d,]+)$"); // This is used with Matcher#find, not #matches
-	private static final Pattern HUNTING_BOX_COUNT_PATTERN = Pattern.compile("Owned: (?<shards>\\d+) Shards?");
+	private static final Pattern HUNTING_BOX_COUNT_PATTERN = Pattern.compile("Owned: (?<shards>[\\d,]+) Shards?");
 	private static final short LOG_INTERVAL = 1000;
 	private static long lastLog = Util.getMillis();
 


### PR DESCRIPTION
In case you have thousands of cool shards:

<img width="849" height="808" alt="image" src="https://github.com/user-attachments/assets/c9e8e284-6cb6-46fa-bd9d-58c9bad8e058" />
