### PR TITLE
Improve consistency of whitespace around formatting chars

### DIFF
--- a/src/main/java/de/hysky/skyblocker/utils/TextTransformer.java
+++ b/src/main/java/de/hysky/skyblocker/utils/TextTransformer.java
@@ -25,7 +25,8 @@ import java.util.stream.Collectors;
  * @author AzureAaron
  */
 public class TextTransformer {
-	private static final Pattern REDUNDANT_COLOR_REGEX = Pattern.compile("&(?:#[\\da-f]{6}|[\\da-f])(\\s*)&(#[\\da-f]{6}|[\\da-f])");
+	private static final Pattern REDUNDANT_COLOR = Pattern.compile("&(?:#[\\da-f]{6}|[\\da-f])(\\s*)&(#[\\da-f]{6}|[\\da-f])");
+	private static final Pattern TRAILING_WHITESPACE = Pattern.compile("(\\s*)&(#[\\da-f]{6}|[\\da-fk-or])(\\s+)");
 	private static final Pattern ALL_WHITESPACE = Pattern.compile("\\s+");
 	private static final CharList FORMAT_CODES = CharList.of('4', 'c', '6', 'e', '2', 'a', 'b', '3', '1', '9', 'd', '5', 'f', '7', '8', '0', 'r', 'k', 'l', 'm', 'n', 'o');
 	private static final Map<Integer, Character> HEX_TO_CODES = Arrays.stream(ChatFormatting.values()).filter(c -> TextColor.fromLegacyFormat(c) != null).collect(Collectors.toUnmodifiableMap(cf -> TextColor.fromLegacyFormat(cf).getValue(), cf -> cf.code));
@@ -68,12 +69,19 @@ public class TextTransformer {
 		return codes.toString();
 	}
 
-	private static String removeRedundantCodes(String message) {
+	private static String removeRedundantStyles(String message) {
 		String result = message;
-		Matcher redundant = REDUNDANT_COLOR_REGEX.matcher(message);
+		Matcher redundant = REDUNDANT_COLOR.matcher(message);
 
 		while (redundant.find()) {
 			result = redundant.replaceAll("$1&$2");
+			redundant.reset(result);
+		}
+
+		redundant = TRAILING_WHITESPACE.matcher(result);
+
+		while (redundant.find()) {
+			result = redundant.replaceAll("$1$3&$2");
 			redundant.reset(result);
 		}
 
@@ -107,7 +115,7 @@ public class TextTransformer {
 			return Optional.empty();
 		}, Style.EMPTY);
 
-		return removeRedundantCodes(result.toString());
+		return removeRedundantStyles(result.toString());
 	}
 
 	/**

--- a/src/test/java/de/hysky/skyblocker/skyblock/chat/ChatRulesHandlerTest.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/chat/ChatRulesHandlerTest.java
@@ -56,8 +56,8 @@ class ChatRulesHandlerTest {
 		spacer.append(Component.literal(" ").withStyle(ChatFormatting.DARK_GRAY));
 
 		Assertions.assertEquals("&eNew buff&r: &fGain &a+5% &2∮ Sweep&f.", TextTransformer.toLegacy(newBuff));
-		Assertions.assertEquals("&fWatchdog has banned &c&l5,565&f players in the last 7 days.", TextTransformer.toLegacy(watchdog));
-		Assertions.assertEquals("&c ☠ &aNOT_LEGEND_&7 fainted from pressure.", TextTransformer.toLegacy(pressure));
+		Assertions.assertEquals("&fWatchdog has banned &c&l5,565 &fplayers in the last 7 days.", TextTransformer.toLegacy(watchdog));
+		Assertions.assertEquals(" &c☠ &aNOT_LEGEND_ &7fainted from pressure.", TextTransformer.toLegacy(pressure));
 		Assertions.assertEquals("       ", TextTransformer.toLegacy(spacer));
 	}
 


### PR DESCRIPTION
Right now spacing around formatting characters parsed from a chat component varies depending on the exact component structure, for example:
```
&fWatchdog has banned &c&l5,565&f players in the last 7 days.
```
Here you can see both `banned &c&l5,565` where the space is before the formatting characters and `5,565&f players` where the space is after the formatting characters. This PR changes the above to this, where the spacing is always consistent:
```
&fWatchdog has banned &c&l5,565 &fplayers in the last 7 days.
```
This makes it a lot easier to create chat rules that include formatting characters because you don't need to analyze the exact component to determine how whitespace and chat formatting characters behave in that particular message.
I tweaked the existing tests to verify this change works and to represent the desired behavior.