### PR TITLE
Enable javac lints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,7 @@ tasks.withType(ProcessResources).configureEach {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.release = 21
+	it.options.compilerArgs += '-Xlint:all,-this-escape'
 }
 
 java {


### PR DESCRIPTION
Turns vague summary of warnings into detailed list of all warnings during the Gradle build.

<details>
<summary>before</summary>

```java
> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: src/main/java/de/hysky/skyblocker/utils/render/gui/special/EquipmentGuiElementRenderer.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

</details>

<details>
<summary>after</summary>

```java
> Task :compileJava
src/main/java/de/hysky/skyblocker/skyblock/chat/SackMessagePrice.java:163: warning: [deprecation] startsWithAny(CharSequence,CharSequence...) in StringUtils has been deprecated
                                        && StringUtils.startsWithAny(rootContent, "Added items:", "Removed items:")) {
                                                      ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/CroesusProfit.java:164: warning: [lossy-conversions] implicit cast from float to int in compound assignment is possibly lossy
                                                                amount *= ChestValue.computeCrimsonEssenceMultiplier();
                                                                                                                    ^
src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java:184: warning: [deprecation] builtInRegistryHolder() in Item has been deprecated
                                if (ClientTags.isInLocal(ConventionalItemTags.GLASS_PANES, item.getItem().builtInRegistryHolder().key())) {
                                                                                                         ^
src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfo.java:37: warning: [varargs] Varargs method could cause heap pollution from non-reifiable varargs parameter callbacks
                this.callbacks = callbacks;
                                 ^
src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/TooltipInfoType.java:56: warning: [overloads] <T#1>ofData(String,Codec<T#1>,boolean,BiPredicate<T#1,String>,Predicate<ItemTooltip>,Predicate<ItemTooltip>,Consumer<T#1>...) in TooltipInfoType is potentially ambiguous with <T#2>ofData(String,Codec<T#2>,boolean,BiPredicate<T#2,String>,Predicate<ItemTooltip>,Consumer<T#2>...) in TooltipInfoType
        private static <T> DataTooltipInfoType<T> ofData(String address, Codec<T> codec, boolean cacheable, BiPredicate<T, String> contains, Predicate<GeneralConfig.ItemTooltip> tooltipEnabled, Predicate<GeneralConfig.ItemTooltip> dataEnabled, Consumer<T>... callbacks) {
                                                  ^
  where T#1,T#2 are type-variables:
    T#1 extends Object declared in method <T#1>ofData(String,Codec<T#1>,boolean,BiPredicate<T#1,String>,Predicate<ItemTooltip>,Predicate<ItemTooltip>,Consumer<T#1>...)
    T#2 extends Object declared in method <T#2>ofData(String,Codec<T#2>,boolean,BiPredicate<T#2,String>,Predicate<ItemTooltip>,Consumer<T#2>...)
src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/TooltipInfoType.java:52: warning: [varargs] Varargs method could cause heap pollution from non-reifiable varargs parameter callbacks
                return ofData(address, codec, cacheable, contains, tooltipEnabled, tooltipEnabled, callbacks);
                                                                                                   ^
src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/TooltipInfoType.java:57: warning: [varargs] Varargs method could cause heap pollution from non-reifiable varargs parameter callbacks
                return new DataTooltipInfo<>(address, codec, cacheable, contains, tooltipEnabled, dataEnabled, callbacks);
                                                                                                               ^
src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java:95: warning: [rawtypes] found raw type: DataTooltipInfoType
                                        .map(DataTooltipInfoType::downloadIfEnabled)
                                             ^
  missing type arguments for generic class DataTooltipInfoType<T>
  where T is a type-variable:
    T extends Object declared in interface DataTooltipInfoType
src/main/java/de/hysky/skyblocker/skyblock/hunting/AttributesDebug.java:93: warning: [rawtypes] found raw type: AbstractContainerScreen
                if (CLIENT.screen instanceof AbstractContainerScreen screen && screen.getTitle().getString().equals("Attribute Menu")) {
                                             ^
  missing type arguments for generic class AbstractContainerScreen<T>
  where T is a type-variable:
    T extends AbstractContainerMenu declared in class AbstractContainerScreen
src/main/java/de/hysky/skyblocker/utils/render/gui/special/EquipmentGuiElementRenderer.java:28: warning: [unchecked] getRenderStateClass() in EquipmentGuiElementRenderer overrides getRenderStateClass() in PictureInPictureRenderer
        public Class getRenderStateClass() {
                     ^
  return type requires unchecked conversion from Class to Class<EquipmentGuiElementRenderState<S>>
  where T,S are type-variables:
    T extends PictureInPictureRenderState declared in class PictureInPictureRenderer
    S extends Object declared in class EquipmentGuiElementRenderer
src/main/java/de/hysky/skyblocker/utils/Calculator.java:382: warning: [serial] non-transient instance field of a serializable class declared with an array having a non-serializable base component type Object
                public final Object[] args;
                                      ^
src/main/java/de/hysky/skyblocker/utils/command/argumenttypes/color/HexColorArgumentType.java:20: warning: [deprecation] startsWithIgnoreCase(CharSequence,CharSequence) in StringUtils has been deprecated
                if (StringUtils.startsWithIgnoreCase(input, "0x")) input = input.substring(2);
                               ^
src/main/java/de/hysky/skyblocker/utils/command/argumenttypes/blockpos/ClientBlockPosArgumentType.java:37: warning: [deprecation] hasChunkAt(BlockPos) in LevelReader has been deprecated
                if (!world.hasChunkAt(blockPos)) throw ERROR_NOT_LOADED.create();
                          ^
src/main/java/de/hysky/skyblocker/utils/ItemUtils.java:600: warning: [deprecation] endsWithAny(CharSequence,CharSequence...) in StringUtils has been deprecated
                if (lines.size() < 2 || !StringUtils.endsWithAny(lines.getFirst(), "Sack", "Gemstones")) {
                                                    ^
14 warnings
```

</details>

Most of these warnings seem genuine things to fix to improve code quality so I think they were not covered already by other linters like spotless in the gradle build, so I think this is a good change but please let me know if otherwise.

<details>
<summary>Explanation of the warnings</summary>

The warnings can be fixed slowly in other prs or commits by others, most ones are easy. For example, StringUtils deprecations can be solved by reading the javadocs and migrating to the apporiate replacement. The `world.hasChunkAt(blockPos)` deprecation might be similarly replaced to solve its deprecation. The lossy-conversions from float to int can be fixed with an explicit cast to show intent or enhanced to use the full float in the feature. Varargs warnings may be fixed with the help of `@SafeVarargs` annotation. Overload ambuigity warnings can be fixed by casting a parameter or return value to clarify which method to pick during overload resolution to javac. Rawtypes can be fixed by filling with `<?>` or `<T>`, or an actual type depending on context. The only unchecked warning seems to also result from a non `@Override` annotated method overriding a method with a raw-type of `Class` whereas the overridden method expected `Class<EquipmentGuiElementRenderState<S>>`. These erase to the same return type `Class` so it is ambigious to javac which generates the unchecked warning. The serial warning can be fixed by either marking the field as `transient` to not use it during serialization or replace the generic `Object[]` type with a type that implements `Serializable` interface.

</details>

I have disabled the `this-escape` warning by default though as that lint was giving lots of violations (see below). Not sure why, but Skyblocker codebase seems to trigger that lint a lot. I felt like that warning was superflous as most likely everything would be fine, but feel free to enable it later.

<details>
<summary>this-escape warnings (most probably superflous)</summary>

```
> Task :compileJava
src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java:126: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                possibleRooms = getPossibleRooms(segmentsX, segmentsY);
                                                ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/Room.java:209: warning: [this-escape] previous possible 'this' escape happens here via invocation
                for (Direction direction : getPossibleDirections(segmentsX, segmentsY)) {
                                                                ^
src/main/java/de/hysky/skyblocker/skyblock/quicknav/QuickNavButton.java:97: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        setTooltip(tip = Tooltip.create(ComponentSerialization.CODEC.decode(JsonOps.INSTANCE, SkyblockerMod.GSON.fromJson(tooltip, JsonElement.class)).getOrThrow().getFirst()));
                                  ^
src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRulesConfigListWidget.java:31: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                updateEntries();
                             ^
src/main/java/de/hysky/skyblocker/skyblock/chat/ChatRuleConfigScreen.java:79: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        private final HeaderAndFooterLayout layout = new HeaderAndFooterLayout(this);
                                                                               ^
src/main/java/de/hysky/skyblocker/skyblock/dwarven/PickobulusHudWidget.java:24: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                update();
                      ^
src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/corpse/RewardList.java:40: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        addEntry(new SingleEntry(Component.translatable("skyblocker.corpseTracker.emptyHistory").withStyle(ChatFormatting.RED), false));
                                ^
src/main/java/de/hysky/skyblocker/skyblock/dwarven/profittrackers/corpse/CorpseList.java:38: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        addEntry(new CorpseList.SingleEntry(Component.literal("Your corpse history list is empty :(").withStyle(ChatFormatting.RED), false));
                                ^
src/main/java/de/hysky/skyblocker/skyblock/fancybars/EditBarWidget.java:54: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                iconOption = new EnumCyclingOption<>(0, 11, getWidth(), translatable, StatusBar.IconPosition.class);
                                                                    ^
src/main/java/de/hysky/skyblocker/skyblock/entity/MobGlowAdder.java:9: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                MobGlow.registerGlowAdder(this);
                                          ^
src/main/java/de/hysky/skyblocker/skyblock/museum/MuseumManager.java:67: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.searchField = new EditBox(TEXT_RENDERER, getX() + 25, getY() + 11, 69, 20, Component.empty());
                                                                  ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/preview/PreviewRoom.java:32: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                loadSecrets();
                           ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/TerminalHud.java:36: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                Scheduler.INSTANCE.scheduleCyclic(this::updateFromScheduler, 50);
                                                  ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/OptionDropdownWidget.java:40: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                setX(x);
                    ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/RangedValueWidget.java:45: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                input.setResponder(this::updateConfirmButton);
                                   ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/DungeonPuzzle.java:31: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                DungeonEvents.PUZZLE_MATCHED.register(room -> {
                                                      ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/Trivia.java:55: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                ClientReceiveMessageEvents.ALLOW_GAME.register(this::onMessage);
                                                               ^
src/main/java/de/hysky/skyblocker/skyblock/dungeon/LeapOverlay.java:66: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                handler.addSlotListener(this);
                                        ^
src/main/java/de/hysky/skyblocker/skyblock/end/EndHudWidget.java:36: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.update();
                           ^
src/main/java/de/hysky/skyblocker/skyblock/galatea/SweepDetailsHudWidget.java:41: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                update();
                      ^
src/main/java/de/hysky/skyblocker/skyblock/galatea/TreeBreakProgressHud.java:40: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                update();
                      ^
src/main/java/de/hysky/skyblocker/skyblock/itemlist/recipebook/SkyblockRecipeResultButton.java:30: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                setPosition(x, y);
                           ^
src/main/java/de/hysky/skyblocker/skyblock/itemlist/recipebook/SkyblockRecipeTabButton.java:20: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.initTextureValues(RecipeBookTabButton.SPRITES);
                                      ^
src/main/java/de/hysky/skyblocker/skyblock/itemlist/recipebook/SkyblockRecipeBookWidget.java:46: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        new SkyblockCraftingTab(this, SkyblockCraftingTab.CRAFTING_TABLE, new SkyblockRecipeResults()),
                                                ^
src/main/java/de/hysky/skyblocker/utils/render/gui/CyclingTextureWidget.java:37: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.setTooltip(tooltipSupplier.apply(initial));
                               ^
src/main/java/de/hysky/skyblocker/utils/render/gui/AbstractCustomHypixelGUI.java:20: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                handler.addSlotListener(this);
                                        ^
src/main/java/de/hysky/skyblocker/utils/render/gui/SideTabButtonWidget.java:22: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                initTextureValues(TEXTURES);
                                 ^
src/main/java/de/hysky/skyblocker/skyblock/auction/AuctionViewScreen.java:57: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                isBinAuction = this.getTitle().getString().toLowerCase(Locale.ENGLISH).contains("bin");
                                            ^
src/main/java/de/hysky/skyblocker/skyblock/garden/FarmingHudWidget.java:81: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                update();
                      ^
src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlotsWidget.java:116: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                                getX() + 7, getBottom() - 24,
                                    ^
src/main/java/de/hysky/skyblocker/utils/render/gui/ItemButtonWidget.java:18: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                setTooltip(Tooltip.create(message));
                          ^
src/main/java/de/hysky/skyblocker/skyblock/slayers/SlayerHudWidget.java:30: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                update();
                      ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerTextWidget.java:51: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.MAGICAL_POWER = getMagicalPower(playerProfile);
                                                    ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerScreen.java:79: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                fetchPlayerData(username).thenRun(this::initialisePagesAndWidgets).exceptionally(err -> {
                                                  ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/collections/CollectionsPage.java:41: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                                collectionSelectButtons.add(new SubPageSelectButton(this, -100, 0, i, ICON_MAP.getOrDefault(COLLECTION_CATEGORIES[i], Ico.BARRIER)));
                                                                                    ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/Inventory.java:37: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        private final PaginationButton previousPage = new PaginationButton(this, -1000, 0, false);
                                                                           ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/Inventory.java:38: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        private final PaginationButton nextPage = new PaginationButton(this, -1000, 0, true);
                                                                       ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/Pet.java:60: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.icon = createIcon();
                                      ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/Pet.java:99: warning: [this-escape] previous possible 'this' escape happens here via invocation
                String targetItemId = this.getName() + ";" + (this.getTier() + (heldItem.isPresent() && heldItem.get().equals("PET_ITEM_TIER_BOOST") ? 1 : 0));
                                                                          ^
src/main/java/de/hysky/skyblocker/skyblock/profileviewer/inventory/InventoryPage.java:43: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        inventorySelectButtons.add(new SubPageSelectButton(this, -100, 0, i, ICON_MAP.getOrDefault(INVENTORY_PAGES[i], Ico.BARRIER)));
                                                                           ^
src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java:128: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        ((ScreenAccessor) this).setTitle(Component.literal(SkyblockerConfigManager.get().quickNav.enableQuickNav ? "InventoryScreenEquipmentQuickNavSkyblocker" : "InventoryScreenEquipmentSkyblocker"));
                                                        ^
src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/TrimSelectionWidget.java:71: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                positionButtons(width, height);
                               ^
src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/TrimSelectionWidget.java:86: warning: [this-escape] previous possible 'this' escape happens here via invocation
                int maxHeight = getHeight() - PADDING * 2;
                                         ^
src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/HeadSelectionWidget.java:54: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.searchField.setResponder(this::filterButtons);
                                              ^
src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/CustomizeScreen.java:52: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        private final TabManager tabManager = new TabManager(this::addRenderableWidget, this::removeWidget);
                                                             ^
src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/ColorSelectionWidget.java:88: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                timelineWidget = new AnimatedDyeTimelineWidget(0, 0, getWidth() - 6, 15, this::onTimelineFrameSelected);
                                                                             ^
src/main/java/de/hysky/skyblocker/utils/render/gui/ColorPickerWidget.java:81: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                updateRects();
                           ^
src/main/java/de/hysky/skyblocker/utils/render/gui/ColorPickerWidget.java:96: warning: [this-escape] previous possible 'this' escape happens here via invocation
                int y = getBottom();
                                 ^
src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/name/CustomizeNameWidget.java:90: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                builder.add(grid.addChild(Button.builder(Component.translatable("skyblocker.customItemNames.screen.customColor"), b ->
                                                                                                                                  ^
src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/ItemTab.java:96: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                visitChildren(clickableWidget -> clickableWidget.visible = false);
                             ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/preview/PreviewTab.java:78: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                previewWidget = new PreviewWidget(this);
                                                  ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsConfigurationScreen.java:86: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        private final TabManager tabManager = new TabManager(this::addRenderableWidget, this::removeWidget);
                                                             ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsConfigurationScreen.java:144: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this(handler, titleLowercase, Location.UNKNOWN, null);
                    ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsConfigurationScreen.java:128: warning: [this-escape] previous possible 'this' escape happens here via invocation
                        this.handler.addSlotListener(this);
                                                     ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsConfigurationScreen.java:154: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this(null, "", targetLocation, WidgetManager.getScreenBuilder(targetLocation).getPositionRuleOrDefault(widgetLayerToGoTo).screenLayer());
                    ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsConfigurationScreen.java:128: warning: [this-escape] previous possible 'this' escape happens here via invocation
                        this.handler.addSlotListener(this);
                                                     ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsConfigurationScreen.java:165: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this(null, "", targetLocation, layerToGo);
                    ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsConfigurationScreen.java:128: warning: [this-escape] previous possible 'this' escape happens here via invocation
                        this.handler.addSlotListener(this);
                                                     ^
src/main/java/de/hysky/skyblocker/skyblock/tabhud/config/WidgetsListTab.java:74: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                widgetsElementList = new WidgetsElementList(this, client, 0, 0, 0);
                                                            ^
src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java:47: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        commandCategory.shortcutsMap.keySet().stream().sorted().forEach(commandTarget -> addEntry(new CommandShortcutEntry(commandCategory, commandTarget)));
                                                                                        ^
src/main/java/de/hysky/skyblocker/skyblock/radialMenu/RadialMenuScreen.java:52: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                handler.addSlotListener(this);
                                        ^
src/main/java/de/hysky/skyblocker/skyblock/speedpreset/SpeedPresetListWidget.java:33: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                addEntry(new TitleEntry());
                        ^
src/main/java/de/hysky/skyblocker/skyblock/speedpreset/SpeedPresetListWidget.java:137: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                        this.removeButton = Button.builder(Component.literal("-"), btn -> SpeedPresetListWidget.this.removeEntry(this))
                                                                                   ^
src/main/java/de/hysky/skyblocker/skyblock/waypoint/AbstractWaypointsScreen.java:42: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        protected final HeaderAndFooterLayout layout = new HeaderAndFooterLayout(this);
                                                                                 ^
src/main/java/de/hysky/skyblocker/utils/waypoint/WaypointGroup.java:68: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                this.waypoints = waypoints.stream().map(this::convertWaypoint).collect(Collectors.toList());
                                                        ^
src/main/java/de/hysky/skyblocker/skyblock/waypoint/WaypointsListWidget.java:70: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                setIsland(screen.island);
                         ^
src/main/java/de/hysky/skyblocker/skyblock/waypoint/WaypointsOptionScreen.java:27: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        private final HeaderAndFooterLayout layout = new HeaderAndFooterLayout(this);
                                                                               ^
src/main/java/de/hysky/skyblocker/utils/render/gui/RangedSliderWidget.java:28: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                setValue(defaultValue);
                        ^
src/main/java/de/hysky/skyblocker/utils/render/gui/SearchableGridWidget.java:34: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                searchField.setResponder(this::filterInternal);
                                         ^
src/main/java/de/hysky/skyblocker/utils/render/gui/CyclingIconButtonWidget.java:40: warning: [this-escape] possible 'this' escape before subclass is fully initialized
                setTooltip(tooltipFactory.apply(value));
                          ^
70 warnings
```

</details>

As said, they are most probably superflous and do not cause any issues, but if the code relies on a state initialized by the subclass, the escaped this reference might indeed be unsafe as warned by javac.

I have not added `-Werror` argument, but once all warnings are fixed, that can be added to fail the build if any warnings occur, which would require fixing them early to not pile up the warnings again.