### PR TITLE
Remove expired hoppity eggs on lobby join

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chocolatefactory/EggFinder.java
@@ -192,7 +192,7 @@ public class EggFinder {
 				return true;
 			}
 			WsMessageHandler.sendLocationMessage(Service.EGG_WAYPOINTS,
-					new EggWaypointMessage(eggType, eggType.egg.pos, Long.MAX_VALUE));
+					new EggWaypointMessage(eggType, eggType.egg.pos, Optional.empty()));
 		} catch (IllegalArgumentException e) {
 			LOGGER.error("[Skyblocker Egg Finder] Failed to process an egg!", e);
 		}

--- a/src/main/java/de/hysky/skyblocker/utils/ws/message/EggWaypointMessage.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ws/message/EggWaypointMessage.java
@@ -10,11 +10,11 @@ import java.util.List;
 import java.util.Optional;
 import net.minecraft.core.BlockPos;
 
-public record EggWaypointMessage(EggFinder.EggType eggType, BlockPos coordinates, long expirationEpoch) implements Message<EggWaypointMessage> {
+public record EggWaypointMessage(EggFinder.EggType eggType, BlockPos coordinates, Optional<Long> expirationEpoch) implements Message<EggWaypointMessage> {
 	private static final Codec<EggWaypointMessage> CODEC = RecordCodecBuilder.create(instance -> instance.group(
 			EggFinder.EggType.CODEC.fieldOf("eggType").forGetter(EggWaypointMessage::eggType),
 			BlockPos.CODEC.fieldOf("coordinates").forGetter(EggWaypointMessage::coordinates),
-			Codec.LONG.fieldOf("expirationEpoch").forGetter(EggWaypointMessage::expirationEpoch)
+			Codec.LONG.optionalFieldOf("expirationEpoch").forGetter(EggWaypointMessage::expirationEpoch)
 	).apply(instance, EggWaypointMessage::new));
 
 	private static final Codec<List<EggWaypointMessage>> LIST_CODEC = CODEC.listOf();
@@ -34,7 +34,7 @@ public record EggWaypointMessage(EggFinder.EggType eggType, BlockPos coordinates
 				long now = System.currentTimeMillis();
 
 				RenderHelper.runOnRenderThread(() -> waypoints.stream()
-						.filter(w -> w.expirationEpoch() > now)
+						.filter(w -> w.expirationEpoch.isPresent() && w.expirationEpoch().get() > now)
 						.forEach(EggFinder::onWebsocketMessage));
 			}
 


### PR DESCRIPTION
Hopefully finally fixes the last scenario where this issue can happen: https://github.com/SkyblockerMod/Skyblocker/issues/2061

The websocket's initial message can contain stale egg locations from a previous cycle if no player has found the new egg yet or if the server sends a message that contains an expired egg by the time it is received by the player. Filters these out using the expirationEpoch field already provided by the server. Anyone already in the lobby as an egg despawns should already see the correct behavior due to the hourly check/reset.

Changes:
* Added expirationEpoch field to EggWaypointMessage
* Filter out expired eggs from INITIAL_MESSAGE on lobby join

Testing: This is god awful to recreate in game so mock testing only
* Confirmed expirationEpoch is correctly parsed and all 6 eggs receive valid future expiration times on join
* Filter logic verified correct via log output showing current time vs expiration diffs
