### PR TITLE
Fix Action Bar Moving

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/VanillaStyleManaBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/VanillaStyleManaBar.java
@@ -7,7 +7,6 @@ import de.hysky.skyblocker.skyblock.StatusBarTracker;
 import de.hysky.skyblocker.utils.Utils;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElement;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.hud.HudStatusBarHeightRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.gui.GuiGraphics;
@@ -69,14 +68,6 @@ public class VanillaStyleManaBar {
 		HudElementRegistry.attachElementBefore(VanillaHudElements.MOUNT_HEALTH, MANABAR_MOUNT_HUD_ID, (context, tickCounter) -> {
 			if (isEnabled()) render(context);
 		});
-
-		// 10 pixels is the spacing for a single bar, the mana bar always has 2 bars so has a height of 20 pixels
-		HudStatusBarHeightRegistry.addRight(VanillaHudElements.FOOD_BAR, (player) -> isEnabled() ? 0 : 10);
-		HudStatusBarHeightRegistry.addRight(VanillaHudElements.MOUNT_HEALTH, (player) -> isEnabled() ? 0 : 10);
-		// Only height for one bar needs to be registered, since the height for both bars is always enabled even when not visible.
-		// This could be changed if we had a condition like "isEnabled() && isHungerBarVisible()" for each individual bar,
-		// but as far as I am aware that condition is not easily available
-		HudStatusBarHeightRegistry.addRight(MANABAR_MOUNT_HUD_ID, (player) -> isEnabled() ? 20 : 0);
 	}
 
 	private static boolean isEnabled() {


### PR DESCRIPTION
Unfortunately, adding anything with `HudStatusBarHeightRegistry` will cause the action bar to move, even when the feature is disabled.