### PR TITLE
Add pelt animal glow

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/OtherLocationsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/OtherLocationsCategory.java
@@ -56,6 +56,13 @@ public class OtherLocationsCategory {
 										newValue -> config.otherLocations.barn.enableCallTrevorMessage = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.otherLocations.barn.enablePeltAnimalHighlighter"))
+								.binding(defaults.otherLocations.barn.enablePeltAnimalHighlighter,
+										() -> config.otherLocations.barn.enablePeltAnimalHighlighter,
+										newValue -> config.otherLocations.barn.enablePeltAnimalHighlighter = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.build())
 
 				//The Rift

--- a/src/main/java/de/hysky/skyblocker/config/configs/OtherLocationsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/OtherLocationsConfig.java
@@ -19,6 +19,8 @@ public class OtherLocationsConfig {
 		public boolean solveTreasureHunter = true;
 
 		public boolean enableCallTrevorMessage = true;
+
+		public boolean enablePeltAnimalHighlighter = true;
 	}
 
 	public static class Rift {

--- a/src/main/java/de/hysky/skyblocker/skyblock/entity/glow/adder/MushroomDesertGlowAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/entity/glow/adder/MushroomDesertGlowAdder.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.skyblock.entity.glow.adder;
 
 import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.entity.MobGlowAdder;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.skyblock.entity.MobGlow;
@@ -27,21 +28,25 @@ public class MushroomDesertGlowAdder extends MobGlowAdder {
 
 	@Override
 	public int computeColour(Entity entity) {
+		if (!SkyblockerConfigManager.get().otherLocations.barn.enablePeltAnimalHighlighter) {
+			return NO_GLOW;
+		}
+
 		String name = MobGlow.getArmorStandName(entity);
 
 		return switch (entity) {
-			case Cow cow when isPeltMob(name, "Cow") -> getGlowColor(name);
-			case Pig pig when isPeltMob(name, "Pig") -> getGlowColor(name);
-			case Sheep sheep when isPeltMob(name, "Sheep") -> getGlowColor(name);
-			case Rabbit rabbit when isPeltMob(name, "Rabbit") -> getGlowColor(name);
-			case Chicken chicken when isPeltMob(name, "Chicken") -> getGlowColor(name);
-			case Horse horse when isPeltMob(name, "Horse") -> getGlowColor(name);
+			case Cow cow when isPeltAnimal(name, "Cow") -> getGlowColor(name);
+			case Pig pig when isPeltAnimal(name, "Pig") -> getGlowColor(name);
+			case Sheep sheep when isPeltAnimal(name, "Sheep") -> getGlowColor(name);
+			case Rabbit rabbit when isPeltAnimal(name, "Rabbit") -> getGlowColor(name);
+			case Chicken chicken when isPeltAnimal(name, "Chicken") -> getGlowColor(name);
+			case Horse horse when isPeltAnimal(name, "Horse") -> getGlowColor(name);
 			default -> NO_GLOW;
 		};
 	}
 
-	// Checks if the name follows the pelt mob naming convention
-	private static boolean isPeltMob(String name, String animal) {
+	// Checks if the name follows the pelt animal naming convention
+	private static boolean isPeltAnimal(String name, String animal) {
 		return name.contains("Trackable " + animal)
 				|| name.contains("Untrackable " + animal)
 				|| name.contains("Undetected " + animal)

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -956,6 +956,7 @@
   "skyblocker.config.otherLocations.barn.callTrevor.@Tooltip": "Adds a message in chat to quickly call Trevor after completing a trapping task.\n\nThis requires having him as an Abiphone contact, and an Abiphone in your inventory!",
   "skyblocker.config.otherLocations.barn.callTrevor.message": "Click here to call Trevor the Trapper!",
   "skyblocker.config.otherLocations.barn.enableGlowingMushroomHelper": "Enable Glowing Mushroom Helper",
+  "skyblocker.config.otherLocations.barn.enablePeltAnimalHighlighter": "Enable Pelt Animal Highlighter",
   "skyblocker.config.otherLocations.barn.solveHungryHiker": "Solve Hungry Hiker",
   "skyblocker.config.otherLocations.barn.solveTreasureHunter": "Solve Treasure Hunter",
 


### PR DESCRIPTION
<img width="2560" height="1227" alt="image" src="https://github.com/user-attachments/assets/464f466b-2827-4971-81cb-cef82dd45e8f" />

Tested it for a bit, didn't see the elusive type or a horse but all the others worked.
The glow doesn't get added if you are far away, I think because the armor stand doesn't get spawned until you are close?
Glow colors are set to the rarity colors right now, but maybe I should change it so it is based on the animal type for visibility reasons (white on a white sheep isn't very clear)?