### PR TITLE
Add rare crops chat filter

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
@@ -96,6 +96,13 @@ public class ChatCategory {
 								.controller(ConfigUtils.createEnumController())
 								.build())
 						.option(Option.<ChatFilterResult>createBuilder()
+								.name(Component.translatable("skyblocker.config.chat.filter.hideRareCrops"))
+								.binding(defaults.chat.hideRareCrops,
+										() -> config.chat.hideRareCrops,
+										newValue -> config.chat.hideRareCrops = newValue)
+								.controller(ConfigUtils.createEnumController())
+								.build())
+						.option(Option.<ChatFilterResult>createBuilder()
 								.name(Component.translatable("skyblocker.config.chat.filter.hideAds"))
 								.binding(defaults.chat.hideAds,
 										() -> config.chat.hideAds,

--- a/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
@@ -21,6 +21,8 @@ public class ChatConfig {
 
 	public ChatFilterResult hideMoltenWave = ChatFilterResult.PASS;
 
+	public ChatFilterResult hideRareCrops = ChatFilterResult.PASS;
+
 	public ChatFilterResult hideAds = ChatFilterResult.PASS;
 
 	public ChatFilterResult hideTeleportPad = ChatFilterResult.PASS;

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
@@ -1,0 +1,79 @@
+package de.hysky.skyblocker.skyblock.chat.filters;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
+import de.hysky.skyblocker.utils.FlexibleItemStack;
+import de.hysky.skyblocker.utils.ItemUtils;
+import de.hysky.skyblocker.utils.NEURepoManager;
+import de.hysky.skyblocker.utils.chat.ChatFilterResult;
+import de.hysky.skyblocker.utils.chat.ChatPatternListener;
+import de.hysky.skyblocker.utils.render.gui.BasicToast;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import org.jspecify.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+public class RareCropFilter extends ChatPatternListener {
+	private static final Map<String, String> IDS;
+	private static final Map<String, FlexibleItemStack> ICONS = new HashMap<>();
+
+	public RareCropFilter() {
+		super("^RARE CROP! (?<crop>[\\w\\s]+) \\(.*$");
+	}
+
+	private @Nullable ItemStack getCropIcon(Matcher matcher) {
+		String skyblockId = IDS.get(matcher.group("crop"));
+		if (skyblockId == null) return null;
+		if (NEURepoManager.isLoading() || !ItemRepository.filesImported()) return ItemUtils.getItemIdPlaceholder(skyblockId).getStack();
+		return ICONS.computeIfAbsent(skyblockId, id -> ItemRepository.getItemStack(id, ItemUtils.getItemIdPlaceholder(id))).getStack();
+	}
+
+	@Override
+	public boolean onMatch(Component message, Matcher matcher) {
+		if (SkyblockerConfigManager.get().chat.hideRareCrops == ChatFilterResult.TOAST) {
+			Minecraft.getInstance().gui.toastManager().addToast(new BasicToast(message, (long) (SkyblockerConfigManager.get().chat.toastDisplayDuration * 1000L), getCropIcon(matcher)));
+		}
+		return true;
+	}
+
+	@Override
+	public ChatFilterResult state() {
+		if (SkyblockerConfigManager.get().chat.hideRareCrops == ChatFilterResult.TOAST)
+			return ChatFilterResult.FILTER;
+		else
+			return SkyblockerConfigManager.get().chat.hideRareCrops;
+	}
+
+	static {
+		IDS = new HashMap<>();
+		IDS.put("Cropie", "CROPIE");
+		IDS.put("Squash", "SQUASH");
+		IDS.put("Fermento", "FERMENTO");
+		IDS.put("Helianthus", "HELIANTHUS");
+		IDS.put("Warty", "WARTY");
+		IDS.put("Burrowing Spores", "BURROWING_SPORES");
+		IDS.put("Overclocker 3000", "OVERCLOCKER_3000");
+		IDS.put("Ethereal Vine", "ETHEREAL_VINE");
+		IDS.put("Rarefinder Chip", "RAREFINDER_GARDEN_CHIP");
+		// Seasoning has no item to display, so it's excluded here
+		IDS.put("Cornucopia", "CORNUCOPIA");
+		IDS.put("Carrot Zest", "CARROT_ZEST");
+		IDS.put("Deepfries", "DEEPFRIES");
+		IDS.put("Aggourdian", "AGGOURDIAN");
+		IDS.put("Cane Knot", "CANE_KNOT");
+		IDS.put("Melon Juice", "MELON_JUICE");
+		IDS.put("Cactus Flower", "CACTUS_FLOWER");
+		IDS.put("Designer Coffee Beans", "DESIGNER_COFFEE_BEANS");
+		IDS.put("Feastfungus", "FEASTFUNGUS");
+		IDS.put("Botroot", "BOTROOT");
+		IDS.put("Salted Sunflower Seeds", "SALTED_SUNFLOWER_SEEDS");
+		IDS.put("Crystalized Moonlight", "CRYSTALIZED_MOONLIGHT");
+		IDS.put("Floral Gelatin", "FLORAL_GELATIN");
+		IDS.put("Wild Strawberry Dye", "DYE_WILD_STRAWBERRY");
+		IDS.put("Ray of Helios", "RAY_OF_HELIOS");
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
@@ -5,6 +5,7 @@ import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.FlexibleItemStack;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.NEURepoManager;
+import de.hysky.skyblocker.utils.SkyBlockIcons;
 import de.hysky.skyblocker.utils.chat.ChatFilterResult;
 import de.hysky.skyblocker.utils.chat.ChatPatternListener;
 import de.hysky.skyblocker.utils.render.gui.BasicToast;
@@ -22,7 +23,7 @@ public class RareCropFilter extends ChatPatternListener {
 	private static final Map<String, FlexibleItemStack> ICONS = new HashMap<>();
 
 	public RareCropFilter() {
-		super("^RARE CROP! (?<crop>[\\w\\s]+) \\(.*$");
+		super("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+" + SkyBlockIcons.OVERBLOOM + "\\)$");
 	}
 
 	private @Nullable ItemStack getCropIcon(Matcher matcher) {
@@ -73,7 +74,6 @@ public class RareCropFilter extends ChatPatternListener {
 		IDS.put("Salted Sunflower Seeds", "SALTED_SUNFLOWER_SEEDS");
 		IDS.put("Crystalized Moonlight", "CRYSTALIZED_MOONLIGHT");
 		IDS.put("Floral Gelatin", "FLORAL_GELATIN");
-		IDS.put("Wild Strawberry Dye", "DYE_WILD_STRAWBERRY");
-		IDS.put("Ray of Helios", "RAY_OF_HELIOS");
+		// Wild Strawberry Dye and Ray of Helios are handled as rare drops instead
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
@@ -50,7 +50,7 @@ public class RareCropFilter extends ChatPatternListener {
 	private static final Map<String, FlexibleItemStack> ICONS = new HashMap<>();
 
 	public RareCropFilter() {
-		super("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+" + SkyBlockIcons.OVERBLOOM + "\\)$");
+		super("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+(?:\\.\\d+)?" + SkyBlockIcons.OVERBLOOM + "\\).*");
 	}
 
 	private @Nullable ItemStack getCropIcon(Matcher matcher) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
@@ -1,5 +1,15 @@
 package de.hysky.skyblocker.skyblock.chat.filters;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+import org.jspecify.annotations.Nullable;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.itemlist.ItemRepository;
 import de.hysky.skyblocker.utils.FlexibleItemStack;
@@ -9,14 +19,6 @@ import de.hysky.skyblocker.utils.SkyBlockIcons;
 import de.hysky.skyblocker.utils.chat.ChatFilterResult;
 import de.hysky.skyblocker.utils.chat.ChatPatternListener;
 import de.hysky.skyblocker.utils.render.gui.BasicToast;
-import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
-import org.jspecify.annotations.Nullable;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
 
 import static java.util.Map.entry;
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
@@ -18,8 +18,35 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 
+import static java.util.Map.entry;
+
 public class RareCropFilter extends ChatPatternListener {
-	private static final Map<String, String> IDS;
+	private static final Map<String, String> IDS = Map.ofEntries(
+			entry("Cropie", "CROPIE"),
+			entry("Squash", "SQUASH"),
+			entry("Fermento", "FERMENTO"),
+			entry("Helianthus", "HELIANTHUS"),
+			entry("Warty", "WARTY"),
+			entry("Burrowing Spores", "BURROWING_SPORES"),
+			entry("Overclocker 3000", "OVERCLOCKER_3000"),
+			entry("Ethereal Vine", "ETHEREAL_VINE"),
+			entry("Rarefinder Chip", "RAREFINDER_GARDEN_CHIP"),
+			// Seasoning has no item to display, so it's excluded here
+			entry("Cornucopia", "CORNUCOPIA"),
+			entry("Carrot Zest", "CARROT_ZEST"),
+			entry("Deepfries", "DEEPFRIES"),
+			entry("Aggourdian", "AGGOURDIAN"),
+			entry("Cane Knot", "CANE_KNOT"),
+			entry("Melon Juice", "MELON_JUICE"),
+			entry("Cactus Flower", "CACTUS_FLOWER"),
+			entry("Designer Coffee Beans", "DESIGNER_COFFEE_BEANS"),
+			entry("Feastfungus", "FEASTFUNGUS"),
+			entry("Botroot", "BOTROOT"),
+			entry("Salted Sunflower Seeds", "SALTED_SUNFLOWER_SEEDS"),
+			entry("Crystalized Moonlight", "CRYSTALIZED_MOONLIGHT"),
+			entry("Floral Gelatin", "FLORAL_GELATIN")
+			// Wild Strawberry Dye and Ray of Helios are handled as rare drops instead
+	);
 	private static final Map<String, FlexibleItemStack> ICONS = new HashMap<>();
 
 	public RareCropFilter() {
@@ -47,33 +74,5 @@ public class RareCropFilter extends ChatPatternListener {
 			return ChatFilterResult.FILTER;
 		else
 			return SkyblockerConfigManager.get().chat.hideRareCrops;
-	}
-
-	static {
-		IDS = new HashMap<>();
-		IDS.put("Cropie", "CROPIE");
-		IDS.put("Squash", "SQUASH");
-		IDS.put("Fermento", "FERMENTO");
-		IDS.put("Helianthus", "HELIANTHUS");
-		IDS.put("Warty", "WARTY");
-		IDS.put("Burrowing Spores", "BURROWING_SPORES");
-		IDS.put("Overclocker 3000", "OVERCLOCKER_3000");
-		IDS.put("Ethereal Vine", "ETHEREAL_VINE");
-		IDS.put("Rarefinder Chip", "RAREFINDER_GARDEN_CHIP");
-		// Seasoning has no item to display, so it's excluded here
-		IDS.put("Cornucopia", "CORNUCOPIA");
-		IDS.put("Carrot Zest", "CARROT_ZEST");
-		IDS.put("Deepfries", "DEEPFRIES");
-		IDS.put("Aggourdian", "AGGOURDIAN");
-		IDS.put("Cane Knot", "CANE_KNOT");
-		IDS.put("Melon Juice", "MELON_JUICE");
-		IDS.put("Cactus Flower", "CACTUS_FLOWER");
-		IDS.put("Designer Coffee Beans", "DESIGNER_COFFEE_BEANS");
-		IDS.put("Feastfungus", "FEASTFUNGUS");
-		IDS.put("Botroot", "BOTROOT");
-		IDS.put("Salted Sunflower Seeds", "SALTED_SUNFLOWER_SEEDS");
-		IDS.put("Crystalized Moonlight", "CRYSTALIZED_MOONLIGHT");
-		IDS.put("Floral Gelatin", "FLORAL_GELATIN");
-		// Wild Strawberry Dye and Ray of Helios are handled as rare drops instead
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/RareCropFilter.java
@@ -33,7 +33,7 @@ public class RareCropFilter extends ChatPatternListener {
 			entry("Overclocker 3000", "OVERCLOCKER_3000"),
 			entry("Ethereal Vine", "ETHEREAL_VINE"),
 			entry("Rarefinder Chip", "RAREFINDER_GARDEN_CHIP"),
-			// Seasoning has no item to display, so it's excluded here
+			// Seasoning has no item so it's displayed without an icon
 			entry("Cornucopia", "CORNUCOPIA"),
 			entry("Carrot Zest", "CARROT_ZEST"),
 			entry("Deepfries", "DEEPFRIES"),
@@ -65,7 +65,10 @@ public class RareCropFilter extends ChatPatternListener {
 	@Override
 	public boolean onMatch(Component message, Matcher matcher) {
 		if (SkyblockerConfigManager.get().chat.hideRareCrops == ChatFilterResult.TOAST) {
-			Minecraft.getInstance().gui.toastManager().addToast(new BasicToast(message, (long) (SkyblockerConfigManager.get().chat.toastDisplayDuration * 1000L), getCropIcon(matcher)));
+			ItemStack cropIcon = getCropIcon(matcher);
+			if (cropIcon != null || matcher.group("crop").equals("Seasoning")) {
+				Minecraft.getInstance().gui.toastManager().addToast(new BasicToast(message, (long) (SkyblockerConfigManager.get().chat.toastDisplayDuration * 1000L), cropIcon));
+			}
 		}
 		return true;
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 public class RareDropSpecialEffects {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RareDropSpecialEffects.class);
 	private static final Pattern MAGIC_FIND_PATTERN = Pattern.compile("^(?!.*:)(?:RARE|VERY RARE|CRAZY RARE|INSANE) DROP!\\s+\\(?(?<item>.+?)\\)?(?:\\s+\\(\\+\\d+%? "+SkyBlockIcons.MAGIC_FIND+" Magic Find\\))?$");
+	private static final Pattern OVERBLOOM_PATTERN = Pattern.compile("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+" + SkyBlockIcons.OVERBLOOM + "\\)$");
 
 	@Init
 	public static void init() {
@@ -34,6 +35,14 @@ public class RareDropSpecialEffects {
 
 				if (magicFindMatcher.matches()) {
 					triggerDropEffect(magicFindMatcher.group("item"));
+
+					return true;
+				}
+
+				Matcher overbloomMatcher = OVERBLOOM_PATTERN.matcher(stringForm);
+
+				if (overbloomMatcher.matches()) {
+					triggerDropEffect(overbloomMatcher.group("crop"));
 				}
 			} catch (Exception e) { //In case there's a regex failure or something else bad happens
 				LOGGER.error("[Skyblocker Special Effects] An unexpected exception was encountered: ", e);
@@ -85,6 +94,8 @@ public class RareDropSpecialEffects {
 			case "Radioactive Vial" -> "RADIOACTIVE_VIAL";
 			case "Tiki Mask" -> "TIKI_MASK";
 			case "Titanoboa Shed" -> "TITANOBOA_SHED";
+			//Farming
+			case "Ray of Helios" -> "RAY_OF_HELIOS";
 			default -> "NONE";
 		};
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
@@ -21,6 +21,7 @@ import de.hysky.skyblocker.utils.Utils;
 public class RareDropSpecialEffects {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RareDropSpecialEffects.class);
 	private static final Pattern MAGIC_FIND_PATTERN = Pattern.compile("^(?!.*:)(?:RARE|VERY RARE|CRAZY RARE|INSANE) DROP!\\s+\\(?(?<item>.+?)\\)?(?:\\s+\\(\\+\\d+%? "+SkyBlockIcons.MAGIC_FIND+" Magic Find\\))?$");
+	private static final Pattern OVERBLOOM_PATTERN = Pattern.compile("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+" + SkyBlockIcons.OVERBLOOM + "\\)$");
 
 	@Init
 	public static void init() {
@@ -36,6 +37,14 @@ public class RareDropSpecialEffects {
 
 				if (magicFindMatcher.matches()) {
 					triggerDropEffect(magicFindMatcher.group("item"));
+
+					return true;
+				}
+
+				Matcher overbloomMatcher = OVERBLOOM_PATTERN.matcher(stringForm);
+
+				if (overbloomMatcher.matches()) {
+					triggerDropEffect(overbloomMatcher.group("crop"));
 				}
 			} catch (Exception e) { //In case there's a regex failure or something else bad happens
 				LOGGER.error("[Skyblocker Special Effects] An unexpected exception was encountered: ", e);
@@ -87,6 +96,8 @@ public class RareDropSpecialEffects {
 			case "Radioactive Vial" -> "RADIOACTIVE_VIAL";
 			case "Tiki Mask" -> "TIKI_MASK";
 			case "Titanoboa Shed" -> "TITANOBOA_SHED";
+			//Farming
+			case "Ray of Helios" -> "RAY_OF_HELIOS";
 			default -> "NONE";
 		};
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
@@ -21,7 +21,7 @@ import de.hysky.skyblocker.utils.Utils;
 public class RareDropSpecialEffects {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RareDropSpecialEffects.class);
 	private static final Pattern MAGIC_FIND_PATTERN = Pattern.compile("^(?!.*:)(?:RARE|VERY RARE|CRAZY RARE|INSANE) DROP!\\s+\\(?(?<item>.+?)\\)?(?:\\s+\\(\\+\\d+%? "+SkyBlockIcons.MAGIC_FIND+" Magic Find\\))?$");
-	private static final Pattern OVERBLOOM_PATTERN = Pattern.compile("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+" + SkyBlockIcons.OVERBLOOM + "\\)$");
+	private static final Pattern OVERBLOOM_PATTERN = Pattern.compile("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+(?:\\.\\d+)?" + SkyBlockIcons.OVERBLOOM + "\\).*");
 
 	@Init
 	public static void init() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/special/RareDropSpecialEffects.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 public class RareDropSpecialEffects {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RareDropSpecialEffects.class);
 	private static final Pattern MAGIC_FIND_PATTERN = Pattern.compile("^(?!.*:)(?:RARE|VERY RARE|CRAZY RARE|INSANE) DROP!\\s+\\(?(?<item>.+?)\\)?(?:\\s+\\(\\+\\d+%? "+SkyBlockIcons.MAGIC_FIND+" Magic Find\\))?$");
-	private static final Pattern OVERBLOOM_PATTERN = Pattern.compile("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+" + SkyBlockIcons.OVERBLOOM + "\\)$");
+	private static final Pattern OVERBLOOM_PATTERN = Pattern.compile("^RARE CROP!\\s+(?<crop>[\\w\\s]+)\\s+\\(\\+\\d+(?:\\.\\d+)?" + SkyBlockIcons.OVERBLOOM + "\\).*");
 
 	@Init
 	public static void init() {

--- a/src/main/java/de/hysky/skyblocker/utils/SkyBlockIcons.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SkyBlockIcons.java
@@ -19,6 +19,7 @@ public final class SkyBlockIcons {
 
 	// Farming Stats
 	public static final char FARMING_FORTUNE = '\uE051';
+	public static final char OVERBLOOM = '\uE02B';
 
 	// Foraging stats
 	public static final char SWEEP = '\uE023';

--- a/src/main/java/de/hysky/skyblocker/utils/SkyBlockIcons.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SkyBlockIcons.java
@@ -23,6 +23,7 @@ public final class SkyBlockIcons {
 
 	// Farming Stats
 	public static final char FARMING_FORTUNE = '\uE051';
+	public static final char OVERBLOOM = '\uE02B';
 
 	// Foraging stats
 	public static final char SWEEP = '\uE023';

--- a/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
+++ b/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
@@ -17,6 +17,7 @@ import de.hysky.skyblocker.skyblock.chat.filters.ImplosionFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.LotteryFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.MimicFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.MoltenWaveFilter;
+import de.hysky.skyblocker.skyblock.chat.filters.RareCropFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.ShowOffFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.SkyMallFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.SpiritSceptreFilter;
@@ -81,6 +82,7 @@ public interface ChatMessageListener {
 				new ImplosionFilter(),
 				new SpiritSceptreFilter(),
 				new MoltenWaveFilter(),
+				new RareCropFilter(),
 				new TeleportPadFilter(),
 				new AutopetFilter(),
 				new ShowOffFilter(),

--- a/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
+++ b/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
@@ -26,6 +26,7 @@ import de.hysky.skyblocker.skyblock.chat.filters.ImplosionFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.LotteryFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.MimicFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.MoltenWaveFilter;
+import de.hysky.skyblocker.skyblock.chat.filters.RareCropFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.ShowOffFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.SkyMallFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.SpiritSceptreFilter;
@@ -84,6 +85,7 @@ public interface ChatMessageListener {
 				new ImplosionFilter(),
 				new SpiritSceptreFilter(),
 				new MoltenWaveFilter(),
+				new RareCropFilter(),
 				new TeleportPadFilter(),
 				new AutopetFilter(),
 				new ShowOffFilter(),

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -173,6 +173,7 @@
   "skyblocker.config.chat.filter.hideMimicKill": "Hide Mimic Kill Messages",
   "skyblocker.config.chat.filter.hideMimicKill.@Tooltip": "Filters the \"Mimic dead!\" and \"Mimic killed!\" messages from chat.",
   "skyblocker.config.chat.filter.hideMoltenWave": "Hide Molten Wave Message",
+  "skyblocker.config.chat.filter.hideRareCrops": "Hide Rare Crop Messages",
   "skyblocker.config.chat.filter.hideShowOff": "Hide Show Off Messages",
   "skyblocker.config.chat.filter.hideShowOff.@Tooltip": "Filters messages from the /show command",
   "skyblocker.config.chat.filter.hideSpiritSceptre": "Hide Spirit Sceptre Message",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -171,6 +171,7 @@
   "skyblocker.config.chat.filter.hideMimicKill": "Hide Mimic Kill Messages",
   "skyblocker.config.chat.filter.hideMimicKill.@Tooltip": "Filters the \"Mimic dead!\" and \"Mimic killed!\" messages from chat.",
   "skyblocker.config.chat.filter.hideMoltenWave": "Hide Molten Wave Message",
+  "skyblocker.config.chat.filter.hideRareCrops": "Hide Rare Crop Messages",
   "skyblocker.config.chat.filter.hideShowOff": "Hide Show Off Messages",
   "skyblocker.config.chat.filter.hideShowOff.@Tooltip": "Filters messages from the /show command",
   "skyblocker.config.chat.filter.hideSpiritSceptre": "Hide Spirit Sceptre Message",


### PR DESCRIPTION
Referenced the autopet filter code to implement this. Used the independent wiki as a source for [a full list of rare crops](https://hypixelskyblock.minecraft.wiki/w/Rare_Crops).

Primary motivation is adding icons to toasts without needing legitimately 23 different chat rules to do it as a player. Also added Ray of Helios to the list of items with a special drop animation, I think it more than deserves that given it's extreme rarity and high value.

### Testing
<img width="456" height="225" alt="image" src="https://github.com/user-attachments/assets/652252c9-b073-471b-938c-50f509d8b2e8" />