### PR TITLE
Check for item count in composter for NPC/bazaar prices

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
@@ -22,7 +22,7 @@ public class BazaarPriceTooltip extends SimpleTooltipAdder {
 		String skyblockApiId = stack.getSkyblockApiId();
 
 		if (TooltipInfoType.BAZAAR.hasOrNullWarning(skyblockApiId)) {
-			int count = Math.max(ItemUtils.getItemCountInSack(stack, stack.skyblocker$getLoreStrings()).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(ItemUtils.getItemCountInSuperpairs(stack).orElse(stack.getCount()))), 1);
+			int count = Math.max(ItemUtils.getItemCountInSack(stack, stack.skyblocker$getLoreStrings()).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(ItemUtils.getItemCountInSuperpairs(stack).orElse(ItemUtils.getCompostCountInComposter(stack.skyblocker$getLoreStrings()).orElse(stack.getCount())))), 1);
 
 			BazaarProduct product = TooltipInfoType.BAZAAR.getData().get(skyblockApiId);
 			lines.add(Component.literal(String.format("%-18s", "Bazaar Buy Price:"))

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
@@ -33,7 +33,7 @@ public class NpcPriceTooltip extends SimpleTooltipAdder {
 		double price = TooltipInfoType.NPC.getData().getOrDefault(internalID, -1); // The original default return value of 0 can be an actual price, so we use a value that can't be a price
 		if (price < 0) return;
 
-		int count = Math.max(ItemUtils.getItemCountInSack(stack, stack.skyblocker$getLoreStrings()).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
+		int count = Math.max(ItemUtils.getItemCountInSack(stack, stack.skyblocker$getLoreStrings()).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(ItemUtils.getCompostCountInComposter(stack.skyblocker$getLoreStrings()).orElse(stack.getCount()))), 1);
 
 		lines.add(Component.literal(String.format("%-21s", "NPC Sell Price:"))
 					.withStyle(ChatFormatting.YELLOW)

--- a/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ItemUtils.java
@@ -85,6 +85,7 @@ public final class ItemUtils {
 	private static final Pattern STORED_PATTERN = Pattern.compile("Stored: ([\\d,]+)/\\S+");
 	private static final Pattern GEMSTONES_SACK_AMOUNT_PATTERN = Pattern.compile(" Amount: ([\\d,]+)");
 	private static final Pattern STASH_COUNT_PATTERN = Pattern.compile("x([\\d,]+)$"); // This is used with Matcher#find, not #matches
+	private static final Pattern COMPOSTER_COUNT_PATTERN = Pattern.compile("Compost Available: ([\\d,]+)");
 	private static final Pattern HUNTING_BOX_COUNT_PATTERN = Pattern.compile("Owned: (?<shards>[\\d,]+) Shards?");
 	private static final short LOG_INTERVAL = 1000;
 	private static long lastLog = Util.getMillis();
@@ -633,6 +634,16 @@ public final class ItemUtils {
 	 */
 	public static OptionalInt getItemCountInStash(Component itemName) {
 		return RegexUtils.findIntFromMatcher(STASH_COUNT_PATTERN.matcher(itemName.getString()));
+	}
+
+	/**
+	 * Finds and returns the number of compost stored in the composter.
+	 * For all other items, returns empty.
+	 */
+	public static OptionalInt getCompostCountInComposter(List<String> lines) {
+		Matcher matcher = RegexListUtils.matchInList(lines, COMPOSTER_COUNT_PATTERN);
+
+		return matcher != null ? RegexUtils.parseOptionalIntFromMatcher(matcher, 1) : OptionalInt.empty();
 	}
 
 	/**


### PR DESCRIPTION
Currently, the composter just displays the prices for the stack size shown (up to 64).

Updated:
<img width="858" height="412" alt="image" src="https://github.com/user-attachments/assets/2b284c40-a47b-4b55-baf5-b14a50ae202a" />

Not sure if there is a better place to put this check than the Math#max in the bazaar/npc tooltip, but that's the best I found