### PR TITLE
Enable sweep details widget in foraging camp

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/SweepDetailsHudWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/SweepDetailsHudWidget.java
@@ -43,8 +43,8 @@ public class SweepDetailsHudWidget extends ComponentBasedWidget {
 
 	@Override
 	public boolean shouldRender(Location location) {
-		// While in the hub only show in the forest
-		return (!Utils.getLocation().equals(Location.HUB) || Utils.getArea() == Area.Hub.FOREST)
+		// While in the hub only show in the forest and foraging camp
+		return (!Utils.getLocation().equals(Location.HUB) || Utils.getArea() == Area.Hub.FOREST || Utils.getArea() == Area.Hub.FORAGING_CAMP)
 			// While in the garden only show in unclean plots
 			&& (!Utils.getLocation().equals(Location.GARDEN) || Utils.STRING_SCOREBOARD.stream().anyMatch(s -> s.contains("Cleanup")))
 			&& super.shouldRender(location);

--- a/src/main/java/de/hysky/skyblocker/utils/Area.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Area.java
@@ -64,6 +64,7 @@ public sealed interface Area {
 		BANK("Bank"),
 		BAZAAR("Bazaar Alley"),
 		CARNIVAL("Carnival"),
+		FORAGING_CAMP("Foraging Camp"),
 		FOREST("Forest");
 
 		private final String displayName;


### PR DESCRIPTION
There are a couple logs there too, and it just feels jarring that the widget disables in a *sub*area.