### PR TITLE
Added option to hide Spirit Sceptre messages

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
@@ -80,6 +80,13 @@ public class ChatCategory {
 								.controller(ConfigUtils.createEnumController())
 								.build())
 						.option(Option.<ChatFilterResult>createBuilder()
+								.name(Component.translatable("skyblocker.config.chat.filter.hideSpiritSceptre"))
+								.binding(defaults.chat.hideSpiritSceptre,
+										() -> config.chat.hideSpiritSceptre,
+										newValue -> config.chat.hideSpiritSceptre = newValue)
+								.controller(ConfigUtils.createEnumController())
+								.build())
+						.option(Option.<ChatFilterResult>createBuilder()
 								.name(Component.translatable("skyblocker.config.chat.filter.hideMoltenWave"))
 								.binding(defaults.chat.hideMoltenWave,
 										() -> config.chat.hideMoltenWave,

--- a/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
@@ -17,6 +17,8 @@ public class ChatConfig {
 
 	public ChatFilterResult hideImplosion = ChatFilterResult.PASS;
 
+	public ChatFilterResult hideSpiritSceptre = ChatFilterResult.PASS;
+
 	public ChatFilterResult hideMoltenWave = ChatFilterResult.PASS;
 
 	public ChatFilterResult hideAds = ChatFilterResult.PASS;

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/SpiritSceptreFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/SpiritSceptreFilter.java
@@ -1,0 +1,14 @@
+package de.hysky.skyblocker.skyblock.chat.filters;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.chat.ChatFilterResult;
+
+public class SpiritSceptreFilter extends SimpleChatFilter {
+	public SpiritSceptreFilter() {
+		super("^Your Spirit Sceptre hit " + NUMBER + " enem(?:y|ies) for " + NUMBER + " damage\\.$");
+	}
+
+	public ChatFilterResult state() {
+		return SkyblockerConfigManager.get().chat.hideSpiritSceptre;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
+++ b/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
@@ -19,6 +19,7 @@ import de.hysky.skyblocker.skyblock.chat.filters.MimicFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.MoltenWaveFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.ShowOffFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.SkyMallFilter;
+import de.hysky.skyblocker.skyblock.chat.filters.SpiritSceptreFilter;
 import de.hysky.skyblocker.skyblock.slayers.features.SlayerMinibossSpawnFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.TeleportPadFilter;
 import de.hysky.skyblocker.skyblock.dungeon.Reparty;
@@ -76,6 +77,7 @@ public interface ChatMessageListener {
 				new ComboFilter(),
 				new HealFilter(),
 				new ImplosionFilter(),
+				new SpiritSceptreFilter(),
 				new MoltenWaveFilter(),
 				new TeleportPadFilter(),
 				new AutopetFilter(),

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -151,6 +151,7 @@
   "skyblocker.config.chat.filter.hideMoltenWave": "Hide Molten Wave Message",
   "skyblocker.config.chat.filter.hideShowOff": "Hide Show Off Messages",
   "skyblocker.config.chat.filter.hideShowOff.@Tooltip": "Filters messages from the /show command",
+  "skyblocker.config.chat.filter.hideSpiritSceptre": "Hide Spirit Sceptre Message",
   "skyblocker.config.chat.filter.hideTeleportPad": "Hide Teleport Pad Messages",
   "skyblocker.config.chat.filter.hideToggleLottery": "Hide Lottery Messages outside Galatea",
   "skyblocker.config.chat.filter.hideToggleLottery.@Tooltip": "Hides Lottery HOTF perk messages while you're outside of Galatea.",

--- a/src/test/java/de/hysky/skyblocker/skyblock/chat/filters/SpiritSceptreFilterTest.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/chat/filters/SpiritSceptreFilterTest.java
@@ -1,0 +1,19 @@
+package de.hysky.skyblocker.skyblock.chat.filters;
+
+import org.junit.jupiter.api.Test;
+
+public class SpiritSceptreFilterTest extends ChatFilterTest<SpiritSceptreFilter> {
+	SpiritSceptreFilterTest() {
+		super(new SpiritSceptreFilter());
+	}
+
+	@Test
+	void oneEnemy() {
+		assertMatches("Your Spirit Sceptre hit 1 enemy for 47,253.4 damage.");
+	}
+
+	@Test
+	void multipleEnemies() {
+		assertMatches("Your Spirit Sceptre hit 3 enemies for 141,760.1 damage.");
+	}
+}


### PR DESCRIPTION
Small filter class which filters out spirit sceptre messages from chat which also adds a configuration in the settings

Image of Configuration in settings:
<img width="1470" height="956" alt="Screenshot 2026-04-13 at 7 28 45 pm" src="https://github.com/user-attachments/assets/ba6fc36f-b4c4-483c-b535-18b0847b453b" />
