### PR TITLE
Evolution item progress tooltip

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -315,6 +315,14 @@ public class GeneralCategory {
 										newValue -> config.general.itemTooltip.enableStackingEnchantProgress = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.general.itemTooltip.enableEvolvingItemProgress"))
+								.description(Component.translatable("skyblocker.config.general.itemTooltip.enableEvolvingItemProgress.@Tooltip"))
+								.binding(defaults.general.itemTooltip.enableEvolvingItemProgress,
+										() -> config.general.itemTooltip.enableEvolvingItemProgress,
+										newValue -> config.general.itemTooltip.enableEvolvingItemProgress = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.build())
 
 				//Item Info Display

--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -124,6 +124,8 @@ public class GeneralConfig {
 		public boolean enableEstimatedItemValue = true;
 
 		public boolean enableStackingEnchantProgress = true;
+
+		public boolean enableEvolvingItemProgress = true;
 	}
 
 	public enum Average {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/TooltipManager.java
@@ -17,7 +17,7 @@ import de.hysky.skyblocker.skyblock.item.tooltip.adders.DateCalculatorTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.DungeonQualityTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.EssenceShopPrice;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.EstimatedItemValueTooltip;
-import de.hysky.skyblocker.skyblock.item.tooltip.adders.EvolvingItemTooltip;
+import de.hysky.skyblocker.skyblock.item.tooltip.adders.EvolvingItemProgressTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.HuntingBoxPriceTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.LBinTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.adders.LineSmoothener;
@@ -59,7 +59,7 @@ public class TooltipManager {
 			new ReorderHelper(),
 			BazaarOrderTracker.INSTANCE,
 			new StackingEnchantProgressTooltip(0), //Would be best to have after the lore but the tech doesn't exist for that
-			new EvolvingItemTooltip(0),
+			new EvolvingItemProgressTooltip(0),
 			new NpcPriceTooltip(1),
 			new BazaarPriceTooltip(2),
 			new LBinTooltip(3),

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EvolvingItemProgressTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EvolvingItemProgressTooltip.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.item.tooltip.adders;
 
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.utils.ItemUtils;
 import net.minecraft.ChatFormatting;
@@ -11,10 +12,10 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
-public class EvolvingItemTooltip extends SimpleTooltipAdder {
+public class EvolvingItemProgressTooltip extends SimpleTooltipAdder {
 	final List<String> evolutionItems = List.of("DARK_CACAO_TRUFFLE", "MOBY_DUCK", "ROSEWATER_FLASK", "DISCRITE", "NEW_BOTTLE_OF_JYRRE", "TRAINING_WEIGHTS");
 
-	public EvolvingItemTooltip(int priority) {
+	public EvolvingItemProgressTooltip(int priority) {
 		super(priority);
 	}
 
@@ -46,6 +47,6 @@ public class EvolvingItemTooltip extends SimpleTooltipAdder {
 
 	@Override
 	public boolean isEnabled() {
-		return true;
+		return SkyblockerConfigManager.get().general.itemTooltip.enableEvolvingItemProgress;
 	}
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -548,6 +548,8 @@
   "skyblocker.config.general.itemTooltip.enableBazaarPrice": "Enable Bazaar buy/sell Price",
   "skyblocker.config.general.itemTooltip.enableEstimatedItemValue": "Enable Estimated Item Value",
   "skyblocker.config.general.itemTooltip.enableEstimatedItemValue.@Tooltip": "Displays an estimation of the item's total value in the tooltip, §lmight not be 100% accurate all the time.§r\n\nWhen selling items always do a manual check of the item price!",
+  "skyblocker.config.general.itemTooltip.enableEvolvingItemProgress": "Enable Evolving Item Progress",
+  "skyblocker.config.general.itemTooltip.enableEvolvingItemProgress.@Tooltip": "Displays the age of evolving items and how long they will take to evolve",
   "skyblocker.config.general.itemTooltip.enableExoticTooltip": "Enable Exotic Tooltip",
   "skyblocker.config.general.itemTooltip.enableExoticTooltip.@Tooltip": "Displays the type of exotic below the item's name if an armor piece is exotic.",
   "skyblocker.config.general.itemTooltip.enableLowestBIN": "Enable Lowest BIN Price",


### PR DESCRIPTION
Adds a line to the tooltip that displays the age of evolution items
<img width="2560" height="1440" alt="2026-01-06_02 36 54" src="https://github.com/user-attachments/assets/6678b22d-253a-4993-803a-7c3bac7dbae3" />
