### PR TITLE
Fix: Item protection not blocking NPC selling

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/AbstractContainerScreenMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/AbstractContainerScreenMixin.java
@@ -21,7 +21,6 @@ import de.hysky.skyblocker.skyblock.item.tooltip.BackpackPreview;
 import de.hysky.skyblocker.skyblock.item.tooltip.CompactorDeletorPreview;
 import de.hysky.skyblocker.skyblock.item.wikilookup.WikiLookupManager;
 import de.hysky.skyblocker.skyblock.museum.MuseumItemCache;
-import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.container.ContainerSolver;
 import de.hysky.skyblocker.utils.container.ContainerSolverManager;
@@ -295,17 +294,16 @@ public abstract class AbstractContainerScreenMixin<T extends AbstractContainerMe
 			return;
 		}
 
+		// Prevent selling protected items to NPC shops
+		if (this.menu instanceof ChestMenu && ItemProtection.isItemProtected(stack)
+				&& !ItemProtection.isNpcSellButton(slot) && ItemProtection.isNpcSellMenu(this.menu)) {
+			ci.cancel();
+			return;
+		}
+
 		switch (this.menu) {
 			case ChestMenu genericContainerScreenHandler when genericContainerScreenHandler.getRowCount() == 6 -> {
 				VisitorHelper.onSlotClick(slot, slotId, title, genericContainerScreenHandler.getSlot(13));
-				// Prevent selling to NPC shops
-				ItemStack sellStack = this.menu.slots.get(49).getItem();
-				if (sellStack.getHoverName().getString().equals("Sell Item") || ItemUtils.getLoreLineIf(sellStack, text -> text.contains("buyback")) != null) {
-					if (slotId != 49 && ItemProtection.isItemProtected(stack)) {
-						ci.cancel();
-						return;
-					}
-				}
 			}
 
 			case ChestMenu genericContainerScreenHandler when title.equals(MuseumItemCache.DONATION_CONFIRMATION_SCREEN_TITLE) -> //Museum Item Cache donation tracking

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemProtection.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemProtection.java
@@ -6,6 +6,7 @@ import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.utils.Constants;
+import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.Utils;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
@@ -26,6 +27,8 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.EntityHitResult;
@@ -128,6 +131,22 @@ public class ItemProtection {
 			ItemStack heldItem = player.getMainHandItem();
 			handleKeyPressed(heldItem);
 		}
+	}
+
+	public static boolean isNpcSellMenu(AbstractContainerMenu menu) {
+		for (Slot slot : menu.slots) {
+			ItemStack stack = slot.getItem();
+			if (stack.isEmpty()) continue;
+			String name = stack.getHoverName().getString();
+			if (name.equals("Sell Item") || name.equals("Sell Inventory")) return true;
+			if (ItemUtils.getLoreLineIf(stack, text -> text.contains("buyback")) != null) return true;
+		}
+		return false;
+	}
+
+	public static boolean isNpcSellButton(Slot slot) {
+		String name = slot.getItem().getHoverName().getString();
+		return name.equals("Sell Item") || name.equals("Sell Inventory");
 	}
 
 	private static InteractionResult onEntityInteract(Player playerEntity, Level world, InteractionHand hand, Entity entity, @Nullable EntityHitResult entityHitResult) {


### PR DESCRIPTION
## What
Protected items will no longer be sold to NPC shops.

## Problem
Protected items are being sold to NPC shops.

Fixes #2459

## Changelog Fixes
+ Fixed item protection not preventing protected items from being sold to NPC shops. - legentpc