### PR TITLE
Improve default mob highlight colors in Galatea

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/configs/HuntingConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/HuntingConfig.java
@@ -1,7 +1,6 @@
 package de.hysky.skyblocker.config.configs;
 
 import java.awt.Color;
-import net.minecraft.world.item.DyeColor;
 
 public class HuntingConfig {
 	public HuntingBox huntingBox = new HuntingBox();
@@ -18,11 +17,11 @@ public class HuntingConfig {
 		public boolean silencePhantoms = true;
 
 		public boolean highlightHideonleaf = true;
-		public Color hideonleafGlowColor = new Color(DyeColor.YELLOW.getTextColor(), false);
+		public Color hideonleafGlowColor = Color.decode("#2ECC40");
 		public boolean highlightShellwise = true;
-		public Color shellwiseGlowColor = new Color(DyeColor.ORANGE.getTextColor(), false);
+		public Color shellwiseGlowColor = Color.decode("#3D9970");
 		public boolean highlightCoralot = true;
-		public Color coralotGlowColor = new Color(DyeColor.BLUE.getTextColor(), false);
+		public Color coralotGlowColor = Color.decode("#F012BE");
 	}
 
 	public static class LassoHud {


### PR DESCRIPTION
The current default colors are a bit harsh and don't match the mobs whatsoever so this just changes them to softer colors that fit the mobs better.

Hideonleaf Color
<img width="137" height="136" alt="image" src="https://github.com/user-attachments/assets/2dd1cb43-b58e-4efc-8b39-9363a340f01a" />

Shellwise Color
<img width="345" height="180" alt="image" src="https://github.com/user-attachments/assets/4c1f92ed-069f-4f1f-97fa-fc3fcad6bf2a" />

Coralot Color
<img width="174" height="167" alt="image" src="https://github.com/user-attachments/assets/307e24d2-94a8-4e03-b5c2-a1f359d3992e" />

Note: Couldn't figure out how to reset colors to their default value so I didn't test this, neither moulconfig nor YACL allow you to do so. It's such a simple change that I *probably* don't need to though.