### PR TITLE
Fix chat waypoints with decimals

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
@@ -25,11 +25,11 @@ import java.util.regex.Pattern;
 
 public class ChatPositionShare {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ChatPositionShare.class);
-	private static final Pattern SIMPLE_COORDS_PATTERN = Pattern.compile("(?<x>-?[0-9]+) (?<y>[0-9]+) (?<z>-?[0-9]+)");
-	private static final Pattern SIMPLE_COMMA_COORDS_PATTERN = Pattern.compile("(?<x>-?[0-9]+), (?<y>[0-9]+), (?<z>-?[0-9]+)");
-	private static final Pattern GENERIC_COORDS_PATTERN = Pattern.compile("x: (?<x>-?[0-9]+), y: (?<y>[0-9]+), z: (?<z>-?[0-9]+)");
-	private static final Pattern SKYBLOCKER_COORDS_PATTERN = Pattern.compile("x: (?<x>-?[0-9]+), y: (?<y>[0-9]+), z: (?<z>-?[0-9]+)(?: \\| (?<area>[^|]+))");
-	private static final Pattern SKYHANNI_DIANA_PATTERN = Pattern.compile("A MINOS INQUISITOR has spawned near \\[(?<area>[^]]*)] at Coords (?<x>-?[0-9]+) (?<y>[0-9]+) (?<z>-?[0-9]+)");
+	private static final Pattern SIMPLE_COORDS_PATTERN = Pattern.compile("(?<x>-?\\d+)\\.?\\d* (?<y>\\d+)\\.?\\d* (?<z>-?\\d+)\\.?\\d*");
+	private static final Pattern SIMPLE_COMMA_COORDS_PATTERN = Pattern.compile("(?<x>-?\\d+)\\.?\\d*, (?<y>\\d+)\\.?\\d*, (?<z>-?\\d+)\\.?\\d*");
+	private static final Pattern GENERIC_COORDS_PATTERN = Pattern.compile("x: (?<x>-?\\d+)\\.?\\d*, y: (?<y>\\d+)\\.?\\d*, z: (?<z>-?\\d+)\\.?\\d*");
+	private static final Pattern SKYBLOCKER_COORDS_PATTERN = Pattern.compile("x: (?<x>-?\\d+)\\.?\\d*, y: (?<y>\\d+)\\.?\\d*, z: (?<z>-?\\d+)\\.?\\d*(?: \\| (?<area>[^|]+))");
+	private static final Pattern SKYHANNI_DIANA_PATTERN = Pattern.compile("A MINOS INQUISITOR has spawned near \\[(?<area>[^]]*)] at Coords (?<x>-?\\d+)\\.?\\d* (?<y>\\d+)\\.?\\d* (?<z>-?\\d+)\\.?\\d*");
 	private static final List<Pattern> PATTERNS = List.of(SKYBLOCKER_COORDS_PATTERN, SKYHANNI_DIANA_PATTERN, GENERIC_COORDS_PATTERN, SIMPLE_COMMA_COORDS_PATTERN, SIMPLE_COORDS_PATTERN);
 
 	@Init

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/ChatPositionShare.java
@@ -25,11 +25,11 @@ import java.util.regex.Pattern;
 
 public class ChatPositionShare {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ChatPositionShare.class);
-	private static final Pattern SIMPLE_COORDS_PATTERN = Pattern.compile("(?<x>-?\\d+)\\.?\\d* (?<y>\\d+)\\.?\\d* (?<z>-?\\d+)\\.?\\d*");
-	private static final Pattern SIMPLE_COMMA_COORDS_PATTERN = Pattern.compile("(?<x>-?\\d+)\\.?\\d*, (?<y>\\d+)\\.?\\d*, (?<z>-?\\d+)\\.?\\d*");
-	private static final Pattern GENERIC_COORDS_PATTERN = Pattern.compile("x: (?<x>-?\\d+)\\.?\\d*, y: (?<y>\\d+)\\.?\\d*, z: (?<z>-?\\d+)\\.?\\d*");
-	private static final Pattern SKYBLOCKER_COORDS_PATTERN = Pattern.compile("x: (?<x>-?\\d+)\\.?\\d*, y: (?<y>\\d+)\\.?\\d*, z: (?<z>-?\\d+)\\.?\\d*(?: \\| (?<area>[^|]+))");
-	private static final Pattern SKYHANNI_DIANA_PATTERN = Pattern.compile("A MINOS INQUISITOR has spawned near \\[(?<area>[^]]*)] at Coords (?<x>-?\\d+)\\.?\\d* (?<y>\\d+)\\.?\\d* (?<z>-?\\d+)\\.?\\d*");
+	private static final Pattern SIMPLE_COORDS_PATTERN = Pattern.compile("(?<x>-?\\d+)(?:\\.\\d*)? (?<y>\\d+)(?:\\.\\d*)? (?<z>-?\\d+)(?:\\.\\d*)?");
+	private static final Pattern SIMPLE_COMMA_COORDS_PATTERN = Pattern.compile("(?<x>-?\\d+)(?:\\.\\d*)?, (?<y>\\d+)(?:\\.\\d*)?, (?<z>-?\\d+)(?:\\.\\d*)?");
+	private static final Pattern GENERIC_COORDS_PATTERN = Pattern.compile("x: (?<x>-?\\d+)(?:\\.\\d*)?, y: (?<y>\\d+)(?:\\.\\d*)?, z: (?<z>-?\\d+)(?:\\.\\d*)?");
+	private static final Pattern SKYBLOCKER_COORDS_PATTERN = Pattern.compile("x: (?<x>-?\\d+)(?:\\.\\d*)?, y: (?<y>\\d+)(?:\\.\\d*)?, z: (?<z>-?\\d+)(?:\\.\\d*)?(?: \\| (?<area>[^|]+))");
+	private static final Pattern SKYHANNI_DIANA_PATTERN = Pattern.compile("A MINOS INQUISITOR has spawned near \\[(?<area>[^]]*)] at Coords (?<x>-?\\d+)(?:\\.\\d*)? (?<y>\\d+)(?:\\.\\d*)? (?<z>-?\\d+)(?:\\.\\d*)?");
 	private static final List<Pattern> PATTERNS = List.of(SKYBLOCKER_COORDS_PATTERN, SKYHANNI_DIANA_PATTERN, GENERIC_COORDS_PATTERN, SIMPLE_COMMA_COORDS_PATTERN, SIMPLE_COORDS_PATTERN);
 
 	@Init


### PR DESCRIPTION
fixes #2562

I chose to ignore the decimal place because it won't change the actual block the waypoint is on (and the waypoint command only accepts integers).

### Testing
<img width="660" height="74" alt="image" src="https://github.com/user-attachments/assets/059cac15-29c6-4b9e-bdc5-65122f0e321e" />
