### PR TITLE
#2288 Builder's Ruler Fix

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/BuildersWandPreview.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/BuildersWandPreview.java
@@ -103,8 +103,8 @@ public class BuildersWandPreview {
 		BlockPos.MutableBlockPos pos = startPos.mutable();
 
 		Direction dir = hitResult.getDirection().getOpposite();
-		// Adjust direction based on if we hit the top/bottom face (then we use client.player.getDirection() instead)
-		if (dir == Direction.UP || dir == Direction.DOWN) {
+		// Adjust direction based on if we hit the top/bottom face (then we use client.player.getDirection() instead). Side checks are exclusive to sneaking (delete) only.
+		if (dir == Direction.UP || dir == Direction.DOWN || !isSneaking) {
 			dir = client.player.getDirection();
 		}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/BuildersWandPreview.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/BuildersWandPreview.java
@@ -101,10 +101,17 @@ public class BuildersWandPreview {
 		else startBlock = client.level.getBlockState(startPos).getBlock();
 
 		BlockPos.MutableBlockPos pos = startPos.mutable();
+
+		Direction dir = hitResult.getDirection().getOpposite();
+		// Adjust direction based on if we hit the top/bottom face (then we use client.player.getDirection() instead)
+		if (dir == Direction.UP || dir == Direction.DOWN) {
+			dir = client.player.getDirection();
+		}
+
 		for (int i = 0; i < MAX_BLOCKS && checkPos(startPos, pos, client.level.getBlockState(pos), isSneaking, startBlock); i++) {
 			if (isSneaking) collector.submitFilledBox(pos.immutable(), RED, SkyblockerConfigManager.get().helpers.buildersWand.previewOpacity, true);
 			else extractBlockPreview(collector, pos.immutable(), Blocks.DIRT.defaultBlockState());
-			pos.move(client.player.getDirection());
+			pos.move(dir);
 		}
 	}
 


### PR DESCRIPTION
Switched to `hitResult.getDirection().getOpposite()` for horizontal faces for deletion preview.

Fixing #2288