### PR TITLE
use chars instead of strings in SkyBlockIcons

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/JacobsContestWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/tabhud/widget/JacobsContestWidget.java
@@ -61,7 +61,7 @@ public class JacobsContestWidget extends TabHudWidget {
 					String crop = matcher.group("crop");
 					String percentage = matcher.group("percentage");
 					MutableComponent cropText = Component.empty().append(crop);
-					if (matcher.group("fortune").equals(SkyBlockIcons.FARMING_FORTUNE)) cropText.append(Component.literal(" " + SkyBlockIcons.FARMING_FORTUNE).withStyle(ChatFormatting.GOLD));
+					if (matcher.group("fortune").equals(String.valueOf(SkyBlockIcons.FARMING_FORTUNE))) cropText.append(Component.literal(" " + SkyBlockIcons.FARMING_FORTUNE).withStyle(ChatFormatting.GOLD));
 
 					this.addComponent(Elements.iconTextComponent(FARM_DATA.get(crop), cropText));
 					if (percentage != null) this.addComponent(new PlainTextElement(Component.literal(percentage)));

--- a/src/main/java/de/hysky/skyblocker/utils/SkyBlockIcons.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SkyBlockIcons.java
@@ -2,40 +2,40 @@ package de.hysky.skyblocker.utils;
 
 public final class SkyBlockIcons {
 	// Combat Stats
-	public static final String HEALTH = "\uE010";
-	public static final String DEFENSE = "\uE008";
-	public static final String TRUE_DEFENSE = "\uE027";
-	public static final String STRENGTH = "\uE00D";
-	public static final String CRIT_DAMAGE = "\uE007";
-	public static final String INTELLIGENCE = "\uE003";
-	public static final String MANA = INTELLIGENCE;
-	public static final String OVERFLOW_MANA = "\uE017";
+	public static final char HEALTH = '\uE010';
+	public static final char DEFENSE = '\uE008';
+	public static final char TRUE_DEFENSE = '\uE027';
+	public static final char STRENGTH = '\uE00D';
+	public static final char CRIT_DAMAGE = '\uE007';
+	public static final char INTELLIGENCE = '\uE003';
+	public static final char MANA = INTELLIGENCE;
+	public static final char OVERFLOW_MANA = '\uE017';
 
 	// Mining Stats
-	public static final String MINING_FORTUNE = "\uE053";
-	public static final String MINING_SPEED = "\uE015";
-	public static final String PRISTINE = "\uE01C";
+	public static final char MINING_FORTUNE = '\uE053';
+	public static final char MINING_SPEED = '\uE015';
+	public static final char PRISTINE = '\uE01C';
 
 	// Farming Stats
-	public static final String FARMING_FORTUNE = "\uE051";
+	public static final char FARMING_FORTUNE = '\uE051';
 
 	// Foraging stats
-	public static final String SWEEP = "\uE023";
-	public static final String FORAGING_FORTUNE = "\uE054";
+	public static final char SWEEP = '\uE023';
+	public static final char FORAGING_FORTUNE = '\uE054';
 
 	// Fishing Stats
-	public static final String FISHING_SPEED = "\uE00C";
+	public static final char FISHING_SPEED = '\uE00C';
 
 	// Misc Stats
-	public static final String MAGIC_FIND = "\uE01A";
+	public static final char MAGIC_FIND = '\uE01A';
 
 	// Rift Stats
-	public static final String RIFT_TIME = "\uE020";
+	public static final char RIFT_TIME = '\uE020';
 
 	// Scoreboard Icons
-	public static final String AREA = "\uE067";
-	public static final String RIFT_AREA = "\uE020";
+	public static final char AREA = '\uE067';
+	public static final char RIFT_AREA = '\uE020';
 
 	// Mob Types
-	public static final String UNDEAD = "\uE084";
+	public static final char UNDEAD = '\uE084';
 }

--- a/src/main/java/de/hysky/skyblocker/utils/Utils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Utils.java
@@ -309,7 +309,7 @@ public class Utils {
 	public static String getIslandArea() {
 		try {
 			for (String sidebarLine : STRING_SCOREBOARD) {
-				if (sidebarLine.contains(SkyBlockIcons.AREA) || sidebarLine.contains(SkyBlockIcons.RIFT_AREA) /* Rift */) {
+				if (sidebarLine.indexOf(SkyBlockIcons.AREA) >= 0 || sidebarLine.indexOf(SkyBlockIcons.RIFT_AREA) >= 0 /* Rift */) {
 					return sidebarLine.strip();
 				}
 			}

--- a/src/main/java/de/hysky/skyblocker/utils/discord/DiscordRPCManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/discord/DiscordRPCManager.java
@@ -109,7 +109,7 @@ public class DiscordRPCManager {
 
 	@SuppressWarnings("deprecation")
 	private static String islandArea() {
-		return Utils.getIslandArea().replace(SkyBlockIcons.AREA, "⏣").replace(SkyBlockIcons.RIFT_AREA, "ф");
+		return Utils.getIslandArea().replace(SkyBlockIcons.AREA, '⏣').replace(SkyBlockIcons.RIFT_AREA, 'ф');
 	}
 
 	public static String getInfo() {


### PR DESCRIPTION
i estimate this saves about 340 bytes of memory. You're welcome.