### PR TITLE
Delay Blood Room Completion for Score Calculation

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/DungeonScore.java
@@ -354,7 +354,7 @@ public class DungeonScore {
 			Scheduler.INSTANCE.schedule(() -> {
 				bloodRoomCompleted = true;
 				tick();
-			}, 20*5+10);
+			}, 20 * 5 + 10);
 		}
 	}
 


### PR DESCRIPTION
The chat message is sent a few seconds before the blood room is actually considered completed.

