### PR TITLE
Better Shortcut Duplicate Handling

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -52,9 +52,9 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		} else {
 			addEntry(new ShortcutLoadingEntry());
 		}
-		ShortcutCategoryEntry<String> commandArgCategory = new ShortcutCategoryEntry<>(Shortcuts.shortcuts.getData().commandArgs(), CommandShortcutEntry::new, "skyblocker.shortcuts.commandArg.target", "skyblocker.shortcuts.commandArg.replacement", "skyblocker.shortcuts.commandArg.tooltip");
+		ShortcutCategoryEntry<String> commandArgCategory = new ShortcutCategoryEntry<>(Shortcuts.shortcuts.getData().commandArgs(), CommandArgShortcutEntry::new, "skyblocker.shortcuts.commandArg.target", "skyblocker.shortcuts.commandArg.replacement", "skyblocker.shortcuts.commandArg.tooltip");
 		if (Shortcuts.isShortcutsLoaded()) {
-			commandArgCategory.shortcutsMap.keySet().stream().sorted().forEach(commandArgTarget -> addEntry(new CommandShortcutEntry(commandArgCategory, commandArgTarget)));
+			commandArgCategory.shortcutsMap.keySet().stream().sorted().forEach(commandArgTarget -> addEntry(new CommandArgShortcutEntry(commandArgCategory, commandArgTarget)));
 		} else {
 			addEntry(new ShortcutLoadingEntry());
 		}
@@ -349,6 +349,21 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		protected void updatePositions() {
 			super.updatePositions();
 			target.setX(width / 2 - 160);
+		}
+	}
+
+	protected class CommandArgShortcutEntry extends CommandShortcutEntry {
+		private CommandArgShortcutEntry(ShortcutCategoryEntry<String> category) {
+			super(category);
+		}
+
+		private CommandArgShortcutEntry(ShortcutCategoryEntry<String> category, String targetString) {
+			super(category, targetString);
+		}
+
+		@Override
+		protected String key() {
+			return "arg" + super.key();
 		}
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -25,6 +25,7 @@ import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.TextColor;
 import net.minecraft.util.CommonColors;
 import org.jspecify.annotations.Nullable;
 
@@ -333,6 +334,7 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		private final List<AbstractWidget> children;
 		private final ShortcutKeyBinding keyBinding;
 		private final KeybindWidget keybindButton;
+		private boolean conflicting = false;
 		private boolean duplicate = false;
 
 		private KeybindShortcutEntry(ShortcutCategoryEntry<ShortcutKeyBinding> category) {
@@ -396,8 +398,9 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 			super.extractContent(graphics, mouseX, mouseY, hovered, a);
 			keybindButton.setY(this.getY() + TEXT_FIELD_PADDING);
 			keybindButton.extractRenderState(graphics, mouseX, mouseY, a);
-			if (duplicate) {
-				graphics.fill(keybindButton.getX() - 6, this.getY(), keybindButton.getX() - 3, this.getY() + this.getHeight(), CommonColors.YELLOW);
+			if (conflicting || duplicate) {
+				int color = duplicate ? CommonColors.RED : CommonColors.YELLOW;
+				graphics.fill(keybindButton.getX() - 6, this.getY(), keybindButton.getX() - 3, this.getY() + this.getHeight(), color);
 			}
 		}
 
@@ -413,28 +416,31 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		@SuppressWarnings("JavadocReference")
 		protected void update() {
 			keybindButton.setMessage(keyBinding.getBoundKeysText());
+			conflicting = false;
 			duplicate = false;
-			MutableComponent text = Component.empty();
+			MutableComponent conflictText = Component.empty();
+			MutableComponent duplicateText = Component.empty();
+
 			if (!keyBinding.isUnbound()) {
 				// Check for conflicts with regular keybinds
 				for (KeyMapping otherKeyBinding : minecraft.options.keyMappings) {
 					if (keyBinding.getBoundKeysTranslationKey().contains(otherKeyBinding.saveString())) {
-						if (duplicate) {
-							text.append(", ");
+						if (conflicting) {
+							conflictText.append(", ");
 						}
-						duplicate = true;
-						text.append(Component.translatable(otherKeyBinding.getName()));
+						conflicting = true;
+						conflictText.append(Component.translatable(otherKeyBinding.getName()));
 					}
 				}
 				// Check for conflicts with other keybind shortcuts
 				for (AbstractShortcutEntry shortcut : ShortcutsConfigListWidget.this.children()) {
 					if (shortcut instanceof KeybindShortcutEntry keyBindingShortcut && keyBinding != keyBindingShortcut.keyBinding && keyBinding.equals(keyBindingShortcut.keyBinding)) {
 						if (duplicate) {
-							text.append(", ");
+							duplicateText.append(", ");
 						}
 						duplicate = true;
 						// We display the replacement command to help users identify which shortcuts have conflicting keybinds.
-						text.append(keyBindingShortcut.replacement.getValue());
+						duplicateText.append(keyBindingShortcut.replacement.getValue());
 					}
 				}
 			}
@@ -443,8 +449,14 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 				keybindButton.setMessage(Component.literal("[ ")
 						.append(keybindButton.getMessage().copy().withStyle(ChatFormatting.WHITE))
 						.append(" ]")
-						.withStyle(ChatFormatting.RED));
-				keybindButton.setTooltip(Tooltip.create(Component.translatable("controls.keybinds.duplicateKeybinds", text)));
+						.withColor(TextColor.RED));
+				keybindButton.setTooltip(Tooltip.create(Component.translatable("skyblocker.shortcuts.keyBinding.duplicate", duplicateText)));
+			} else if (conflicting) {
+				keybindButton.setMessage(Component.literal("[ ")
+						.append(keybindButton.getMessage().copy().withStyle(ChatFormatting.WHITE))
+						.append(" ]")
+						.withColor(TextColor.YELLOW));
+				keybindButton.setTooltip(Tooltip.create(Component.translatable("controls.keybinds.duplicateKeybinds", conflictText)));
 			} else {
 				keybindButton.setTooltip(null);
 			}

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -391,7 +391,7 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		}
 
 		/**
-		 * Modified from {@link net.minecraft.client.gui.screens.options.controls.KeyBindsList.KeyEntry#renderContent(GuiGraphics, int, int, boolean, float) ControlsListWidget.KeyBindingEntry#render(DrawContext, int, int, int, int, int, int, int, boolean, float)}.
+		 * Modified from {@link net.minecraft.client.gui.screens.options.controls.KeyBindsList.KeyEntry#extractRenderState(GuiGraphicsExtractor, int, int, float)}  ControlsListWidget.KeyBindingEntry#render(DrawContext, int, int, int, int, int, int, int, boolean, float)}.
 		 */
 		@Override
 		public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float a) {
@@ -413,7 +413,6 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		/**
 		 * Modified from {@link net.minecraft.client.gui.screens.options.controls.KeyBindsList.KeyEntry#resetMappingAndUpdateButtons() ControlsListWidget.KeyBindingEntry#update()}.
 		 */
-		@SuppressWarnings("JavadocReference")
 		protected void update() {
 			keybindButton.setMessage(keyBinding.getBoundKeysText());
 			conflicting = false;

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -115,7 +115,9 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 	}
 
 	protected boolean stopEditing() {
-		return children().stream().filter(KeybindShortcutEntry.class::isInstance).map(KeybindShortcutEntry.class::cast).anyMatch(KeybindShortcutEntry::stopEditing);
+		boolean bl = children().stream().filter(KeybindShortcutEntry.class::isInstance).map(KeybindShortcutEntry.class::cast).anyMatch(KeybindShortcutEntry::stopEditing);
+		screen.checkForDuplicates();
+		return bl;
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -7,9 +7,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
@@ -128,6 +131,18 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 	protected boolean hasChanges() {
 		ShortcutEntry<?>[] notEmptyShortcuts = getNotEmptyShortcuts().toArray(ShortcutEntry[]::new);
 		return notEmptyShortcuts.length != Shortcuts.shortcuts.getData().size() || Arrays.stream(notEmptyShortcuts).anyMatch(ShortcutEntry::isChanged);
+	}
+
+	protected boolean hasDuplicates() {
+		Set<String> keys = new ObjectOpenHashSet<>();
+		for (AbstractShortcutEntry entry : children()) {
+			if (entry instanceof ShortcutEntry<?> shortcutEntry) {
+				String key = shortcutEntry.key();
+				if (keys.contains(key)) return true;
+				keys.add(key);
+			}
+		}
+		return false;
 	}
 
 	protected void saveShortcuts() {
@@ -256,6 +271,8 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 
 		protected abstract void save();
 
+		protected abstract String key();
+
 		@Override
 		public void extractContent(GuiGraphicsExtractor graphics, int mouseX, int mouseY, boolean hovered, float a) {
 			replacement.setY(this.getY() + TEXT_FIELD_PADDING);
@@ -314,6 +331,11 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		@Override
 		protected void save() {
 			category.shortcutsMap.put(target.getValue(), replacement.getValue());
+		}
+
+		@Override
+		protected String key() {
+			return target.getValue();
 		}
 
 		@Override
@@ -388,6 +410,11 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 		@Override
 		protected void save() {
 			category.shortcutsMap.put(keyBinding, replacement.getValue());
+		}
+
+		@Override
+		protected String key() {
+			return keyBinding.getBoundKeysText().getString();
 		}
 
 		/**

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
@@ -22,6 +22,7 @@ public class ShortcutsConfigScreen extends Screen {
 	private Button buttonDone;
 	private boolean initialized;
 	private double scrollAmount;
+	private boolean hasDuplicates;
 
 	public ShortcutsConfigScreen() {
 		this(null);
@@ -93,7 +94,9 @@ public class ShortcutsConfigScreen extends Screen {
 		if (wasEditing) {
 			shortcutsConfigListWidget.updateKeybinds();
 		}
-		return super.mouseClicked(click, doubled);
+		boolean bl = super.mouseClicked(click, doubled);
+		checkForDuplicates();
+		return bl;
 	}
 
 	@Override
@@ -125,5 +128,19 @@ public class ShortcutsConfigScreen extends Screen {
 		buttonDelete.active = Shortcuts.isShortcutsLoaded() && shortcutsConfigListWidget.getSelected() instanceof ShortcutsConfigListWidget.ShortcutEntry;
 		buttonNew.active = Shortcuts.isShortcutsLoaded() && shortcutsConfigListWidget.getCategory().isPresent();
 		buttonDone.active = Shortcuts.isShortcutsLoaded();
+	}
+
+	protected void checkForDuplicates() {
+		hasDuplicates = shortcutsConfigListWidget.hasDuplicates();
+
+		if (hasDuplicates) {
+			buttonDone.active = false;
+			buttonDone.setTooltip(Tooltip.create(Component.translatable("skyblocker.shortcuts.hasDuplicates")));
+			// set button text
+		} else {
+			buttonDone.active = true;
+			buttonDone.setTooltip(Tooltip.create(Component.translatable("skyblocker.shortcuts.commandSuggestionTooltip")));
+			// set button text
+		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
@@ -136,11 +136,9 @@ public class ShortcutsConfigScreen extends Screen {
 		if (hasDuplicates) {
 			buttonDone.active = false;
 			buttonDone.setTooltip(Tooltip.create(Component.translatable("skyblocker.shortcuts.hasDuplicates")));
-			// set button text
 		} else {
 			buttonDone.active = true;
 			buttonDone.setTooltip(Tooltip.create(Component.translatable("skyblocker.shortcuts.commandSuggestionTooltip")));
-			// set button text
 		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
@@ -84,15 +84,11 @@ public class ShortcutsConfigScreen extends Screen {
 
 	@Override
 	public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
-		if (super.mouseClicked(click, doubled)) {
-			return true;
-		}
-		// Only stop editing if super didn't consume the click
 		boolean wasEditing = shortcutsConfigListWidget.stopEditing();
 		if (wasEditing) {
 			shortcutsConfigListWidget.updateKeybinds();
 		}
-		return wasEditing;
+		return super.mouseClicked(click, doubled);
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigScreen.java
@@ -69,8 +69,13 @@ public class ShortcutsConfigScreen extends Screen {
 	}
 
 	private void deleteEntry(boolean confirmedAction, ShortcutsConfigListWidget.AbstractShortcutEntry entry) {
-		if (confirmedAction && entry instanceof ShortcutsConfigListWidget.ShortcutEntry<?> shortcutEntry) {
-			shortcutsConfigListWidget.removeEntry(shortcutEntry);
+		if (confirmedAction) {
+			if (entry instanceof ShortcutsConfigListWidget.ShortcutEntry<?> shortcutEntry) {
+				shortcutsConfigListWidget.removeEntry(shortcutEntry);
+			}
+			if (entry instanceof ShortcutsConfigListWidget.KeybindShortcutEntry) {
+				shortcutsConfigListWidget.updateKeybinds();
+			}
 		}
 		minecraft.gui.setScreen(this); // Re-inits the screen and keeps the old instance of ShortcutsConfigListWidget
 		shortcutsConfigListWidget.setScrollAmount(scrollAmount);

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1904,6 +1904,7 @@
   "skyblocker.shortcuts.keyBinding.target": "Key Bind",
   "skyblocker.shortcuts.keyBinding.tooltip": "Run a command when a key is pressed.",
 	"skyblocker.shortcuts.keyBinding.duplicate": "⚠ This key is used by another shortcut, which is not allowed! ⚠\n\nRemove this shortcut or:\n%s",
+	"skyblocker.shortcuts.hasDuplicates": "Cannot save as there are entries with the same target command or keybind!",
   "skyblocker.shortcuts.new": "New Shortcut",
   "skyblocker.shortcuts.notLoaded": "§c§lShortcuts not loaded yet",
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1900,7 +1900,7 @@
   "skyblocker.shortcuts.config": "Shortcuts Config",
   "skyblocker.shortcuts.deleteQuestion": "Are you sure you want to remove this shortcut?",
   "skyblocker.shortcuts.deleteWarning": "Shortcut '%s' will be lost forever! (A long time!)",
-  "skyblocker.shortcuts.hasDuplicates": "Cannot save as there are entries with the same target command or keybind!",
+  "skyblocker.shortcuts.hasDuplicates": "Cannot save as there are entries with the same target command or key bind!",
   "skyblocker.shortcuts.keyBinding.duplicate": "⚠ This key is used by another shortcut, which is not allowed! ⚠\n\nRemove this shortcut or:\n%s",
   "skyblocker.shortcuts.keyBinding.replacement": "Execute Command",
   "skyblocker.shortcuts.keyBinding.target": "Key Bind",

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1900,11 +1900,11 @@
   "skyblocker.shortcuts.config": "Shortcuts Config",
   "skyblocker.shortcuts.deleteQuestion": "Are you sure you want to remove this shortcut?",
   "skyblocker.shortcuts.deleteWarning": "Shortcut '%s' will be lost forever! (A long time!)",
+  "skyblocker.shortcuts.hasDuplicates": "Cannot save as there are entries with the same target command or keybind!",
+  "skyblocker.shortcuts.keyBinding.duplicate": "⚠ This key is used by another shortcut, which is not allowed! ⚠\n\nRemove this shortcut or:\n%s",
   "skyblocker.shortcuts.keyBinding.replacement": "Execute Command",
   "skyblocker.shortcuts.keyBinding.target": "Key Bind",
   "skyblocker.shortcuts.keyBinding.tooltip": "Run a command when a key is pressed.",
-	"skyblocker.shortcuts.keyBinding.duplicate": "⚠ This key is used by another shortcut, which is not allowed! ⚠\n\nRemove this shortcut or:\n%s",
-	"skyblocker.shortcuts.hasDuplicates": "Cannot save as there are entries with the same target command or keybind!",
   "skyblocker.shortcuts.new": "New Shortcut",
   "skyblocker.shortcuts.notLoaded": "§c§lShortcuts not loaded yet",
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1903,6 +1903,7 @@
   "skyblocker.shortcuts.keyBinding.replacement": "Execute Command",
   "skyblocker.shortcuts.keyBinding.target": "Key Bind",
   "skyblocker.shortcuts.keyBinding.tooltip": "Run a command when a key is pressed.",
+	"skyblocker.shortcuts.keyBinding.duplicate": "⚠ This key is used by another shortcut, which is not allowed! ⚠\n\nRemove this shortcut or:\n%s",
   "skyblocker.shortcuts.new": "New Shortcut",
   "skyblocker.shortcuts.notLoaded": "§c§lShortcuts not loaded yet",
 


### PR DESCRIPTION
Duplicates currently cause the screen to exit and prevent proper saving (one will overwrite the other), so it should tell you that there are duplicates that need to be removed/modified.

For keybinds with duplicates, they will now be in red and have this text:
<img width="743" height="288" alt="image" src="https://github.com/user-attachments/assets/bd71eb45-6318-44c6-8237-91600e293f71" />

Keybinds that conflict with vanilla keybinds are now fully in yellow:
<img width="695" height="188" alt="image" src="https://github.com/user-attachments/assets/3e1c0b3b-4c05-414f-b7d2-f335e320becc" />

For all duplicates, the "Done" button will be disabled and have this tooltip:
<img width="539" height="145" alt="image" src="https://github.com/user-attachments/assets/5f208c7e-9f94-47d6-934d-12735e929057" />

Once removed, it is re-enabled, and the tooltip is reset.