### PR TITLE
fix: Handle enchantment book ids in bazaar

### DIFF
--- a/src/main/java/de/hysky/skyblocker/utils/EnchantedBookUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/EnchantedBookUtils.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 public final class EnchantedBookUtils {
 	public static String getApiIdByName(Component enchantName) {
 		String name = enchantName.getString().toUpperCase(Locale.ENGLISH);
-		name = name.replace("BUY ", "").replace("SELL ", "").replace("'", "");
+		name = name.replace("BUY ", "").replace("SELL ", "").replace("'", "").replace("-", "_");
 
 		String[] parts = name.split(" ");
 		if (parts.length == 0) return "";


### PR DESCRIPTION
Issue: Fixes https://github.com/SkyblockerMod/Skyblocker/issues/2087

Cause: Skyblock ids for enchantment books have a dash (-) instead of an underscore (_) in the bazaar but not in their inventory ids. This affects all enchantment books including Counter-Strike and Turbo-Wheat. Example:
```
In the bazaar:
skyblockApiId='ENCHANTMENT_TURBO-CANE_1' bazaarHas=false

In inventory:
skyblockApiId='ENCHANTMENT_TURBO_CANE_1' bazaarHas=true

Other item in bazaar:
skyblockApiId='HALF_EATEN_MUSHROOM' bazaarHas=true
```
Other items such a Bo-omb are already formatted with underscores in their id correctly.

Fix: In the tooltip, replace a dash with an underscore before searching to see if bazaar data exists for the item.

Testing: Used DevAuth in run/mods/ folder with Prism client and `./gradlew runClient`. Saw expected bazaar prices from Turbo-Wheat books and no modification in existing items with a dash in the name.
<img width="3024" height="1890" alt="2026-03-02_18 05 16" src="https://github.com/user-attachments/assets/4f0702e7-1a46-407f-a474-7fc8ce15e6a2" />
<img width="3024" height="1890" alt="2026-03-02_18 05 35" src="https://github.com/user-attachments/assets/69f80f92-809b-4fbe-a3b3-cc67f776f628" />
