### PR TITLE
Trinity/Other Rare Rooms Alert

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -755,10 +755,12 @@ public class DungeonsCategory {
 								.build())
 						.build())
 
+				// Secret Sync
 				.group(OptionGroup.createBuilder()
 						.name(Component.translatable("skyblocker.config.dungeons.secretSync"))
 						.collapsed(true)
 						// TODO: Add description when labels work properly on MoulConfig
+						// Soon?
 						.option(Option.<Boolean>createBuilder()
 								.name(Component.translatable("skyblocker.config.dungeons.secretSync.receiveMatchedRooms"))
 								.tags(CommonTags.ADDED_IN_5_10_0)
@@ -781,6 +783,41 @@ public class DungeonsCategory {
 								.binding(defaults.dungeons.secretSync.hideReceivedWaypoints,
 										() -> config.dungeons.secretSync.hideReceivedWaypoints,
 										newValue -> config.dungeons.secretSync.hideReceivedWaypoints = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.build())
+
+				// Rare Room Alert
+				.group(OptionGroup.createBuilder()
+						.name(Component.translatable("skyblocker.config.dungeons.rareRoomAlert"))
+						.collapsed(true)
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.dungeons.rareRoomAlert.enabled"))
+								.description(Component.translatable("skyblocker.config.dungeons.rareRoomAlert.enabled.@Tooltip"))
+								.binding(defaults.dungeons.rareRoomAlert.enabled,
+										() -> config.dungeons.rareRoomAlert.enabled,
+										newValue -> config.dungeons.rareRoomAlert.enabled = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.dungeons.rareRoomAlert.showForTrinity"))
+								.binding(defaults.dungeons.rareRoomAlert.showForTrinity,
+										() -> config.dungeons.rareRoomAlert.showForTrinity,
+										newValue -> config.dungeons.rareRoomAlert.showForTrinity = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.dungeons.rareRoomAlert.showForTomioka"))
+								.binding(defaults.dungeons.rareRoomAlert.showForTomioka,
+										() -> config.dungeons.rareRoomAlert.showForTomioka,
+										newValue -> config.dungeons.rareRoomAlert.showForTomioka = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.dungeons.rareRoomAlert.showForDuncan"))
+								.binding(defaults.dungeons.rareRoomAlert.showForDuncan,
+										() -> config.dungeons.rareRoomAlert.showForDuncan,
+										newValue -> config.dungeons.rareRoomAlert.showForDuncan = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
 						.build())

--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -57,6 +57,8 @@ public class DungeonsConfig {
 
 	public SecretSync secretSync = new SecretSync();
 
+	public RareRoomAlert rareRoomAlert = new RareRoomAlert();
+
 	public MimicMessage mimicMessage = new MimicMessage();
 
 	public PrinceMessage princeMessage = new PrinceMessage();
@@ -248,6 +250,16 @@ public class DungeonsConfig {
 		public boolean receiveRoomSecretCount = true;
 
 		public boolean hideReceivedWaypoints = true;
+	}
+
+	public static class RareRoomAlert {
+		public boolean enabled = false;
+
+		public boolean showForTrinity = true;
+
+		public boolean showForTomioka = false;
+
+		public boolean showForDuncan = false;
 	}
 
 	public static class MimicMessage {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/RareRoomAlert.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/RareRoomAlert.java
@@ -1,0 +1,59 @@
+package de.hysky.skyblocker.skyblock.dungeon;
+
+import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.DungeonsConfig;
+import de.hysky.skyblocker.events.DungeonEvents;
+import de.hysky.skyblocker.skyblock.dungeon.secrets.DungeonManager;
+import de.hysky.skyblocker.utils.Constants;
+import de.hysky.skyblocker.utils.render.title.Title;
+import de.hysky.skyblocker.utils.render.title.TitleContainer;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+
+import java.util.Locale;
+import java.util.function.Supplier;
+
+public class RareRoomAlert {
+	private static final Minecraft CLIENT = Minecraft.getInstance();
+	private static final Supplier<DungeonsConfig.RareRoomAlert> CONFIG = () -> SkyblockerConfigManager.get().dungeons.rareRoomAlert;
+	private static final String TRINITY_ROOM_NAME = "trinity-4";
+	private static final String TOMIOKA_ROOM_NAME = "tomioka-0";
+	private static final String DUNCAN_ROOM_NAME = "duncan-1";
+
+	@Init
+	public static void init() {
+		DungeonEvents.ROOM_MATCHED.register(room -> {
+			if (!CONFIG.get().enabled) return;
+			String roomName = room.getName();
+			switch (roomName) {
+				case TRINITY_ROOM_NAME -> {
+					if (!CONFIG.get().showForTrinity) return;
+				}
+				case TOMIOKA_ROOM_NAME -> {
+					if (!CONFIG.get().showForTomioka) return;
+				}
+				case DUNCAN_ROOM_NAME -> {
+					if (!CONFIG.get().showForDuncan) return;
+				}
+				case null, default -> {
+					return;
+				}
+			}
+			showAlert(roomName);
+		});
+	}
+
+	private static void showAlert(String roomId) {
+		if (CLIENT.player == null) return;
+
+		var roomData = DungeonManager.getRoomMetadata(roomId);
+		String roomName = roomData != null ? roomData.name() : roomId;
+
+		TitleContainer.addTitle(new Title(Component.literal(roomName.toUpperCase(Locale.ENGLISH)).withStyle(ChatFormatting.LIGHT_PURPLE)), 100);
+		TitleContainer.playNotificationSound();
+
+		CLIENT.player.displayClientMessage(Constants.PREFIX.get().append(Component.translatable("skyblocker.dungeons.rareRoomAlert.foundRoom", roomName)), false);
+	}
+}

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -345,6 +345,13 @@
   "skyblocker.config.dungeons.puzzle.solveWaterboard": "Solve Waterboard Puzzle",
   "skyblocker.config.dungeons.puzzle.solveWaterboard.@Tooltip": "Click the indicated levers at the correct times to solve the puzzle.",
 
+  "skyblocker.config.dungeons.rareRoomAlert": "Rare Room Alert",
+  "skyblocker.config.dungeons.rareRoomAlert.enabled": "Enabled",
+  "skyblocker.config.dungeons.rareRoomAlert.enabled.@Tooltip": "Shows a title on screen and a message in chat when a rare room (below) is discovered by you or your party* in Dungeons.",
+  "skyblocker.config.dungeons.rareRoomAlert.showForDuncan": "Show for 'Duncan'",
+  "skyblocker.config.dungeons.rareRoomAlert.showForTomioka": "Show for 'Tomioka'",
+  "skyblocker.config.dungeons.rareRoomAlert.showForTrinity": "Show for 'Trinity'",
+
   "skyblocker.config.dungeons.salvageHelper": "Salvage Helper",
   "skyblocker.config.dungeons.salvageHelper.@Tooltip": "Highlights items picked up in dungeons that can be salvaged.",
   "skyblocker.config.dungeons.salvageHelper.onlyDonated": "Salvage Helper - Only Highlight Donated Items",
@@ -1539,6 +1546,7 @@
   "skyblocker.dungeons.puzzle.boulder.noSolution": "No solution found!",
   "skyblocker.dungeons.puzzle.waterboard.invalidDoors": "Doors are in an unrecognized state. Make sure exactly three doors are closed, then reset the solver.",
   "skyblocker.dungeons.puzzle.waterboard.waterFound": "Water must be toggled off or it will interfere with the solution. Turn the water off and let it drain, then reset the solver.",
+  "skyblocker.dungeons.rareRoomAlert.foundRoom": "Found rare room %s!",
   "skyblocker.dungeons.roomPreview.failedToLoad": "Failed to load room: %s",
   "skyblocker.dungeons.roomPreview.invalidRoom": "Invalid room!",
   "skyblocker.dungeons.roomPreview.joinMessage": "You are currently viewing %s.\nYou can fly around, modify your custom secret waypoints, and more!",


### PR DESCRIPTION
If enabled, it shows a title on screen and adds a message in chat.
Works for Trinity, Tomioka, and Duncan (individually toggled).

Useful for getting Abiphone contacts.