### PR TITLE
Stop Removing Spaces for Contact Names in CallAutocomplete

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/CallAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/CallAutocomplete.java
@@ -62,7 +62,7 @@ public class CallAutocomplete {
 	}
 
 	private static String formatDefaultCallName(String npcName) {
-		return npcName.toLowerCase(Locale.ENGLISH).replaceAll("\\s", "");
+		return npcName.toLowerCase(Locale.ENGLISH);
 	}
 
 	private record AbiphoneContact(Optional<List<String>> callNames) {


### PR DESCRIPTION
some of the new names require spaces, some of the old names don't support spaces 😭 

~~depends on https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/2472~~