### PR TITLE
Pause farming tool mouse lock while in the garden's barn

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/LowerSensitivity.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/LowerSensitivity.java
@@ -6,24 +6,31 @@ import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.Utils;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
 public class LowerSensitivity {
+	private static final Minecraft CLIENT = Minecraft.getInstance();
 	private static boolean sensitivityLowered = false;
 
 	@Init
 	public static void init() {
 		ClientTickEvents.END_LEVEL_TICK.register(_ -> {
-			if (Utils.getLocation() != Location.GARDEN || Minecraft.getInstance().player == null || !SkyblockerConfigManager.get().farming.mouseLock.lockMouseTool) {
+			if (Utils.getLocation() != Location.GARDEN || CLIENT.player == null || isInBarn(CLIENT.player) || !SkyblockerConfigManager.get().farming.mouseLock.lockMouseTool) {
 				if (sensitivityLowered) lowerSensitivity(false);
 				return;
 			}
-			ItemStack mainHandStack = Minecraft.getInstance().player.getMainHandItem();
+			ItemStack mainHandStack = CLIENT.player.getMainHandItem();
 			String itemId = mainHandStack.getSkyblockId();
-			boolean shouldLockMouse = FarmingHudWidget.FARMING_TOOLS.containsKey(itemId) && (!SkyblockerConfigManager.get().farming.mouseLock.lockMouseGroundOnly || Minecraft.getInstance().player.onGround());
+			boolean shouldLockMouse = FarmingHudWidget.FARMING_TOOLS.containsKey(itemId) && (!SkyblockerConfigManager.get().farming.mouseLock.lockMouseGroundOnly || CLIENT.player.onGround());
 			if (shouldLockMouse && !sensitivityLowered) lowerSensitivity(true);
 			else if (!shouldLockMouse && sensitivityLowered) lowerSensitivity(false);
 		});
+	}
+
+	// pause mouse locking while in the garden's barn
+	private static boolean isInBarn(Player player) {
+		return player.getX() <= 35.5d && player.getX() >= -32.5d && player.getZ() <= -4.5d && player.getZ() >= -46.5d;
 	}
 
 	public static void lowerSensitivity(boolean lowerSensitivity) {


### PR DESCRIPTION
See title & [discord context](https://discord.com/channels/879732108745125969/950163141482926111/1504785407756472450). This only applies to the barn structure itself (the protected area where blocks can't be placed or broken) not the entire barn plot, because some people might have built parts of their farm into the barn plot.

I tested this in my garden but can't really show that with screenshots given the nature of the change.