### PR TITLE
Add overflow to status bar values if necessary

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
@@ -94,7 +94,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 	private @Nullable Integer value = null;
 	private @Nullable Integer max = null;
 	private @Nullable Integer overflow = null;
-	protected @Nullable Function<Integer, String> toDisplay = null;
+	private final Function<Integer, String> toDisplay;
 
 	private int renderX = 0;
 	private int renderY = 0;
@@ -107,10 +107,15 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 	public boolean showOverflow = false;
 
 	public StatusBar(StatusBarType type) {
+		this(type, String::valueOf);
+	}
+
+	public StatusBar(StatusBarType type, Function<Integer, String> toDisplay) {
 		this.icon = SkyblockerMod.id("bars/icons/" + type.getSerializedName());
 		this.colors = type.getColors();
 		this.textColor = type.getTextColor();
 		this.type = type;
+		this.toDisplay = toDisplay;
 	}
 
 	protected int transparency(int color) {
@@ -169,7 +174,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 		Font textRenderer = Minecraft.getInstance().font;
 		int barWidth = iconPosition.equals(IconPosition.OFF) ? renderWidth : renderWidth - ICON_SIZE - 1;
 		int barX = iconPosition.equals(IconPosition.LEFT) ? renderX + ICON_SIZE + 2 : renderX;
-		String stringValue = value == null ? "???" : toDisplay == null ? String.valueOf(overflow == null || showOverflow ? value : value + overflow) : toDisplay.apply(overflow == null || showOverflow ? value : value + overflow);
+		String stringValue = value == null ? "???" : toDisplay.apply(overflow == null || showOverflow ? value : value + overflow);
 		MutableComponent text = Component.literal(stringValue).withStyle(style -> style.withColor((textColor == null ? colors[0] : textColor).getRGB()));
 
 		if (hasMax() && showMax && max != null) {
@@ -177,7 +182,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 		}
 		if (hasOverflow() && showOverflow && overflow != null) {
 			MutableComponent literal = Component.literal(" + ").withStyle(style -> style.withColor(colors[1].getRGB()));
-			literal.append(overflow.toString());
+			literal.append(toDisplay.apply(overflow));
 			text.append(literal);
 		}
 
@@ -441,8 +446,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 	public static class ManaStatusBar extends StatusBar {
 
 		public ManaStatusBar(StatusBarType type) {
-			super(type);
-			this.toDisplay = mana -> StatusBarTracker.isManaEstimated() ? "~" + mana : mana.toString();
+			super(type, mana -> StatusBarTracker.isManaEstimated() ? "~" + mana : mana.toString());
 		}
 
 		@Override
@@ -464,13 +468,12 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 	public static class ExperienceStatusBar extends StatusBar {
 		private static final Identifier CLOCK_ICON = SkyblockerMod.id("bars/icons/rift_time");
 		public ExperienceStatusBar(StatusBarType type) {
-			super(type);
-			this.toDisplay = time -> {
+			super(type, time -> {
 				if (Utils.isInTheRift()) {
 					return time < 60 ? time + "s" : String.format("%dm%02ds", time / 60, time % 60);
 				}
 				return time.toString();
-			};
+			});
 		}
 
 		@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
@@ -175,7 +175,8 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 		int barWidth = iconPosition.equals(IconPosition.OFF) ? renderWidth : renderWidth - ICON_SIZE - 1;
 		int barX = iconPosition.equals(IconPosition.LEFT) ? renderX + ICON_SIZE + 2 : renderX;
 		String stringValue = value == null ? "???" : toDisplay.apply(overflow == null || showOverflow ? value : value + overflow);
-		MutableComponent text = Component.literal(stringValue).withStyle(style -> style.withColor((textColor == null ? colors[0] : textColor).getRGB()));
+		Color displayColor = overflow != null && !showOverflow ? colors[1] : textColor == null ? colors[0] : textColor;
+		MutableComponent text = Component.literal(stringValue).withStyle(style -> style.withColor(displayColor.getRGB()));
 
 		if (hasMax() && showMax && max != null) {
 			text.append("/").append(max.toString());
@@ -196,7 +197,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 		}
 		int y = this.renderY - 3;
 
-		int color = transparency((textColor == null ? colors[0] : textColor).getRGB());
+		int color = transparency(displayColor.getRGB());
 		int outlineColor = transparency(CommonColors.BLACK);
 
 		GuiHelper.outlinedText(graphics, Component.translationArg(text), x, y, color, outlineColor);

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
@@ -15,6 +15,8 @@ import org.jspecify.annotations.Nullable;
 
 import java.awt.Color;
 import java.util.function.Consumer;
+import java.util.function.Function;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -89,9 +91,10 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 	public boolean visible = true;
 	public boolean enabled = true;
 
-	private Object value = "???";
-	private @Nullable Object max = "???";
-	private @Nullable Object overflow = "???";
+	private @Nullable Integer value = null;
+	private @Nullable Integer max = null;
+	private @Nullable Integer overflow = null;
+	protected @Nullable Function<Integer, String> toDisplay = null;
 
 	private int renderX = 0;
 	private int renderY = 0;
@@ -149,8 +152,8 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 		}
 	}
 
-	public void updateValues(float fill, float overflowFill, Object text, @Nullable Object max, @Nullable Object overflow) {
-		this.value = text;
+	public void updateValues(float fill, float overflowFill, int value, @Nullable Integer max, @Nullable Integer overflow) {
+		this.value = value;
 		this.fill = Math.clamp(fill, 0, 1);
 		this.overflowFill = Math.clamp(overflowFill, 0, 1);
 		this.max = max;
@@ -158,7 +161,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 	}
 
 	public void updateWithResource(StatusBarTracker.Resource resource) {
-		updateValues(resource.value() / (float) resource.max(), resource.overflow() / (float) resource.max(), resource.value(), resource.max(), resource.overflow() > 0 ? resource.overflow() : null);
+		this.updateValues(resource.value() / (float) resource.max(), resource.overflow() / (float) resource.max(), resource.value(), resource.max(), resource.overflow() > 0 ? resource.overflow() : null);
 	}
 
 	public void extractText(GuiGraphicsExtractor graphics) {
@@ -166,7 +169,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 		Font textRenderer = Minecraft.getInstance().font;
 		int barWidth = iconPosition.equals(IconPosition.OFF) ? renderWidth : renderWidth - ICON_SIZE - 1;
 		int barX = iconPosition.equals(IconPosition.LEFT) ? renderX + ICON_SIZE + 2 : renderX;
-		String stringValue = this.value.toString();
+		String stringValue = value == null ? "???" : toDisplay == null ? String.valueOf(overflow == null || showOverflow ? value : value + overflow) : toDisplay.apply(overflow == null || showOverflow ? value : value + overflow);
 		MutableComponent text = Component.literal(stringValue).withStyle(style -> style.withColor((textColor == null ? colors[0] : textColor).getRGB()));
 
 		if (hasMax() && showMax && max != null) {
@@ -439,6 +442,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 
 		public ManaStatusBar(StatusBarType type) {
 			super(type);
+			this.toDisplay = mana -> StatusBarTracker.isManaEstimated() ? "~" + mana : mana.toString();
 		}
 
 		@Override
@@ -455,30 +459,23 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 				GuiHelper.nineSliceColored(graphics, BAR_FILL, barX + 1, getY() + 2, (int) ((barWith - 2) * fill), 5, transparency(getColors()[0].getRGB()));
 			}
 		}
-
-		@Override
-		public void updateValues(float fill, float overflowFill, Object text, @Nullable Object max, @Nullable Object overflow) {
-			super.updateValues(fill, overflowFill, StatusBarTracker.isManaEstimated() ? "~" + text : text, max, overflow);
-		}
 	}
 
 	public static class ExperienceStatusBar extends StatusBar {
 		private static final Identifier CLOCK_ICON = SkyblockerMod.id("bars/icons/rift_time");
 		public ExperienceStatusBar(StatusBarType type) {
 			super(type);
+			this.toDisplay = time -> {
+				if (Utils.isInTheRift()) {
+					return time < 60 ? time + "s" : String.format("%dm%02ds", time / 60, time % 60);
+				}
+				return time.toString();
+			};
 		}
 
 		@Override
 		protected Identifier getIcon() {
 			return Utils.isInTheRift() ? CLOCK_ICON : super.getIcon();
-		}
-
-		@Override
-		public void updateValues(float fill, float overflowFill, Object text, @Nullable Object max, @Nullable Object overflow) {
-			if (Utils.isInTheRift() && text instanceof Integer time) {
-				text = time < 60 ? time + "s" : String.format("%dm%02ds", time / 60, time % 60);
-			}
-			super.updateValues(fill, overflowFill, text, max, overflow);
 		}
 	}
 


### PR DESCRIPTION
Two main changes:
1. Overflow is added to value unless the status bar option to show overflow separately is enabled.
2. Instead of ugly `Object` types for `value`/`max`/`overflow` a `toDisplay` method (lets bars change how `value` is converted into the displayed `String`) is added and those three fields are changed to `Integer`s.

### Testing
<details>
<summary>Overflow is included in bar value when showOverflow is false</summary>
<img width="375" height="101" alt="image" src="https://github.com/user-attachments/assets/f5558c28-7988-49dd-962b-9e663e9c94e9" />
</details>
<details>
<summary>Overflow is excluded from bar value when showOverflow is true</summary>
<img width="374" height="98" alt="image" src="https://github.com/user-attachments/assets/99eae115-db0d-4b6b-8872-7aa586f80eb6" />
</details>
<details>
<summary>Text color reverts to normal when there's no overflow</summary>
<img width="376" height="98" alt="image" src="https://github.com/user-attachments/assets/fd5172ff-27b1-410c-8d65-f30462350862" />
</details>
<details>
<summary>Custom bar value displays still work as intended</summary>
<img width="375" height="99" alt="image" src="https://github.com/user-attachments/assets/6cab8539-f5a6-4ca0-9f43-afb9761ccb33" />
</details>
<details>
<summary>Bar value is shown as ??? when null</summary>
<img width="376" height="100" alt="image" src="https://github.com/user-attachments/assets/0ecb7512-9335-4ce4-ab3c-2264c1dd9146" />
</details>