### PR TITLE
Hide event toasts after event end

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/events/EventNotifications.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/events/EventNotifications.java
@@ -65,22 +65,34 @@ public class EventNotifications {
 
 	public static LiteralArgumentBuilder<FabricClientCommandSource> debugToasts() {
 		return ClientCommandManager.literal("toasts").then(
-				ClientCommandManager.argument("time", IntegerArgumentType.integer(0))
-						.then(ClientCommandManager.argument("jacob", BoolArgumentType.bool()).executes(context -> {
-											long time = System.currentTimeMillis() / 1000 + context.getArgument("time", int.class);
-											if (context.getArgument("jacob", Boolean.class)) {
-												Minecraft.getInstance().getToastManager().addToast(
-														new JacobEventToast(time, "Jacob's farming contest", List.of("Cactus", "Cocoa Beans", "Pumpkin"))
-												);
-											} else {
-												Minecraft.getInstance().getToastManager().addToast(
-														new EventToast(time, "Jacob's or something idk", new ItemStack(Items.PAPER))
-												);
-											}
-											return 0;
-										}
-								)
+				ClientCommandManager.argument("time", IntegerArgumentType.integer(0)).then(
+						ClientCommandManager.argument("duration", IntegerArgumentType.integer(0)).then(
+								ClientCommandManager.argument("jacob", BoolArgumentType.bool()).executes(context -> {
+									long time = System.currentTimeMillis() / 1000 + context.getArgument("time", int.class);
+									int duration = context.getArgument("duration", int.class);
+									if (context.getArgument("jacob", Boolean.class)) {
+										Minecraft.getInstance().getToastManager().addToast(
+												new JacobEventToast(
+														time,
+														time + duration,
+														"Jacob's farming contest",
+														List.of("Cactus", "Cocoa Beans", "Pumpkin")
+												)
+										);
+									} else {
+										Minecraft.getInstance().getToastManager().addToast(
+												new EventToast(
+														time,
+														time + duration,
+														"Jacob's or something idk",
+														new ItemStack(Items.PAPER)
+												)
+										);
+									}
+									return 0;
+								})
 						)
+				)
 		);
 	}
 
@@ -154,11 +166,21 @@ public class EventNotifications {
 					Minecraft instance = Minecraft.getInstance();
 					if (eventName.equals(JACOBS) && skyblockEvent.extras().left().isPresent()) {
 						instance.getToastManager().addToast(
-								new JacobEventToast(skyblockEvent.start(), eventName, skyblockEvent.extras().left().get())
+								new JacobEventToast(
+										skyblockEvent.start(),
+										skyblockEvent.start() + skyblockEvent.duration(),
+										eventName,
+										skyblockEvent.extras().left().get()
+								)
 						);
 					} else {
 						instance.getToastManager().addToast(
-								new EventToast(skyblockEvent.start(), eventName, eventIcons.getOrDefault(eventName, new ItemStack(Items.PAPER)))
+								new EventToast(
+										skyblockEvent.start(),
+										skyblockEvent.start() + skyblockEvent.duration(),
+										eventName,
+										eventIcons.getOrDefault(eventName, new ItemStack(Items.PAPER))
+								)
 						);
 					}
 					SoundEvent soundEvent = SkyblockerConfigManager.get().eventNotifications.reminderSound.getSoundEvent();

--- a/src/main/java/de/hysky/skyblocker/skyblock/events/EventToast.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/events/EventToast.java
@@ -22,6 +22,7 @@ public class EventToast implements Toast {
 
 	private long toastTime = 0;
 	private final long eventStartTime;
+	private final long eventEndTime;
 
 	protected final List<FormattedCharSequence> message;
 	protected final List<FormattedCharSequence> messageNow;
@@ -31,8 +32,10 @@ public class EventToast implements Toast {
 
 	protected boolean started;
 
-	public EventToast(long eventStartTime, String name, ItemStack icon) {
+	public EventToast(long eventStartTime, long eventEndTime, String name, ItemStack icon) {
 		this.eventStartTime = eventStartTime;
+		this.eventEndTime = eventEndTime;
+
 		MutableComponent formatted = Component.translatable("skyblocker.events.startsSoon", Component.literal(name).withStyle(ChatFormatting.YELLOW)).withStyle(ChatFormatting.WHITE);
 		Font renderer = Minecraft.getInstance().font;
 		message = renderer.split(formatted, 150);
@@ -43,8 +46,8 @@ public class EventToast implements Toast {
 		messageNowWidth = messageNow.stream().mapToInt(renderer::width).max().orElse(150);
 		this.icon = icon;
 		this.started = eventStartTime - System.currentTimeMillis() / 1000 < 0;
-
 	}
+
 	@Override
 	public void render(GuiGraphics context, Font textRenderer, long startTime) {
 		context.blitSprite(RenderPipelines.GUI_TEXTURED, TEXTURE, 0, 0, width(), height());
@@ -93,7 +96,9 @@ public class EventToast implements Toast {
 
 	@Override
 	public Visibility getWantedVisibility() {
-		return toastTime > 5_000 ? Visibility.HIDE : Visibility.SHOW;
+		long currentTime = System.currentTimeMillis() / 1000;
+		if (toastTime > 5_000 || currentTime > eventEndTime) return Visibility.HIDE;
+		return Visibility.SHOW;
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/events/JacobEventToast.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/events/JacobEventToast.java
@@ -22,8 +22,8 @@ public class JacobEventToast extends EventToast {
 	private static final Component CROPS = Component.translatable("skyblocker.events.crops");
 	private final int cropsWidth;
 
-	public JacobEventToast(long eventStartTime, String name, List<String> crops) {
-		super(eventStartTime, name, new ItemStack(Items.IRON_HOE));
+	public JacobEventToast(long eventStartTime, long eventEndTime, String name, List<String> crops) {
+		super(eventStartTime, eventEndTime, name, DEFAULT_ITEM);
 		this.crops = crops;
 		Font renderer = Minecraft.getInstance().font;
 		cropsWidth = renderer.width(CROPS);


### PR DESCRIPTION
Issue: Fixes https://github.com/SkyblockerMod/Skyblocker/issues/2216

Change:
- Change visibility of toast to HIDE if current time is after expected event end time
- Duration option for toast debug

Testing: Added duration to debug command and toast disappears as expected