### PR TITLE
Add Predict Mana Bar Usage Option

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -496,6 +496,14 @@ public class UIAndVisualsCategory {
 										newValue -> config.uiAndVisuals.bars.useHungerBarSprites = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.uiAndVisuals.bars.predictManaUsage"))
+								.description(Component.translatable("skyblocker.config.uiAndVisuals.bars.predictManaUsage.@Tooltip"))
+								.binding(defaults.uiAndVisuals.bars.predictManaUsage,
+										() -> config.uiAndVisuals.bars.predictManaUsage,
+										newValue -> config.uiAndVisuals.bars.predictManaUsage = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.option(ButtonOption.createBuilder()
 								.name(Component.translatable("skyblocker.config.uiAndVisuals.bars.openScreen"))
 								.prompt(Component.translatable("text.skyblocker.open"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -286,6 +286,8 @@ public class UIAndVisualsConfig {
 
 		public boolean useHungerBarSprites = false;
 
+		public boolean predictManaUsage = true;
+
 		public IntelligenceDisplay intelligenceDisplay = IntelligenceDisplay.ORIGINAL;
 
 		// Kept in for backwards compatibility, remove if needed

--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -101,6 +101,7 @@ public class StatusBarTracker {
 
 	@SuppressWarnings("SameReturnValue")
 	private static InteractionResult interactItem(Player player, Level world, InteractionHand hand) {
+		if (!SkyblockerConfigManager.get().uiAndVisuals.bars.predictManaUsage) return InteractionResult.PASS;
 		if (MINECRAFT.player == null) return InteractionResult.PASS;
 		ItemStack handStack = MINECRAFT.player.getMainHandItem();
 		int manaCost = 0;

--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock;
 
+import com.mojang.logging.LogUtils;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.debug.Debug;
@@ -23,12 +24,9 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-
 import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
-
-import com.mojang.logging.LogUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,6 +44,7 @@ public class StatusBarTracker {
 	private static final Minecraft MINECRAFT = Minecraft.getInstance();
 	private static Resource health = new Resource(100, 100, 0);
 	private static Resource mana = new Resource(100, 100, 0);
+	private static Resource actionBarMana = new Resource(100, 100, 0); // this only exists for showing server side mana
 	private static Resource speed = new Resource(100, 400, 0);
 	private static Resource air = new Resource(100, 300, 0);
 	private static int defense = 0;
@@ -70,6 +69,10 @@ public class StatusBarTracker {
 
 	public static Resource getMana() {
 		return mana;
+	}
+
+	public static Resource getActionBarMana() {
+		return actionBarMana;
 	}
 
 	public static boolean isManaEstimated() {
@@ -101,7 +104,6 @@ public class StatusBarTracker {
 
 	@SuppressWarnings("SameReturnValue")
 	private static InteractionResult interactItem(Player player, Level world, InteractionHand hand) {
-		if (!SkyblockerConfigManager.get().uiAndVisuals.bars.predictManaUsage) return InteractionResult.PASS;
 		if (MINECRAFT.player == null) return InteractionResult.PASS;
 		ItemStack handStack = MINECRAFT.player.getMainHandItem();
 		int manaCost = 0;
@@ -238,6 +240,7 @@ public class StatusBarTracker {
 		int mana = RegexUtils.parseIntFromMatcher(m, "mana");
 		int max = RegexUtils.parseIntFromMatcher(m, "max");
 		int overflow = m.group("overflow") == null ? 0 : RegexUtils.parseIntFromMatcher(m, "overflow");
+		StatusBarTracker.actionBarMana = new Resource(mana, max, overflow);
 		StatusBarTracker.mana = new Resource(mana, max, overflow);
 		if (mana != max && lastMana < mana) manaPerSecond = Math.max(mana - lastMana, 0);
 		if (lastMana != mana || mana == max) lastManaTick = ticks;

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
@@ -387,7 +387,7 @@ public class FancyStatusBars {
 			defenseBar.updateValues(defense / (defense + 100.f), 0, defense, null, null);
 		}
 
-		StatusBarTracker.Resource intelligence = StatusBarTracker.getMana();
+		StatusBarTracker.Resource intelligence = SkyblockerConfigManager.get().uiAndVisuals.bars.predictManaUsage ? StatusBarTracker.getMana() : StatusBarTracker.getActionBarMana();
 		if (SkyblockerConfigManager.get().uiAndVisuals.bars.intelligenceDisplay == UIAndVisualsConfig.IntelligenceDisplay.ACCURATE) {
 			float totalIntelligence = (float) intelligence.max() + intelligence.overflow();
 			statusBars.get(StatusBarType.INTELLIGENCE).updateValues(intelligence.value() / totalIntelligence + intelligence.overflow() / totalIntelligence, intelligence.overflow() / totalIntelligence, intelligence.value(), intelligence.max(), intelligence.overflow());

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1199,6 +1199,8 @@
   "skyblocker.config.uiAndVisuals.bars.riftHealthHP": "Rift Health: HP instead of hearts",
   "skyblocker.config.uiAndVisuals.bars.riftHealthHP.@Tooltip": "In the rift, if enabled, the health status bar will display HP (20, 19, 18, ...) instead of Hearts (10, 9.5, 9, ...)",
   "skyblocker.config.uiAndVisuals.bars.useHungerBarSprites": "Use Vanilla Hunger Bar Sprites",
+	"skyblocker.config.uiAndVisuals.bars.predictManaUsage": "Predict Mana Usage",
+	"skyblocker.config.uiAndVisuals.bars.predictManaUsage.@Tooltip": "Updates Mana Bar Client-Side as Soon as an Ability is Used Without Waiting for Server Update",
 
   "skyblocker.config.uiAndVisuals.bazaarQuickQuantities": "Bazaar Quick Quantities",
   "skyblocker.config.uiAndVisuals.bazaarQuickQuantities.closeSignOnUse": "Close Sign on Use",


### PR DESCRIPTION
Added an option to enable/disable Mana Bar Usage Prediction since it was enforced and there was no option to disable it and made it default enabled as it's the current behaviour.

<img width="593" height="159" alt="image" src="https://github.com/user-attachments/assets/f7b4ed33-3956-4fd6-889e-7c0b162a5d73" />
