### PR TITLE
Change VacuumCache to ScreenEvents#remove

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/VacuumCache.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/VacuumCache.java
@@ -25,42 +25,42 @@ public class VacuumCache {
 		CACHED_VINYL.load();
 
 		ScreenEvents.BEFORE_INIT.register((_client, screen, _scaledWidth, _scaledHeight) -> {
-			if (Utils.isOnSkyblock() && screen instanceof ContainerScreen genericContainerScreen) {
-				if (genericContainerScreen.getTitle().getString().startsWith("Stereo Harmony")) {
-					ScreenEvents.afterTick(screen).register(screen1 -> {
-						for (Slot slot : genericContainerScreen.getMenu().slots) {
-							ItemStack stack = slot.getItem();
-
-							if (!stack.isEmpty() && ItemUtils.getLoreLineIf(stack, line -> line.equals("Click to stop playing!")) != null) {
-								setVinyl(stack.getSkyblockId());
-
-								return;
-							}
-						}
-
-						setVinyl("");
-					});
-				}
+			if (!Utils.isOnSkyblock() || !(screen instanceof ContainerScreen containerScreen)) {
+				return;
 			}
+
+			if (!containerScreen.getTitle().getString().equals("Stereo Harmony")) {
+				return;
+			}
+
+			ScreenEvents.remove(screen).register(_screen -> VacuumCache.update(containerScreen));
 		});
+	}
+
+	private static void update(ContainerScreen containerScreen) {
+		for (Slot slot : containerScreen.getMenu().slots) {
+			ItemStack stack = slot.getItem();
+
+			if (!stack.isEmpty() && ItemUtils.getLoreLineIf(stack, line -> line.equals("Click to stop playing!")) != null) {
+				setVinyl(stack.getSkyblockId());
+
+				return;
+			}
+		}
+
+		setVinyl("");
 	}
 
 	private static void setVinyl(String skyblockId) {
 		if (Utils.getProfileId().isEmpty()) return;
 
 		if (skyblockId.isEmpty()) {
-			if (!getVinyl().isEmpty()) {
-				CACHED_VINYL.remove();
-				CACHED_VINYL.save();
-			}
+			CACHED_VINYL.remove();
 		} else {
-			String current = getVinyl();
-
-			if (!current.equals(skyblockId)) {
-				CACHED_VINYL.put(skyblockId);
-				CACHED_VINYL.save();
-			}
+			CACHED_VINYL.put(skyblockId);
 		}
+
+		CACHED_VINYL.save();
 	}
 
 	public static String getVinyl() {


### PR DESCRIPTION
See title (also thanks @viciscat for the advice), I tested this and everything works as intended. 

One thing worth noting is that [hypixel seems to resend the entire screen](https://discord.com/channels/879732108745125969/950163141482926111/1479208515305345034) whenever a vinyl is selected or deselected, causing `ScreenEvents#remove` to trigger early. This doesn't negatively affect the feature in any way (and this is still way better than scanning every item slot each tick).