### PR TITLE
Fix Rare ForestNodes NPE

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/ForestNodes.java
@@ -97,7 +97,9 @@ public class ForestNodes {
 		// Count those with minecraft:string
 		return (int) entities.stream()
 				.filter(entity -> {
-					ItemStack stack = entity.itemRenderState().itemStack();
+					var state = entity.itemRenderState();
+					if (state == null) return false;
+					ItemStack stack = state.itemStack();
 					return !stack.isEmpty() && stack.getItem().equals(Items.STRING);
 				})
 				.count();


### PR DESCRIPTION
Fixes:
```txt
---- Minecraft Network Protocol Error Report ----
// Too many suspicious packets
// Server bug reporting link: https://hypixel.net/bug-reports/create?server_ip=alpha.hypixel.net

Time: 2026-05-17 19:55:33
Description: Packet handling error

java.lang.NullPointerException: Cannot invoke "net.minecraft.world.entity.Display$ItemDisplay$ItemRenderState.itemStack()" because the return value of "net.minecraft.world.entity.Display$ItemDisplay.itemRenderState()" is null
	at knot//de.hysky.skyblocker.skyblock.galatea.ForestNodes.lambda$countStringItemDisplays$1(ForestNodes.java:100)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
```