### PR TITLE
Add item protection for Equipment & Stats, Equipment Sets, Armor Sets, Loadouts, and Pets screens

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemProtection.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemProtection.java
@@ -153,7 +153,13 @@ public class ItemProtection {
 				|| screenTitle.startsWith("Endstone Chest")
 				|| screenTitle.startsWith("Skull Chest")
 				|| screenTitle.startsWith("Weapon Rack")
-				|| screenTitle.startsWith("Armor Stand");
+				|| screenTitle.startsWith("Armor Stand")
+				// Equipment & Stats
+				|| screenTitle.startsWith("Your Equipment and Stats")
+				|| screenTitle.contains("Equipment Sets")
+				|| screenTitle.contains("Armor Sets")
+				|| screenTitle.contains("Loadouts")
+				|| screenTitle.contains("Pets");
 	}
 
 	public static boolean isNpcSellMenu(AbstractContainerMenu menu) {


### PR DESCRIPTION
## What 
Added more screens to item protection. Adds item protection support for additional SkyBlock inventory screens that were previously unprotected.  

## Changelog Improvements
+ Added more screens to item protection.
    * Equipment & Stats, Equipment Sets, Armor Sets, Loadouts, and Pets screens.
