### PR TITLE
Remove fishing bobber timer after swapping to non-rod item

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/fishing/FishingHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fishing/FishingHelper.java
@@ -6,37 +6,55 @@ import de.hysky.skyblocker.config.configs.HelperConfig;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.title.Title;
 import de.hysky.skyblocker.utils.render.title.TitleContainer;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.decoration.ArmorStand;
-import net.minecraft.world.item.FishingRodItem;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 
 public class FishingHelper {
 	private static final Title title = new Title("skyblocker.fishing.reelNow", ChatFormatting.GREEN);
 	protected static long startTime;
 
+	private static final int BOBBER_TIMEOUT_TICKS = 10;
+	private static int waitingForBobberTicks = 0;
+
 	@Init
 	public static void init() {
+		// Initiate wait for bobber to appear server-side upon cast
 		UseItemCallback.EVENT.register((player, world, hand) -> {
 			ItemStack stack = player.getItemInHand(hand);
 			if (!Utils.isOnSkyblock()) {
 				return InteractionResult.PASS;
 			}
-			if (stack.getItem() instanceof FishingRodItem) {
+			if (stack.is(Items.FISHING_ROD)) {
 				if (player.fishing == null) {
-					start();
+					waitingForBobberTicks = BOBBER_TIMEOUT_TICKS;
 				} else {
+					waitingForBobberTicks = 0;
 					reset();
 				}
 			}
 			return InteractionResult.PASS;
 		});
-		ClientPlayConnectionEvents.JOIN.register((_cPL, _pS, _mc) -> reset());
+
+		// Start fishing bobber timer and remove timer when no bobber detected after server grace period
+		ClientTickEvents.END_CLIENT_TICK.register(client -> {
+			if (client.player != null) {
+				if (waitingForBobberTicks > 0) {
+					if (client.player.fishing != null) {
+						waitingForBobberTicks = 0;
+						start(); // only start timer when bobber confirmed
+					} else {
+						waitingForBobberTicks--;
+					}
+				} else if (client.player.fishing == null) reset();
+			}
+		});
 	}
 
 	public static void start() {


### PR DESCRIPTION
Issue: When rod swapping pets, the bobber timer persists even when no longer using a fishing rod.

Changes: 
- Upon rod cast, start a grace period timer to allow the server to mark the player as fishing and spawn a bobber
  - Check every tick to see if a bobber is present, and if so start the bobber timer
  - If the grace period is over, remove the bobber timer (this automatically handles weapons that are rods like Soul Whip)
- Remove reset on server-change as it is no longer needed

Testing: Verified the following scenarios
- Rod cast then swapping to drill removed bobber timer HUD
- Fishing up a sea creature, then casting and swapping to sword removes bobber timer but not sea creature HUD
- Quickly swapping from one rod to another does not remove bobber timer (for rod swapping to trophy fish Vanille)
- Changing servers removes bobber hud
- Swapping to rod weapon (Soul Whip) removes hud