### PR TITLE
Increase accuracy of absorption health

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -33,7 +33,7 @@ public class StatusBarTracker {
 	private static final Pattern HEALTH_STATUS = Pattern.compile("(?<health>[\\d,]+)/(?<max>[\\d,]+)❤(?<healing>\\+([\\d,]+)[▁-▆])?");
 	private static final Pattern HEALING = Pattern.compile("(?:§[\\da-z])*❤");
 	private static final Pattern DEFENSE_STATUS = Pattern.compile("(?<defense>[\\d,]+)❈ Defense");
-	private static final Pattern MANA_USE = Pattern.compile("-(?:[\\d,]+) Mana \\(.*?\\)");
+	private static final Pattern MANA_USE = Pattern.compile("-([\\d,]+) Mana \\(.*?\\)");
 	private static final Pattern MANA_STATUS = Pattern.compile("(?<mana>[\\d,]+)/(?<max>[\\d,]+)✎ (?:Mana|(?<overflow>[\\d,]+)ʬ)");
 
 	private static final Minecraft client = Minecraft.getInstance();
@@ -42,6 +42,7 @@ public class StatusBarTracker {
 	private static Resource speed = new Resource(100, 400, 0);
 	private static Resource air = new Resource(100, 300, 0);
 	private static int defense = 0;
+	private static int absorption = 0;
 
 	private static int ticks;
 	private static int lastManaTick;
@@ -83,7 +84,7 @@ public class StatusBarTracker {
 	private static void tick() {
 		if (client.player == null || !Utils.isOnSkyblock()) return;
 		ticks++;
-		updateHealth(health.value, health.max, health.overflow);
+		updateHealth(health.value, health.max);
 		updateSpeed();
 		updateAir();
 		if (ticks - lastManaTick > 0 && (ticks - lastManaTick) % 20 == 0) {
@@ -195,16 +196,24 @@ public class StatusBarTracker {
 	private static void updateHealth(Matcher matcher) {
 		int health = RegexUtils.parseIntFromMatcher(matcher, "health");
 		int max = RegexUtils.parseIntFromMatcher(matcher, "max");
-		updateHealth(health, max, Math.max(0, health - max));
+
+		if (Debug.isTestEnvironment() || client.player == null || client.player.getHealth() == client.player.getMaxHealth()) {
+			// If at full HP or in test environment, then use simple absorption math.
+			absorption = Math.max(0, health - max);
+		} else {
+			// Otherwise approximate absorption based on player health.
+			absorption = (int) (health - (client.player.getHealth() * max / client.player.getMaxHealth()));
+		}
+
+		updateHealth(health, max);
 	}
 
-	private static void updateHealth(int value, int max, int overflow) {
+	private static void updateHealth(int value, int max) {
 		// Client doesn't exist in test environment.
 		if (!Debug.isTestEnvironment() && client.player != null) {
 			value = (int) (client.player.getHealth() * max / client.player.getMaxHealth());
-			overflow = (int) (client.player.getAbsorptionAmount() * max / client.player.getMaxHealth());
 		}
-		health = new Resource(Math.min(value, max), max, Math.min(overflow, max));
+		health = new Resource(Math.min(value, max), max, absorption);
 	}
 
 	private static void updateMana(Matcher m) {


### PR DESCRIPTION
Right now the custom health bar updates absorption based on the actual player absorption hearts every tick. This is wildly inaccurate (see below screenshots), seems like **there is no correlation between player absorption hearts & actual absorption amount**. The amount of absorption hearts is instead determined by the source of absorption. So this PR uses just regular player hearts and the action bar to determine absorption accurately.

<details>
<summary>Zero absorption hearts with absorption</summary>
<img width="795" height="168" alt="image" src="https://github.com/user-attachments/assets/08580abb-90fb-4204-bc04-a1967f370e46" />
</details>
<details>
<summary>Fifteen *rows* of absorption hearts at under 400 absorption</summary>
<img width="569" height="208" alt="image" src="https://github.com/user-attachments/assets/d92688f2-fa69-436c-b4e6-8392cb020383" />

(this one is thanks to martiarch)
</details>
<details>
<summary>God potion & wither shield always gives 8 absorption hearts</summary>
<img width="878" height="252" alt="image" src="https://github.com/user-attachments/assets/e223b6f5-1f01-45c4-b759-d7e6cd2107ce" />
<img width="721" height="161" alt="image" src="https://github.com/user-attachments/assets/2dbf6fd7-dcb0-4405-aaf8-050de5e3dd0e" />
</details>
<details>
<summary>Bee pet always gives 5 absorption hearts</summary>
<img width="913" height="314" alt="image" src="https://github.com/user-attachments/assets/bb28f918-3579-4a7c-a3c0-5931d4610c1a" />
</details>

See [this discord conversation](https://discord.com/channels/879732108745125969/879732108745125972/1488338791424065628) for more context and details.

fixes #2041

## Testing
<details>
<summary>Immediately after Matriarch</summary>

Vanilla:
<img width="569" height="208" alt="image" src="https://github.com/user-attachments/assets/5bdd3ed4-72bf-4a6f-a659-cb10f1bb74b7" />

Before this change:
<img width="196" height="53" alt="image" src="https://github.com/user-attachments/assets/176586da-a696-4310-9895-ee0e80d2a57a" />

After this change:
<img width="596" height="193" alt="image" src="https://github.com/user-attachments/assets/b4745c7d-9f18-4d14-8ef9-a5f49ffb0d5d" />

</details>
<details>
<summary>At full health w/ god pot absorption</summary>

Vanilla:
<img width="612" height="158" alt="image" src="https://github.com/user-attachments/assets/f6f29bfb-202d-4754-98be-8015030782bd" />

Before this change:
<img width="501" height="119" alt="image" src="https://github.com/user-attachments/assets/6001574e-fe47-473d-a2f0-f4d0c3a63075" />

After this change:
<img width="527" height="122" alt="image" src="https://github.com/user-attachments/assets/ac0cde77-cae4-47a0-b8a9-9f4877e1ea79" />
</details>
<details>
<summary>At half health w/ wither shield absorption</summary>

Vanilla:
<img width="660" height="167" alt="image" src="https://github.com/user-attachments/assets/c032b7cd-6ce1-44a4-8749-814432fbcee0" />

Before this change:
<img width="546" height="143" alt="image" src="https://github.com/user-attachments/assets/c7a3e543-e388-439b-9216-acf6c3bc0ffc" />

After this change:
<img width="544" height="169" alt="image" src="https://github.com/user-attachments/assets/6a6b8bf3-02d2-4e98-882f-b7bf74be2591" />
</details>

(exact health numbers vary even within tests because getting the exact same health is hard)