### PR TITLE
Early clicks in Ultrasequencer can count when the mod thinks it doesn't

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/experiment/UltrasequencerSolver.java
@@ -105,7 +105,7 @@ public final class UltrasequencerSolver extends ExperimentSolver {
 	@SuppressWarnings("JavadocReference")
 	@Override
 	public boolean onClickSlot(int slot, ItemStack stack, int screenId, int button) {
-		if (getState() != State.SHOW) { return true; }  // Block early clicks when table is still loading
+		if (getState() != State.SHOW) { return shouldBlockIncorrectClicks(); }  // Block early clicks when table is still loading
 		if (slot != ultrasequencerNextSlot) { return shouldBlockIncorrectClicks(); }
 
 		int count = getSlots().get(ultrasequencerNextSlot).getCount() + 1;


### PR DESCRIPTION
# Fixes #1942

Added early-interaction-block for the Ultrasequencer when it doesnt take clicks yet

## Changes:
 - added if statement and block to prevent early clicks, that caused this bug to happen

## Bug:
Click on the first element, right when the show animation is done (only once if 'Block Incorrect Clicks' is turned off). When done correctly (time window is pretty small), the solver thinks the current number is still 1, even though you already clicked it. If you then click 1 again, it will fail the puzzle. If 'Block Incorrect Clicks' is off, you can continue playing like normal, even though the highlighting will be stuck at the first item. Otherwise, if its turned on, you cant continue playing and will/need to fail the puzzle.

**Notes:**
 - the sequence must be at least 2 items long
 - when the bug happened, it is only for the sequence your currently on

## Testing the fix:
Tested it with several 'Ultrasequencer (Metaphysical)' runs, with 'Block Incorrect Clicks' both enabled and disabled. Tried reproducing the bug multiple times, without success.