### PR TITLE
Bump SkyBlock Item List version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ emi_version = 1.1.10+1.21
 ## JEI (https://modrinth.com/mod/jei/versions)
 jei_version = 30.0.0.3
 ## SkyBlock Item List (https://github.com/OperationPotato/ItemList)
-skyblock_item_list_version = 0.0.5+26.1.2-SNAPSHOT
+skyblock_item_list_version = 0.0.13+26.2
 
 # Minecraft and Related Libraries
 ## McDev Annotations (https://central.sonatype.com/artifact/com.demonwav.mcdev/annotations)


### PR DESCRIPTION
to switch off the SNAPSHOT version.