### PR TITLE
fix: Allow empty values in DurationController to disable event notifications

### DIFF
--- a/src/main/java/de/hysky/skyblocker/utils/config/DurationController.java
+++ b/src/main/java/de/hysky/skyblocker/utils/config/DurationController.java
@@ -27,6 +27,7 @@ public class DurationController extends IntegerControllerImpl {
 	}
 
 	private static String toString(int duration) {
+		if (duration <= 0) return "";
 		return SkyblockTime.formatTime(duration).getString();
 	}
 
@@ -49,6 +50,9 @@ public class DurationController extends IntegerControllerImpl {
 	}
 
 	private static boolean isValid(String s) {
+		// Allow empty string to disable notifications
+		if (s.isBlank()) return true;
+
 		Matcher hoursMatcher = hoursPattern.matcher(s);
 		Matcher minutesMatcher = minutesPattern.matcher(s);
 		Matcher secondsMatcher = secondsPattern.matcher(s);


### PR DESCRIPTION
- Modify toString() to return empty string for duration <= 0
- Modify isValid() to accept blank strings as valid input
- This allows users to clear text boxes to disable notifications as documented in the tooltip

Fixes #2148 