### PR TITLE
Hide mirrorverse waypoints when outside of the mirrorverse

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/rift/MirrorverseWaypoints.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/rift/MirrorverseWaypoints.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.Area;
 import de.hysky.skyblocker.utils.ColorUtils;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.primitive.PrimitiveCollector;
@@ -65,8 +66,7 @@ public class MirrorverseWaypoints {
 	}
 
 	protected static void extractRendering(PrimitiveCollector collector) {
-		//I would also check for the mirrorverse location but the scoreboard stuff is not performant at all...
-		if (Utils.isInTheRift() && SkyblockerConfigManager.get().otherLocations.rift.mirrorverseWaypoints && waypointsLoaded.isDone()) {
+		if (Utils.isInTheRift() && Utils.getArea() == Area.TheRift.MIRRORVERSE && SkyblockerConfigManager.get().otherLocations.rift.mirrorverseWaypoints && waypointsLoaded.isDone()) {
 			for (Waypoint waypoint : LAVA_PATH_WAYPOINTS) {
 				waypoint.extractRendering(collector);
 			}


### PR DESCRIPTION
fixes #1895

<details>
<summary>Before this change</summary>
<img width="638" height="310" alt="image" src="https://github.com/user-attachments/assets/84e8231c-7764-4728-ae94-ce514a83bd6b" />
<img width="1417" height="894" alt="image" src="https://github.com/user-attachments/assets/2d088cbe-5797-4f96-af91-08f9df0760a2" />
</details>
<details>
<summary>After this change</summary>
<img width="582" height="314" alt="image" src="https://github.com/user-attachments/assets/eab6b4fc-76ea-47a0-953a-e7f4dd183def" />
<img width="948" height="557" alt="image" src="https://github.com/user-attachments/assets/d9178dab-e5a9-4404-ad7c-98550da7035d" />
</details>
<details>
<summary>Waypoints still show in the mirrorverse</summary>
<img width="1115" height="554" alt="image" src="https://github.com/user-attachments/assets/3192e714-b3a9-40c4-ab5d-4d06787a841e" />
<img width="860" height="407" alt="image" src="https://github.com/user-attachments/assets/e204ed6a-05d3-41ff-bb81-d02d83062a7a" />
</details>