### PR TITLE
Add autocomplete to /ahs, /bzs, & /bz

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -802,6 +802,14 @@ public class UIAndVisualsCategory {
 										newValue -> config.uiAndVisuals.searchOverlay.enableCommands = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.uiAndVisuals.searchOverlay.commandAutocomplete"))
+								.description(Component.translatable("skyblocker.config.uiAndVisuals.searchOverlay.commandAutocomplete.@Tooltip"))
+								.binding(defaults.uiAndVisuals.searchOverlay.commandAutocomplete,
+										() -> config.uiAndVisuals.searchOverlay.commandAutocomplete,
+										newValue -> config.uiAndVisuals.searchOverlay.commandAutocomplete = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.build())
 
 				// Bazaar Quick Quantities

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -386,6 +386,8 @@ public class UIAndVisualsConfig {
 	}
 
 	public static class SearchOverlay {
+		public boolean commandAutocomplete = true;
+
 		public boolean enableBazaar = true;
 
 		public boolean enableAuctionHouse = true;

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -386,8 +386,6 @@ public class UIAndVisualsConfig {
 	}
 
 	public static class SearchOverlay {
-		public boolean commandAutocomplete = true;
-
 		public boolean enableBazaar = true;
 
 		public boolean enableAuctionHouse = true;
@@ -401,6 +399,8 @@ public class UIAndVisualsConfig {
 		public int historyLength = 3;
 
 		public boolean enableCommands = false;
+
+		public boolean commandAutocomplete = true;
 
 		public List<String> bazaarHistory = new ArrayList<>();
 

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientboundCommandsPacketMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientboundCommandsPacketMixin.java
@@ -37,7 +37,6 @@ public class ClientboundCommandsPacketMixin {
 				case String s when s.equals("call") && CallAutocomplete.commandNode != null -> CallAutocomplete.commandNode;
 				case String s when s.equals("ahs") && AuctionBazaarAutocomplete.ahsNode != null -> AuctionBazaarAutocomplete.ahsNode;
 				case String s when s.equals("ahsearch") && AuctionBazaarAutocomplete.ahsearchNode != null -> AuctionBazaarAutocomplete.ahsearchNode;
-				case String s when s.equals("bzs") && AuctionBazaarAutocomplete.bzsNode != null -> AuctionBazaarAutocomplete.bzsNode;
 				case String s when s.equals("bz") && AuctionBazaarAutocomplete.bzNode != null -> AuctionBazaarAutocomplete.bzNode;
 				case String s when s.equals("bazaar") && AuctionBazaarAutocomplete.bazaarNode != null -> AuctionBazaarAutocomplete.bazaarNode;
 				case String s when s.equals("chapter") && ChaptersAutocomplete.singularCommandNode != null -> ChaptersAutocomplete.singularCommandNode;

--- a/src/main/java/de/hysky/skyblocker/mixins/ClientboundCommandsPacketMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/ClientboundCommandsPacketMixin.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 
+import de.hysky.skyblocker.skyblock.AuctionBazaarAutocomplete;
 import de.hysky.skyblocker.skyblock.CallAutocomplete;
 import de.hysky.skyblocker.skyblock.ChaptersAutocomplete;
 import de.hysky.skyblocker.skyblock.JoinInstanceAutocomplete;
@@ -34,6 +35,11 @@ public class ClientboundCommandsPacketMixin {
 				case String s when s.equals("rngmeter") && RngMeterAutocomplete.longCommand != null -> RngMeterAutocomplete.longCommand;
 				case String s when s.equals("rng") && RngMeterAutocomplete.shortCommand != null -> RngMeterAutocomplete.shortCommand;
 				case String s when s.equals("call") && CallAutocomplete.commandNode != null -> CallAutocomplete.commandNode;
+				case String s when s.equals("ahs") && AuctionBazaarAutocomplete.ahsNode != null -> AuctionBazaarAutocomplete.ahsNode;
+				case String s when s.equals("ahsearch") && AuctionBazaarAutocomplete.ahsearchNode != null -> AuctionBazaarAutocomplete.ahsearchNode;
+				case String s when s.equals("bzs") && AuctionBazaarAutocomplete.bzsNode != null -> AuctionBazaarAutocomplete.bzsNode;
+				case String s when s.equals("bz") && AuctionBazaarAutocomplete.bzNode != null -> AuctionBazaarAutocomplete.bzNode;
+				case String s when s.equals("bazaar") && AuctionBazaarAutocomplete.bazaarNode != null -> AuctionBazaarAutocomplete.bazaarNode;
 				case String s when s.equals("chapter") && ChaptersAutocomplete.singularCommandNode != null -> ChaptersAutocomplete.singularCommandNode;
 				case String s when s.equals("chapters") && ChaptersAutocomplete.pluralCommandNode != null -> ChaptersAutocomplete.pluralCommandNode;
 				default -> original;

--- a/src/main/java/de/hysky/skyblocker/skyblock/AuctionBazaarAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/AuctionBazaarAutocomplete.java
@@ -4,6 +4,9 @@ import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.literal;
 
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.skyblock.searchoverlay.SearchOverManager;
@@ -14,12 +17,12 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.commands.SharedSuggestionProvider;
 import org.jspecify.annotations.Nullable;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 public class AuctionBazaarAutocomplete {
 	public static @Nullable LiteralCommandNode<FabricClientCommandSource> ahsNode;
 	public static @Nullable LiteralCommandNode<FabricClientCommandSource> ahsearchNode;
-	public static @Nullable LiteralCommandNode<FabricClientCommandSource> bzsNode;
 	public static @Nullable LiteralCommandNode<FabricClientCommandSource> bzNode;
 	public static @Nullable LiteralCommandNode<FabricClientCommandSource> bazaarNode;
 
@@ -28,10 +31,14 @@ public class AuctionBazaarAutocomplete {
 		NEURepoManager.runAsyncAfterLoad(AuctionBazaarAutocomplete::createNodes);
 	}
 
+	// since /bzs is only client-side it needs separate handling
+	public static CompletableFuture<Suggestions> suggestBzs(CommandContext<FabricClientCommandSource> context, SuggestionsBuilder builder) {
+		return SharedSuggestionProvider.suggest(SearchOverManager.getBazaarItems(), builder);
+	}
+
 	private static void createNodes() {
 		ahsNode = createNode("ahs", SearchOverManager::getAuctionItems);
 		ahsearchNode = createNode("ahsearch", SearchOverManager::getAuctionItems);
-		bzsNode = createNode("bzs", SearchOverManager::getBazaarItems);
 		bzNode = createNode("bz", SearchOverManager::getBazaarItems);
 		bazaarNode = createNode("bazaar", SearchOverManager::getBazaarItems);
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/AuctionBazaarAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/AuctionBazaarAutocomplete.java
@@ -1,0 +1,48 @@
+package de.hysky.skyblocker.skyblock;
+
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.argument;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.literal;
+
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.skyblock.searchoverlay.SearchOverManager;
+import de.hysky.skyblocker.utils.NEURepoManager;
+import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.command.CommandUtils;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.commands.SharedSuggestionProvider;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+public class AuctionBazaarAutocomplete {
+	public static @Nullable LiteralCommandNode<FabricClientCommandSource> ahsNode;
+	public static @Nullable LiteralCommandNode<FabricClientCommandSource> ahsearchNode;
+	public static @Nullable LiteralCommandNode<FabricClientCommandSource> bzsNode;
+	public static @Nullable LiteralCommandNode<FabricClientCommandSource> bzNode;
+	public static @Nullable LiteralCommandNode<FabricClientCommandSource> bazaarNode;
+
+	@Init(priority = 100) // Load after SearchOverManager
+	public static void init() {
+		NEURepoManager.runAsyncAfterLoad(AuctionBazaarAutocomplete::createNodes);
+	}
+
+	private static void createNodes() {
+		ahsNode = createNode("ahs", SearchOverManager::getAuctionItems);
+		ahsearchNode = createNode("ahsearch", SearchOverManager::getAuctionItems);
+		bzsNode = createNode("bzs", SearchOverManager::getBazaarItems);
+		bzNode = createNode("bz", SearchOverManager::getBazaarItems);
+		bazaarNode = createNode("bazaar", SearchOverManager::getBazaarItems);
+	}
+
+	private static LiteralCommandNode<FabricClientCommandSource> createNode(String command, Supplier<Iterable<String>> suggester) {
+		return literal(command)
+				.requires(_ -> Utils.isOnSkyblock())
+				.executes(CommandUtils.noOp)
+				.then(argument("item", StringArgumentType.greedyString())
+						.suggests((_, builder) -> SharedSuggestionProvider.suggest(suggester.get(), builder))
+						.executes(CommandUtils.noOp))
+				.build();
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/AuctionBazaarAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/AuctionBazaarAutocomplete.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import de.hysky.skyblocker.annotations.Init;
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.searchoverlay.SearchOverManager;
 import de.hysky.skyblocker.utils.NEURepoManager;
 import de.hysky.skyblocker.utils.Utils;
@@ -37,10 +38,12 @@ public class AuctionBazaarAutocomplete {
 	}
 
 	private static void createNodes() {
-		ahsNode = createNode("ahs", SearchOverManager::getAuctionItems);
-		ahsearchNode = createNode("ahsearch", SearchOverManager::getAuctionItems);
-		bzNode = createNode("bz", SearchOverManager::getBazaarItems);
-		bazaarNode = createNode("bazaar", SearchOverManager::getBazaarItems);
+		if (SkyblockerConfigManager.get().uiAndVisuals.searchOverlay.commandAutocomplete) {
+			ahsNode = createNode("ahs", SearchOverManager::getAuctionItems);
+			ahsearchNode = createNode("ahsearch", SearchOverManager::getAuctionItems);
+			bzNode = createNode("bz", SearchOverManager::getBazaarItems);
+			bazaarNode = createNode("bazaar", SearchOverManager::getBazaarItems);
+		}
 	}
 
 	private static LiteralCommandNode<FabricClientCommandSource> createNode(String command, Supplier<Iterable<String>> suggester) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -90,9 +90,13 @@ public class SearchOverManager {
 	private static void registerSearchCommands(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandBuildContext registryAccess) {
 		if (SkyblockerConfigManager.get().uiAndVisuals.searchOverlay.enableCommands) {
 			dispatcher.register(literal("ahs").executes(_ -> startCommand(true, "")));
+			dispatcher.register(literal("ahsearch").executes(_ -> startCommand(true, "")));
 			dispatcher.register(literal("bzs").executes(_ -> startCommand(false, "")));
 
 			dispatcher.register(literal("ahs").then(argument("item", StringArgumentType.greedyString())
+					.executes(context -> startCommand(true, StringArgumentType.getString(context, "item"))
+					)));
+			dispatcher.register(literal("ahsearch").then(argument("item", StringArgumentType.greedyString())
 					.executes(context -> startCommand(true, StringArgumentType.getString(context, "item"))
 					)));
 			dispatcher.register(literal("bzs").then(argument("item", StringArgumentType.greedyString())
@@ -213,6 +217,14 @@ public class SearchOverManager {
 		SearchOverManager.level200Pets = level200Pets;
 		SearchOverManager.starableItems = starableItems;
 		SearchOverManager.namesToNeuId = namesToNeuId;
+	}
+
+	public static HashSet<String> getBazaarItems() {
+		return bazaarItems;
+	}
+
+	public static HashSet<String> getAuctionItems() {
+		return auctionItems;
 	}
 
 	/**

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -10,6 +10,7 @@ import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.UIAndVisualsConfig;
 import de.hysky.skyblocker.debug.Debug;
 import de.hysky.skyblocker.injected.SkyblockerStack;
+import de.hysky.skyblocker.skyblock.AuctionBazaarAutocomplete;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.skyblock.museum.Donation;
@@ -19,6 +20,7 @@ import de.hysky.skyblocker.utils.Constants;
 import de.hysky.skyblocker.utils.FlexibleItemStack;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.NEURepoManager;
+import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.scheduler.MessageScheduler;
 import io.github.moulberry.repo.data.NEUItem;
 import io.github.moulberry.repo.util.NEUId;
@@ -89,17 +91,30 @@ public class SearchOverManager {
 
 	private static void registerSearchCommands(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandBuildContext registryAccess) {
 		if (SkyblockerConfigManager.get().uiAndVisuals.searchOverlay.enableCommands) {
-			dispatcher.register(literal("ahs").executes(_ -> startCommand(true, "")));
-			dispatcher.register(literal("ahsearch").executes(_ -> startCommand(true, "")));
-			dispatcher.register(literal("bzs").executes(_ -> startCommand(false, "")));
+			dispatcher.register(literal("ahs")
+					.requires(_ -> Utils.isOnSkyblock())
+					.executes(_ -> startCommand(true, "")));
+			dispatcher.register(literal("ahsearch")
+					.requires(_ -> Utils.isOnSkyblock())
+					.executes(_ -> startCommand(true, "")));
+			dispatcher.register(literal("bzs")
+					.requires(_ -> Utils.isOnSkyblock())
+					.executes(_ -> startCommand(false, "")));
 
-			dispatcher.register(literal("ahs").then(argument("item", StringArgumentType.greedyString())
+			dispatcher.register(literal("ahs")
+					.requires(_ -> Utils.isOnSkyblock())
+					.then(argument("item", StringArgumentType.greedyString())
 					.executes(context -> startCommand(true, StringArgumentType.getString(context, "item"))
 					)));
-			dispatcher.register(literal("ahsearch").then(argument("item", StringArgumentType.greedyString())
+			dispatcher.register(literal("ahsearch")
+					.requires(_ -> Utils.isOnSkyblock())
+					.then(argument("item", StringArgumentType.greedyString())
 					.executes(context -> startCommand(true, StringArgumentType.getString(context, "item"))
 					)));
-			dispatcher.register(literal("bzs").then(argument("item", StringArgumentType.greedyString())
+			dispatcher.register(literal("bzs")
+					.requires(_ -> Utils.isOnSkyblock())
+					.then(argument("item", StringArgumentType.greedyString())
+					.suggests(AuctionBazaarAutocomplete::suggestBzs)
 					.executes(context -> startCommand(false, StringArgumentType.getString(context, "item"))
 					)));
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/searchoverlay/SearchOverManager.java
@@ -111,12 +111,20 @@ public class SearchOverManager {
 					.then(argument("item", StringArgumentType.greedyString())
 					.executes(context -> startCommand(true, StringArgumentType.getString(context, "item"))
 					)));
-			dispatcher.register(literal("bzs")
-					.requires(_ -> Utils.isOnSkyblock())
-					.then(argument("item", StringArgumentType.greedyString())
-					.suggests(AuctionBazaarAutocomplete::suggestBzs)
-					.executes(context -> startCommand(false, StringArgumentType.getString(context, "item"))
-					)));
+			if (SkyblockerConfigManager.get().uiAndVisuals.searchOverlay.commandAutocomplete) {
+				dispatcher.register(literal("bzs")
+						.requires(_ -> Utils.isOnSkyblock())
+						.then(argument("item", StringArgumentType.greedyString())
+						.suggests(AuctionBazaarAutocomplete::suggestBzs)
+						.executes(context -> startCommand(false, StringArgumentType.getString(context, "item"))
+						)));
+			} else {
+				dispatcher.register(literal("bzs")
+						.requires(_ -> Utils.isOnSkyblock())
+						.then(argument("item", StringArgumentType.greedyString())
+						.executes(context -> startCommand(false, StringArgumentType.getString(context, "item"))
+						)));
+			}
 		}
 
 		if (!Debug.debugEnabled()) return;

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1344,6 +1344,8 @@
   "skyblocker.config.uiAndVisuals.radialMenu.wardrobe": "Wardrobe",
 
   "skyblocker.config.uiAndVisuals.searchOverlay": "AH/BZ Search Overlay",
+  "skyblocker.config.uiAndVisuals.searchOverlay.commandAutocomplete": "Show autocomplete suggestions for auction house/bazaar commands.",
+  "skyblocker.config.uiAndVisuals.searchOverlay.commandAutocomplete.@Tooltip": "A re-log is required for this setting to be updated.",
   "skyblocker.config.uiAndVisuals.searchOverlay.enableAuctionHouse": "Enable For Auction House",
   "skyblocker.config.uiAndVisuals.searchOverlay.enableAuctionHouse.@Tooltip": "Show custom search overlay when searching in the Auction House.",
   "skyblocker.config.uiAndVisuals.searchOverlay.enableBazaar": "Enable For Bazaar",


### PR DESCRIPTION
See title, `CallAutocomplete` was used as a reference. Also fixes two related bugs:
1. The search overlay opened on `/ahs` but not `/ahsearch`.
2. `/ahs`, `/ahsearch`, & `/bzs` all worked even when not playing skyblock.

**Note:** Auction House autocomplete doesn't seem to fully match the search overlay? (see the last test for an example, autocomplete has "Bunny" and "Bunny Jerry" but the search overlay doesn't)

### Testing
<details>
<summary>/ahs & /ahsearch now have autocomplete</summary>
<img width="285" height="205" alt="image" src="https://github.com/user-attachments/assets/ef6bbbe7-cba3-4c4c-8e69-92db9a6c1071" />
<img width="358" height="212" alt="image" src="https://github.com/user-attachments/assets/3aa89bd7-98e2-4600-9463-fa0484af6871" />
</details>
<details>
<summary>/bzs, /bz, & /bazaar now have autocomplete</summary>
<img width="311" height="110" alt="image" src="https://github.com/user-attachments/assets/6cff727e-4e34-4ef7-94de-894d114462e0" />
<img width="300" height="117" alt="image" src="https://github.com/user-attachments/assets/fa895cdb-97cd-46db-9087-4c195121b349" />
<img width="356" height="114" alt="image" src="https://github.com/user-attachments/assets/79a9c38f-727f-4f6e-a212-dc05d880c597" />
</details>
<details>
<summary>/ahs, /ahsearch, & /bzs no longer work outside of skyblock</summary>
In the main lobby:
<img width="562" height="138" alt="image" src="https://github.com/user-attachments/assets/090cb64a-7d08-4bc2-93af-c95ad61056e6" />
In the garden:
<img width="388" height="134" alt="image" src="https://github.com/user-attachments/assets/3c8bd1e4-4b1b-42ff-ad1c-29272ebac54f" />
</details>
<details>
<summary>/ahsearch now opens the search overlay</summary>
<img width="346" height="188" alt="image" src="https://github.com/user-attachments/assets/3b002a5b-49f6-4674-a135-9e58fba5003c" />
<img width="607" height="402" alt="image" src="https://github.com/user-attachments/assets/374c78d1-333a-47c7-bb80-c59da73dbac4" />
</details>