### PR TITLE
Fix REI NPC Shop Recipe Offset

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/recipes/SkyblockNpcShopRecipe.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/recipes/SkyblockNpcShopRecipe.java
@@ -82,6 +82,7 @@ public class SkyblockNpcShopRecipe implements SkyblockRecipe {
 	}
 
 	boolean shouldOffsetArrow() {
+		if (!shouldSplit()) return false;
 		int size = inputs.size();
 		return size % 2 == 1 || size >= 8;
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/recipes/SkyblockNpcShopRecipe.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/recipes/SkyblockNpcShopRecipe.java
@@ -42,13 +42,12 @@ public class SkyblockNpcShopRecipe implements SkyblockRecipe {
 	 * <p>
 	 * Recipes greater than 3 items are split into 2 rows evenly.
 	 * If the input size is odd, it is offset further so those items do not overlap with the arrow.
-	 * There are currently no recipes with > 7 items.
 	 */
 	private int getCenterX(int width) {
 		int centerX = width / 2;
 		int size = inputs.size();
 		centerX += Math.min(getRowSize(), 3) * SLOT_SIZE / 2 - SLOT_SIZE / 2;
-		if (size > 1 && size % 2 == 1) centerX -= SLOT_SIZE / 2;
+		if (size > 1 && shouldOffsetArrow()) centerX -= SLOT_SIZE / 2;
 		return centerX;
 	}
 
@@ -82,11 +81,16 @@ public class SkyblockNpcShopRecipe implements SkyblockRecipe {
 		return slots;
 	}
 
+	boolean shouldOffsetArrow() {
+		int size = inputs.size();
+		return size % 2 == 1 || size >= 8;
+	}
+
 	@Override
 	public List<RecipeSlot> getOutputSlots(int width, int height) {
 		int centerX = getCenterX(width);
 		int centerY = height / 2;
-		if (inputs.size() == 7 || inputs.size() == 8) centerX += SLOT_SIZE;
+		if (shouldOffsetArrow()) centerX += SLOT_SIZE;
 		return List.of(new RecipeSlot(centerX + ARROW_LENGTH / 2 + ARROW_PADDING, centerY, output));
 	}
 
@@ -94,7 +98,7 @@ public class SkyblockNpcShopRecipe implements SkyblockRecipe {
 	public @Nullable ScreenPosition getArrowLocation(int width, int height) {
 		int centerX = getCenterX(width);
 		int centerY = height / 2;
-		if (inputs.size() == 7 || inputs.size() == 8) centerX += SLOT_SIZE;
+		if (shouldOffsetArrow()) centerX += SLOT_SIZE;
 		return new ScreenPosition(centerX - ARROW_LENGTH / 2 - 1, centerY);
 	}
 


### PR DESCRIPTION
### Fixes the arrow position for the Giant Witch Cauldron recipe

Before:
<img width="311" height="150" alt="image" src="https://github.com/user-attachments/assets/5084d44d-e921-4239-9b4b-f21957a79fc1" />

After:
<img width="297" height="155" alt="image" src="https://github.com/user-attachments/assets/88406890-2cf8-4520-9932-2fc910e55497" />


### Fixes the centering for the Rose Dragon recipe

Before:
<img width="338" height="160" alt="image" src="https://github.com/user-attachments/assets/9f198f83-07e9-4cde-a835-5bdd1de58434" />

After:
<img width="336" height="160" alt="image" src="https://github.com/user-attachments/assets/1a0a6554-5113-4ba7-951a-cc16cc18c326" />
