### PR TITLE
Lerp bounding boxes

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/EntityRendererMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/EntityRendererMixin.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.mixins;
 
+import de.hysky.skyblocker.utils.Boxes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -41,12 +42,12 @@ public class EntityRendererMixin {
 
 	// This is meant to be separate from the previous injection for organizational purposes.
 	@Inject(method = "extractRenderState", at = @At(value = "TAIL"))
-	private void skyblocker$mobBoundingBox(CallbackInfo ci, @Local(argsOnly = true) Entity entity) {
+	private void skyblocker$mobBoundingBox(CallbackInfo ci, @Local(argsOnly = true) Entity entity, @Local(argsOnly = true) float partialTick) {
 		boolean shouldShowBoundingBox = MobBoundingBoxes.shouldDrawMobBoundingBox(entity);
 
 		if (shouldShowBoundingBox) {
 			MobBoundingBoxes.submitBox2BeRendered(
-					entity instanceof ArmorStand e ? SlayerManager.getSlayerMobBoundingBox(e) : entity.getBoundingBox(),
+					entity instanceof ArmorStand e ? SlayerManager.getSlayerMobBoundingBox(e, partialTick) : Boxes.lerpEntityBoundingBox(entity, partialTick),
 					MobBoundingBoxes.getBoxColor(entity)
 			);
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerManager.java
@@ -25,6 +25,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.entity.monster.spider.CaveSpider;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -274,12 +275,14 @@ public class SlayerManager {
 	 * Returns the highlight bounding box for the given slayer boss armor stand entity.
 	 * It's slightly larger and lower than the armor stand's bounding box.
 	 */
-	public static @Nullable AABB getSlayerMobBoundingBox(ArmorStand armorStand) {
+	public static @Nullable AABB getSlayerMobBoundingBox(ArmorStand armorStand, float partialTick) {
+		// lowkey we should figure out where the actual boss entity is, because the armor stand lags behind
+		Vec3 lerpedPos = armorStand.getPosition(partialTick);
 		return switch (getSlayerType()) {
-			case SlayerType.REVENANT -> new AABB(armorStand.getX() - 0.4, armorStand.getY() - 0.1, armorStand.getZ() - 0.4, armorStand.getX() + 0.4, armorStand.getY() - 2.2, armorStand.getZ() + 0.4);
-			case SlayerType.TARANTULA -> new AABB(armorStand.getX() - 0.9, armorStand.getY() - 0.2, armorStand.getZ() - 0.9, armorStand.getX() + 0.9, armorStand.getY() - 1.2, armorStand.getZ() + 0.9);
-			case SlayerType.VOIDGLOOM -> new AABB(armorStand.getX() - 0.4, armorStand.getY() - 0.2, armorStand.getZ() - 0.4, armorStand.getX() + 0.4, armorStand.getY() - 3, armorStand.getZ() + 0.4);
-			case SlayerType.SVEN -> new AABB(armorStand.getX() - 0.5, armorStand.getY() - 0.1, armorStand.getZ() - 0.5, armorStand.getX() + 0.5, armorStand.getY() - 1, armorStand.getZ() + 0.5);
+			case SlayerType.REVENANT -> new AABB(lerpedPos.x - 0.4, lerpedPos.y - 0.1, lerpedPos.z - 0.4, lerpedPos.x + 0.4, lerpedPos.y - 2.2, lerpedPos.z + 0.4);
+			case SlayerType.TARANTULA -> new AABB(lerpedPos.x - 0.9, lerpedPos.y - 0.2, lerpedPos.z - 0.9, lerpedPos.x + 0.9, lerpedPos.y - 1.2, lerpedPos.z + 0.9);
+			case SlayerType.VOIDGLOOM -> new AABB(lerpedPos.x - 0.4, lerpedPos.y - 0.2, lerpedPos.z - 0.4, lerpedPos.x + 0.4, lerpedPos.y - 3, lerpedPos.z + 0.4);
+			case SlayerType.SVEN -> new AABB(lerpedPos.x - 0.5, lerpedPos.y - 0.1, lerpedPos.z - 0.5, lerpedPos.x + 0.5, lerpedPos.y - 1, lerpedPos.z + 0.5);
 			case null -> null;
 			default -> armorStand.getBoundingBox();
 		};

--- a/src/main/java/de/hysky/skyblocker/utils/Boxes.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Boxes.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.utils;
 
 import net.minecraft.core.Direction.Axis;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
@@ -54,5 +55,24 @@ public class Boxes {
 				getAxisLength(box, Axis.X) * (x - 1) / 2d,
 				getAxisLength(box, Axis.Y) * (y - 1) / 2d,
 				getAxisLength(box, Axis.Z) * (z - 1) / 2d);
+	}
+
+	public static AABB lerpEntityBoundingBox(Entity entity, float partialTick) {
+		// These names are so incredibly bad. Why is the function that returns the lerped
+		// position called "getPosition" when the function that returns the non-lerped position
+		// is just called "position"? Find me a single person that can tell me how the two
+		// functions differ just by reading their names. A real human being sat down and picked
+		// these names. Seriously.
+
+		// Compute how much more the entity has to move backwards from its current position to reach its interpolated position
+		// (old - new) * (1 - partialTick)
+
+		// faster than recalculating a hitbox from the entity's current pose. very balzingaly fast
+		final float remainingTick = 1 - partialTick;
+		final Vec3 backwardsDeltaMovement = entity.oldPosition()
+				.subtract(entity.position())
+				.multiply(remainingTick, remainingTick, remainingTick);
+		// Subtract this vector from the entity hitbox
+		return entity.getBoundingBox().move(backwardsDeltaMovement);
 	}
 }


### PR DESCRIPTION
This fixes a long-standing issue where drawn bounding boxes didn't use the interpolated position of the entity, causing them to move at 20fps.
The bounding box system should probably get merged with the glow system. They do the exact same thing, after all - it's just a visual preference.