### PR TITLE
Remove waypoints for already found eggs

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
@@ -235,12 +235,11 @@ public class EggFinder {
 		}
 
 		public void onEggReceived() {
-			if (!SkyblockerConfigManager.get().helpers.chocolateFactory.sendEggFoundMessages) return;
 			if (collected) {
 				egg.setFound();
-				return;
+			} else if (SkyblockerConfigManager.get().helpers.chocolateFactory.sendEggFoundMessages) {
+				sendEggMessage();
 			}
-			sendEggMessage();
 		}
 
 		public void sendEggMessage() {


### PR DESCRIPTION
If the player has disabled chat messages showing them where the websocket supplied eggs are, the waypoints are always rendered regardless of whether the player has found them or not. This is because eggs create a waypoint by default, but the logic only stops rendering the waypoint after it checks if the player will see a chat message.

Fix: swap logic

Testing: Disabled sendEggFoundMessages in config and waypoints correctly render only if egg hasn't been found yet.