### PR TITLE
Fix pickob not appearing in glacite lake

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PickobulusHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dwarven/PickobulusHelper.java
@@ -30,7 +30,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
-
 public class PickobulusHelper {
 	private static final Set<Block> CONVERT_INTO_BEDROCK_BLOCKS = Set.of(
 			Blocks.STONE,


### PR DESCRIPTION
Issue: PIckobulus helper does not appear in the great glacite lake

Change: Add Great Glacite Lake option to pickob helper logic

Testing: Pickob HUD and helper are displayed correctly while in great glacite lake
<img width="3024" height="1890" alt="2026-03-10_13 54 00" src="https://github.com/user-attachments/assets/9a55c85a-b3ad-4e01-9d24-5e3647a356df" />
