### PR TITLE
Clean up some concurrency usage

### DIFF
--- a/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
+++ b/src/main/java/de/hysky/skyblocker/SkyblockerMod.java
@@ -20,6 +20,8 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.Identifier;
 import java.nio.file.Path;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 /**
  * Main class for Skyblocker which initializes features, registers events, and
@@ -34,6 +36,7 @@ public class SkyblockerMod implements ClientModInitializer {
 	public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 	public static final Gson GSON_COMPACT = new GsonBuilder().create();
 	public static final KeyMapping.Category KEYBINDING_CATEGORY = KeyMapping.Category.register(id("main"));
+	public static final Executor VIRTUAL_THREAD_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
 
 	public static Identifier id(String path) {
 		return Identifier.fromNamespaceAndPath(NAMESPACE, path);

--- a/src/main/java/de/hysky/skyblocker/UpdateNotifications.java
+++ b/src/main/java/de/hysky/skyblocker/UpdateNotifications.java
@@ -40,7 +40,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.UnaryOperator;
 
 public class UpdateNotifications {
@@ -110,7 +109,7 @@ public class UpdateNotifications {
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker Update Notifications] Failed to determine if an update is available or not!", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static void introduceNewUpdate() {

--- a/src/main/java/de/hysky/skyblocker/config/ConfigPatchLoader.java
+++ b/src/main/java/de/hysky/skyblocker/config/ConfigPatchLoader.java
@@ -2,7 +2,6 @@ package de.hysky.skyblocker.config;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 
@@ -58,7 +57,7 @@ public class ConfigPatchLoader {
 				LOGGER.error(LogUtils.FATAL_MARKER, "[Skyblocker Config Patch Loader] Failed to load config patches!", e);
 				return null;
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor())
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR)
 		.thenApplyAsync(json -> {
 			List<ConfigPatch> patches = ConfigPatch.PATCH_LIST_CODEC.parse(JsonOps.INSTANCE, json)
 					.setPartial(List.of())

--- a/src/main/java/de/hysky/skyblocker/config/ImageRepoLoader.java
+++ b/src/main/java/de/hysky/skyblocker/config/ImageRepoLoader.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -86,7 +85,7 @@ public class ImageRepoLoader {
 					update(retries + 1);
 				}
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	/**

--- a/src/main/java/de/hysky/skyblocker/config/backup/ConfigBackupManager.java
+++ b/src/main/java/de/hysky/skyblocker/config/backup/ConfigBackupManager.java
@@ -15,7 +15,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 /**
@@ -36,7 +35,7 @@ public class ConfigBackupManager {
 			} catch (IOException e) {
 				LOGGER.error("[Skyblocker] Failed to create backup directory!", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 
 		ClientLifecycleEvents.CLIENT_STOPPING.register(_ -> backupConfig());
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/ChaptersAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/ChaptersAutocomplete.java
@@ -7,6 +7,7 @@ import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.utils.Http;
 import de.hysky.skyblocker.utils.Utils;
@@ -18,7 +19,6 @@ import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.literal;
@@ -41,7 +41,7 @@ public final class ChaptersAutocomplete {
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker Chapters Autocomplete] Failed to load Chapters data...", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static LiteralCommandNode<FabricClientCommandSource> createCommandNode(String command) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/JoinInstanceAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/JoinInstanceAutocomplete.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.utils.Http;
 import de.hysky.skyblocker.utils.Utils;
@@ -16,7 +17,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.argument;
@@ -50,7 +50,7 @@ public class JoinInstanceAutocomplete {
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker] Failed to load joininstance list", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static LiteralCommandNode<FabricClientCommandSource> buildCommand(String command, java.util.function.Predicate<String> filter) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/RngMeterAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/RngMeterAutocomplete.java
@@ -7,9 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
-import de.hysky.skyblocker.utils.command.CommandUtils;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -20,9 +18,11 @@ import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.utils.Http;
 import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.command.CommandUtils;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.commands.SharedSuggestionProvider;
 
@@ -45,7 +45,7 @@ public class RngMeterAutocomplete {
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker RNG Meter Autocomplete] Failed to load RNG Meter data.", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static LiteralCommandNode<FabricClientCommandSource> createCommandNode(String command) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/WarpAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/WarpAutocomplete.java
@@ -32,7 +32,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.argument;
@@ -59,7 +58,7 @@ public class WarpAutocomplete {
 				LOGGER.error("[Skyblocker] Failed to download warps list", e);
 			}
 			return Object2BooleanMaps.<String>emptyMap();
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(warps -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(warps -> {
 					if (warps.isEmpty()) {
 						getWarpsFromFile();
 					} else {
@@ -72,7 +71,7 @@ public class WarpAutocomplete {
 							} catch (Exception e) {
 								LOGGER.error("[Skyblocker] Failed to save warps auto complete", e);
 							}
-						}, Executors.newVirtualThreadPerTaskExecutor());
+						}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 						createCommandNode(warps);
 					}
 				}
@@ -91,7 +90,7 @@ public class WarpAutocomplete {
 				return Object2BooleanMaps.<String>emptyMap();
 			}
 			return MAP_CODEC.parse(JsonOps.INSTANCE, object).result().orElse(Object2BooleanMaps.emptyMap());
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(WarpAutocomplete::createCommandNode);
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(WarpAutocomplete::createCommandNode);
 	}
 
 	private static void createCommandNode(Object2BooleanMap<String> warps) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/WarpAutocomplete.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/WarpAutocomplete.java
@@ -58,39 +58,37 @@ public class WarpAutocomplete {
 				LOGGER.error("[Skyblocker] Failed to download warps list", e);
 			}
 			return Object2BooleanMaps.<String>emptyMap();
-		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(warps -> {
-					if (warps.isEmpty()) {
-						getWarpsFromFile();
-					} else {
-						CompletableFuture.runAsync(() -> {
-							Optional<JsonElement> result = MAP_CODEC.encodeStart(JsonOps.INSTANCE, warps).result();
-							if (result.isEmpty()) return;
-							JsonElement warpsJson = result.get();
-							try (BufferedWriter writer = Files.newBufferedWriter(FILE, StandardCharsets.UTF_8)) {
-								SkyblockerMod.GSON.toJson(warpsJson, writer);
-							} catch (Exception e) {
-								LOGGER.error("[Skyblocker] Failed to save warps auto complete", e);
-							}
-						}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
-						createCommandNode(warps);
-					}
-				}
-		);
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(warps -> {
+			if (warps.isEmpty()) {
+				warps = getWarpsFromFile();
+			}
+			createCommandNode(warps);
+			saveWarpsToFile(warps);
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
-	private static void getWarpsFromFile() {
-		CompletableFuture.supplyAsync(() -> {
-			JsonObject object;
-			try (BufferedReader reader = Files.newBufferedReader(FILE)) {
-				object = SkyblockerMod.GSON.fromJson(reader, JsonObject.class);
-			} catch (NoSuchFileException _) {
-				return Object2BooleanMaps.<String>emptyMap();
-			} catch (Exception e) {
-				LOGGER.error("[Skyblocker] Failed to read warp autocomplete file", e);
-				return Object2BooleanMaps.<String>emptyMap();
-			}
-			return MAP_CODEC.parse(JsonOps.INSTANCE, object).result().orElse(Object2BooleanMaps.emptyMap());
-		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(WarpAutocomplete::createCommandNode);
+	private static Object2BooleanMap<String> getWarpsFromFile() {
+		JsonObject object;
+		try (BufferedReader reader = Files.newBufferedReader(FILE)) {
+			object = SkyblockerMod.GSON.fromJson(reader, JsonObject.class);
+		} catch (NoSuchFileException _) {
+			return Object2BooleanMaps.emptyMap();
+		} catch (Exception e) {
+			LOGGER.error("[Skyblocker] Failed to read warp autocomplete file", e);
+			return Object2BooleanMaps.emptyMap();
+		}
+		return MAP_CODEC.parse(JsonOps.INSTANCE, object).result().orElse(Object2BooleanMaps.emptyMap());
+	}
+
+	private static void saveWarpsToFile(Object2BooleanMap<String> warps) {
+		Optional<JsonElement> result = MAP_CODEC.encodeStart(JsonOps.INSTANCE, warps).result();
+		if (result.isEmpty()) return;
+		JsonElement warpsJson = result.get();
+		try (BufferedWriter writer = Files.newBufferedWriter(FILE, StandardCharsets.UTF_8)) {
+			SkyblockerMod.GSON.toJson(warpsJson, writer);
+		} catch (Exception e) {
+			LOGGER.error("[Skyblocker] Failed to save warps auto complete", e);
+		}
 	}
 
 	private static void createCommandNode(Object2BooleanMap<String> warps) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/kuudra/KuudraWaypoints.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/kuudra/KuudraWaypoints.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -79,7 +78,7 @@ public class KuudraWaypoints {
 
 				return List.<Waypoint>of();
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(list::addAll);
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(list::addAll);
 	}
 
 	private static JsonElement getWaypoints(BufferedReader reader) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/crimson/kuudra/KuudraWaypoints.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/crimson/kuudra/KuudraWaypoints.java
@@ -78,7 +78,7 @@ public class KuudraWaypoints {
 
 				return List.<Waypoint>of();
 			}
-		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(list::addAll);
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(list::addAll, client);
 	}
 
 	private static JsonElement getWaypoints(BufferedReader reader) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GoldorWaypointsManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GoldorWaypointsManager.java
@@ -93,13 +93,13 @@ public class GoldorWaypointsManager {
 
 				return List.<GoldorWaypoint>of();
 			}
-		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(list -> list.forEach(waypoint -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(list -> list.forEach(waypoint -> {
 			switch (waypoint.kind) {
 				case TERMINAL -> TERMINALS.add(waypoint);
 				case DEVICE -> DEVICES.add(waypoint);
 				case LEVER -> LEVERS.add(waypoint);
 			}
-		}));
+		}), client);
 	}
 
 	/**

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GoldorWaypointsManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/GoldorWaypointsManager.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -94,7 +93,7 @@ public class GoldorWaypointsManager {
 
 				return List.<GoldorWaypoint>of();
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(list -> list.forEach(waypoint -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(list -> list.forEach(waypoint -> {
 			switch (waypoint.kind) {
 				case TERMINAL -> TERMINALS.add(waypoint);
 				case DEVICE -> DEVICES.add(waypoint);

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/partyfinder/PartyFinderScreen.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 public class PartyFinderScreen extends Screen {
 	protected static final Logger LOGGER = LoggerFactory.getLogger(PartyFinderScreen.class);
@@ -137,7 +136,7 @@ public class PartyFinderScreen extends Screen {
 				} catch (Exception e) {
 					LOGGER.error("[Skyblocker] Failed to load dungeons floor skull textures json", e);
 				}
-			}, Executors.newVirtualThreadPerTaskExecutor());
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		});
 		ClientSendMessageEvents.COMMAND.register(command -> {
 			if (!Utils.isOnSkyblock() || !SkyblockerConfigManager.get().dungeons.fancyPartyFinder) return;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonManager.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
@@ -347,11 +346,11 @@ public class DungeonManager {
 			String room = path[3].substring(0, path[3].length() - ".skeleton".length());
 			ROOMS_DATA.computeIfAbsent(dungeon, _ -> new ConcurrentHashMap<>());
 			ROOMS_DATA.get(dungeon).computeIfAbsent(roomShape, _ -> new ConcurrentHashMap<>());
-			dungeonFutures.add(CompletableFuture.supplyAsync(() -> readRoom(resourceEntry.getValue()), Executors.newVirtualThreadPerTaskExecutor()).thenAcceptAsync(blocks -> {
+			dungeonFutures.add(CompletableFuture.supplyAsync(() -> readRoom(resourceEntry.getValue()), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(blocks -> {
 				Map<String, int[]> roomsMap = ROOMS_DATA.get(dungeon).get(roomShape);
 				roomsMap.put(room, blocks);
 				LOGGER.debug("[Skyblocker Dungeon Secrets] Loaded dungeon room skeleton - dungeon={}, shape={}, room={}", dungeon, roomShape, room);
-			}, Executors.newVirtualThreadPerTaskExecutor()).exceptionally(e -> {
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(e -> {
 				LOGGER.error("[Skyblocker Dungeon Secrets] Failed to load dungeon room skeleton - dungeon={}, shape={}, room={}", dungeon, roomShape, room, e);
 				return null;
 			}));
@@ -373,7 +372,7 @@ public class DungeonManager {
 					throw new RuntimeException(ex);
 				}
 				LOGGER.debug("[Skyblocker Dungeon Secrets] Loaded dungeon room secrets - dungeon={}, shape={}, room={}", dungeon, roomShape, room);
-			}, Executors.newVirtualThreadPerTaskExecutor()).exceptionally(e -> {
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(e -> {
 				LOGGER.error("[Skyblocker Dungeon Secrets] Failed to load room secrets - dungeon={}, shape={}, room={}", dungeon, roomShape, room, e);
 				return null;
 			}));
@@ -389,7 +388,7 @@ public class DungeonManager {
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker Dungeon Secrets] Failed to load custom dungeon secret waypoints", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor()));
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR));
 		roomsLoaded = CompletableFuture.allOf(dungeonFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("[Skyblocker Dungeon Secrets] Loaded dungeon secrets for {} dungeon(s), {} room shapes, {} rooms, and {} custom secret waypoints total in {} ms", ROOMS_DATA.size(), ROOMS_DATA.values().stream().mapToInt(Map::size).sum(), ROOMS_DATA.values().stream().map(Map::values).flatMap(Collection::stream).mapToInt(Map::size).sum(), customWaypoints.size(), System.currentTimeMillis() - startTime)).exceptionally(e -> {
 			LOGGER.error("[Skyblocker Dungeon Secrets] Failed to load dungeon secrets", e);
 			return null;

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonPlayerManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonPlayerManager.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.dungeon.secrets;
 
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.GenToString;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.events.DungeonEvents;
@@ -19,7 +20,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
@@ -133,7 +133,7 @@ public class DungeonPlayerManager {
 			update(dungeonClass);
 
 			// Pre-fetches game profiles for rendering skins in the leap overlay and fancy dungeon map.
-			CompletableFuture.runAsync(() -> Minecraft.getInstance().services().sessionService().fetchProfile(uuid, false), Executors.newVirtualThreadPerTaskExecutor());
+			CompletableFuture.runAsync(() -> Minecraft.getInstance().services().sessionService().fetchProfile(uuid, false), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		}
 
 		private static @Nullable UUID findPlayerUuid(String name) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretsTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/secrets/SecretsTracker.java
@@ -2,6 +2,7 @@ package de.hysky.skyblocker.skyblock.dungeon.secrets;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.events.DungeonEvents;
@@ -18,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -65,7 +65,7 @@ public class SecretsTracker {
 				}
 
 				currentRun = newlyStartedRun;
-			}, Executors.newVirtualThreadPerTaskExecutor());
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 
 			case END -> CompletableFuture.runAsync(() -> {
 				TrackedRun thisRun = currentRun;
@@ -96,7 +96,7 @@ public class SecretsTracker {
 				} else {
 					RenderHelper.runOnRenderThread(SecretsTracker::sendFailureMessage);
 				}
-			}, Executors.newVirtualThreadPerTaskExecutor());
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		}
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/events/EventNotifications.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/events/EventNotifications.java
@@ -9,6 +9,7 @@ import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.EventNotificationsConfig;
@@ -32,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 
 public class EventNotifications {
 	private static final Logger LOGGER = LogUtils.getLogger();
@@ -112,7 +112,7 @@ public class EventNotifications {
 				LOGGER.error("[Skyblocker] Failed to download events list", e);
 			}
 			return null;
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(response -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(response -> {
 			events.clear();
 			if (response == null) {
 				LOGGER.error("[Skyblocker] Failed to get events list");

--- a/src/main/java/de/hysky/skyblocker/skyblock/events/EventNotifications.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/events/EventNotifications.java
@@ -112,7 +112,7 @@ public class EventNotifications {
 				LOGGER.error("[Skyblocker] Failed to download events list", e);
 			}
 			return null;
-		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(response -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(response -> {
 			events.clear();
 			if (response == null) {
 				LOGGER.error("[Skyblocker] Failed to get events list");
@@ -135,7 +135,7 @@ public class EventNotifications {
 					config.eventNotifications.events.computeIfAbsent(s, _ -> DEFAULT_REMINDERS);
 				}
 			});
-		}).exceptionally(EventNotifications::itBorked);
+		}, Minecraft.getInstance()).exceptionally(EventNotifications::itBorked);
 	}
 
 	private static Void itBorked(Throwable throwable) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
@@ -42,7 +42,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 public class FancyStatusBars {
@@ -125,7 +124,7 @@ public class FancyStatusBars {
 		initBarPosition(statusBars.get(StatusBarType.SPEED), counts, UIAndVisualsConfig.LegacyBarPosition.RIGHT);
 		initBarPosition(statusBars.get(StatusBarType.AIR), counts, UIAndVisualsConfig.LegacyBarPosition.RIGHT);
 
-		CompletableFuture.supplyAsync(FancyStatusBars::loadBarConfig, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(object -> {
+		CompletableFuture.supplyAsync(FancyStatusBars::loadBarConfig, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(object -> {
 			if (object != null) {
 				for (String s : object.keySet()) {
 					StatusBarType type = StatusBarType.from(s);

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
@@ -124,7 +124,7 @@ public class FancyStatusBars {
 		initBarPosition(statusBars.get(StatusBarType.SPEED), counts, UIAndVisualsConfig.LegacyBarPosition.RIGHT);
 		initBarPosition(statusBars.get(StatusBarType.AIR), counts, UIAndVisualsConfig.LegacyBarPosition.RIGHT);
 
-		CompletableFuture.supplyAsync(FancyStatusBars::loadBarConfig, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(object -> {
+		CompletableFuture.supplyAsync(FancyStatusBars::loadBarConfig, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(object -> {
 			if (object != null) {
 				for (String s : object.keySet()) {
 					StatusBarType type = StatusBarType.from(s);
@@ -141,7 +141,7 @@ public class FancyStatusBars {
 			}
 			placeBarsInPositioner();
 			configLoaded = true;
-		}).exceptionally(throwable -> {
+		}, Minecraft.getInstance()).exceptionally(throwable -> {
 			LOGGER.error("[Skyblocker] Failed reading status bars config", throwable);
 			return null;
 		});

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlots.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlots.java
@@ -41,7 +41,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 public final class GardenPlots {
 	private static final Logger LOGGER = LoggerFactory.getLogger("Garden Plots");
@@ -105,14 +104,14 @@ public final class GardenPlots {
 
 		SkyblockEvents.PROFILE_CHANGE.register(((prevProfileId, profileId) -> {
 			if (!prevProfileId.isEmpty())
-				CompletableFuture.runAsync(() -> save(prevProfileId), Executors.newVirtualThreadPerTaskExecutor()).thenRun(() -> load(profileId));
+				CompletableFuture.runAsync(() -> save(prevProfileId), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenRun(() -> load(profileId));
 			else load(profileId);
 		}));
 
 		ClientLifecycleEvents.CLIENT_STOPPING.register(_ -> {
 			String profileId = Utils.getProfileId();
 			if (!profileId.isBlank()) {
-				CompletableFuture.runAsync(() -> save(profileId), Executors.newVirtualThreadPerTaskExecutor());
+				CompletableFuture.runAsync(() -> save(profileId), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 			}
 		});
 	}
@@ -153,7 +152,7 @@ public final class GardenPlots {
 			}
 			return new GardenPlot[25];
 			// Schedule on main thread to avoid any async weirdness
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(newPlots -> Minecraft.getInstance().execute(() -> System.arraycopy(newPlots, 0, GARDEN_PLOTS, 0, Math.min(newPlots.length, 25))));
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(newPlots -> Minecraft.getInstance().execute(() -> System.arraycopy(newPlots, 0, GARDEN_PLOTS, 0, Math.min(newPlots.length, 25))));
 	}
 
 	public record GardenPlot(Either<Item, String> icon, String name, Optional<String> customIcon) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlots.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/garden/GardenPlots.java
@@ -152,7 +152,7 @@ public final class GardenPlots {
 			}
 			return new GardenPlot[25];
 			// Schedule on main thread to avoid any async weirdness
-		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(newPlots -> Minecraft.getInstance().execute(() -> System.arraycopy(newPlots, 0, GARDEN_PLOTS, 0, Math.min(newPlots.length, 25))));
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(newPlots -> System.arraycopy(newPlots, 0, GARDEN_PLOTS, 0, Math.min(newPlots.length, 25)), Minecraft.getInstance());
 	}
 
 	public record GardenPlot(Either<Item, String> icon, String name, Optional<String> customIcon) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/hunting/AttributesDebug.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/hunting/AttributesDebug.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -99,7 +98,7 @@ public class AttributesDebug {
 				} catch (Exception e) {
 					LOGGER.error("[Skyblocker Attributes Debug] Failed to export attributes!", e);
 				}
-			}, Executors.newVirtualThreadPerTaskExecutor());
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/ItemPrice.java
@@ -16,6 +16,7 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.Slot;
@@ -101,10 +102,10 @@ public class ItemPrice {
 		CompletableFuture.allOf(Stream.of(TooltipInfoType.NPC, TooltipInfoType.BAZAAR, TooltipInfoType.LOWEST_BINS, TooltipInfoType.ONE_DAY_AVERAGE, TooltipInfoType.THREE_DAY_AVERAGE)
 						.map(DataTooltipInfoType::downloadIfEnabled)
 						.toArray(CompletableFuture[]::new)
-		).thenRun(() -> {
+		).thenRunAsync(() -> {
 			ItemPriceUpdateEvent.ON_PRICE_UPDATE.invoker().onPriceUpdate();
 			player.sendSystemMessage(Constants.PREFIX.get().append(Component.translatable("skyblocker.config.helpers.itemPrice.refreshedItemPrices")));
-		}).exceptionally(e -> {
+		}, Minecraft.getInstance()).exceptionally(e -> {
 			ItemTooltip.LOGGER.error("[Skyblocker Item Price] Failed to refresh item prices", e);
 			player.sendSystemMessage(Constants.PREFIX.get().append(Component.translatable("skyblocker.config.helpers.itemPrice.itemPriceRefreshFailed")));
 			return null;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
@@ -50,6 +50,7 @@ import java.util.function.Supplier;
  * <p>Opened here {@link de.hysky.skyblocker.mixins.MinecraftMixin#skyblocker$skyblockInventoryScreen MinecraftClientMixin#skyblocker$skyblockInventoryScreen}</p>
  * <p>Book button is moved here {@link de.hysky.skyblocker.mixins.InventoryScreenMixin#skyblocker$moveButton InventoryScreenMixin#skyblocker$moveButton}</p>
  */
+@SuppressWarnings("JavadocReference")
 public class SkyblockInventoryScreen extends InventoryScreen implements HoveredItemStackProvider {
 	private static final Logger LOGGER = LoggerFactory.getLogger("Equipment");
 	private static final Supplier<ItemStack[]> EMPTY_EQUIPMENT = () -> new ItemStack[]{ItemStack.EMPTY, ItemStack.EMPTY, ItemStack.EMPTY, ItemStack.EMPTY};
@@ -204,7 +205,7 @@ public class SkyblockInventoryScreen extends InventoryScreen implements HoveredI
 	@Override
 	public boolean keyPressed(KeyEvent input) {
 		Minecraft client = Minecraft.getInstance();
-		if (client.isWindowActive()) {
+		if (client.isWindowActive() && client.player != null) {
 			var mouse = client.mouseHandler;
 			var window = client.getWindow();
 			var mouseX = MouseHandler.getScaledXPos(window, mouse.xpos());
@@ -240,7 +241,7 @@ public class SkyblockInventoryScreen extends InventoryScreen implements HoveredI
 		}
 
 		@Override
-		public @Nullable Identifier getNoItemIcon() {
+		public Identifier getNoItemIcon() {
 			return noItemIcon;
 		}
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
@@ -43,7 +43,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 /**
@@ -99,7 +98,7 @@ public class SkyblockInventoryScreen extends InventoryScreen implements HoveredI
 			}
 			return EMPTY_EQUIPMENT.get();
 			// Schedule on main thread to avoid any async weirdness
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenAccept(itemStacks -> Minecraft.getInstance().execute(() -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(itemStacks -> Minecraft.getInstance().execute(() -> {
 			System.arraycopy(itemStacks, 0, equipment, 0, Math.min(itemStacks.length, 4));
 			if (itemStacks.length <= 4) return;
 			System.arraycopy(itemStacks, 4, equipment_rift, 0, Math.clamp(itemStacks.length - 4, 0, 4));
@@ -115,7 +114,7 @@ public class SkyblockInventoryScreen extends InventoryScreen implements HoveredI
 	@Init
 	public static void initEquipment() {
 		SkyblockEvents.PROFILE_CHANGE.register(((prevProfileId, profileId) -> {
-			if (!prevProfileId.isEmpty()) CompletableFuture.runAsync(() -> save(prevProfileId), Executors.newVirtualThreadPerTaskExecutor()).thenRun(() -> load(profileId));
+			if (!prevProfileId.isEmpty()) CompletableFuture.runAsync(() -> save(prevProfileId), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenRun(() -> load(profileId));
 			else load(profileId);
 		}));
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockInventoryScreen.java
@@ -98,11 +98,11 @@ public class SkyblockInventoryScreen extends InventoryScreen implements HoveredI
 			}
 			return EMPTY_EQUIPMENT.get();
 			// Schedule on main thread to avoid any async weirdness
-		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAccept(itemStacks -> Minecraft.getInstance().execute(() -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(itemStacks -> {
 			System.arraycopy(itemStacks, 0, equipment, 0, Math.min(itemStacks.length, 4));
 			if (itemStacks.length <= 4) return;
 			System.arraycopy(itemStacks, 4, equipment_rift, 0, Math.clamp(itemStacks.length - 4, 0, 4));
-		}));
+		}, Minecraft.getInstance());
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockItemData.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/SkyblockItemData.java
@@ -4,13 +4,13 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.logging.LogUtils;
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.utils.Http;
 import de.hysky.skyblocker.utils.networth.NetworthDataSuppliers;
 import org.slf4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 public class SkyblockItemData {
 	private static final Logger LOGGER = LogUtils.getLogger();
@@ -36,6 +36,6 @@ public class SkyblockItemData {
 
 			//Complete the future exceptionally so that the other things don't run
 			throw new IllegalStateException();
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/BackpackPreview.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/BackpackPreview.java
@@ -38,7 +38,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -85,7 +84,7 @@ public class BackpackPreview {
 					} catch (Exception e) {
 						LOGGER.error("[Skyblocker] Failed to create the backpack preview save directory! Path: {}", saveDir, e);
 					}
-				}, Executors.newVirtualThreadPerTaskExecutor());
+				}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 
 				// load storage again because profile id changed
 				loaded = id;
@@ -112,7 +111,7 @@ public class BackpackPreview {
 				}
 
 				return null;
-			}, Executors.newVirtualThreadPerTaskExecutor()).thenAcceptAsync(storage -> storages[index2] = storage, Minecraft.getInstance());
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenAcceptAsync(storage -> storages[index2] = storage, Minecraft.getInstance());
 		}
 	}
 
@@ -139,7 +138,7 @@ public class BackpackPreview {
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker] Failed to save backpack preview file: {}", storageFile.getFileName(), e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenRunAsync(() -> storage.markClean(), Minecraft.getInstance());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenRunAsync(() -> storage.markClean(), Minecraft.getInstance());
 	}
 
 	private static void updateStorage(AbstractContainerScreen<?> handledScreen) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/ItemTooltip.java
@@ -105,7 +105,7 @@ public class ItemTooltip {
 					.map(DataTooltipInfoType.class::cast)
 					.map(DataTooltipInfoType::downloadIfEnabled)
 					.toArray(CompletableFuture[]::new)
-			).thenRun(ItemPriceUpdateEvent.ON_PRICE_UPDATE.invoker()::onPriceUpdate
+			).thenRunAsync(ItemPriceUpdateEvent.ON_PRICE_UPDATE.invoker()::onPriceUpdate, Minecraft.getInstance()
 			).exceptionally(e -> {
 				LOGGER.error("[Skyblocker] Encountered unknown error while downloading tooltip data", e);
 				return null;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfoType.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfoType.java
@@ -1,8 +1,8 @@
 package de.hysky.skyblocker.skyblock.item.tooltip.info;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
+import de.hysky.skyblocker.SkyblockerMod;
 import org.jspecify.annotations.Nullable;
 
 import com.mojang.serialization.Codec;
@@ -39,7 +39,7 @@ public interface DataTooltipInfoType<T> extends TooltipInfoType, Runnable {
 	 * Downloads the data.
 	 */
 	default CompletableFuture<Void> download() {
-		return CompletableFuture.runAsync(this, Executors.newVirtualThreadPerTaskExecutor());
+		return CompletableFuture.runAsync(this, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	/**

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/wikilookup/WikiLookupManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/wikilookup/WikiLookupManager.java
@@ -2,7 +2,6 @@ package de.hysky.skyblocker.skyblock.item.wikilookup;
 
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -91,7 +90,7 @@ public final class WikiLookupManager {
 	}
 
 	public static void openWikiLink(String wikiLink, Player player) {
-		CompletableFuture.runAsync(() -> Util.getPlatform().openUri(wikiLink), Executors.newVirtualThreadPerTaskExecutor()).exceptionally(e -> {
+		CompletableFuture.runAsync(() -> Util.getPlatform().openUri(wikiLink), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(e -> {
 			WikiLookupManager.LOGGER.error("[Skyblocker] Error while retrieving wiki article: {}", wikiLink, e);
 			player.sendSystemMessage(Constants.PREFIX.get().append("Error while retrieving wiki article, see logs..."));
 			return null;

--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
@@ -119,20 +119,10 @@ public class ItemRepository {
 		RecipeItemStackCache.CACHE.clear();
 		filesImported = true;
 
-		afterImportTasks.forEach(task -> {
-			if (task.async) {
-				CompletableFuture.runAsync(task.runnable, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(e -> {
-					LOGGER.error("[Skyblocker Item Repo Loader] Encountered unknown exception while running after import tasks", e);
-					return null;
-				});
-			} else {
-				try {
-					task.runnable.run();
-				} catch (Exception e) {
-					LOGGER.error("[Skyblocker Item Repo Loader] Encountered unknown exception while running after import tasks", e);
-				}
-			}
-		});
+		afterImportTasks.forEach(task -> CompletableFuture.runAsync(task.runnable, task.async ? SkyblockerMod.VIRTUAL_THREAD_EXECUTOR : Minecraft.getInstance()).exceptionally(e -> {
+			LOGGER.error("[Skyblocker Item Repo Loader] Encountered unknown exception while running after import tasks", e);
+			return null;
+		}));
 	}
 
 	private static void loadItem(NEUItem item) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemRepository.java
@@ -1,5 +1,6 @@
 package de.hysky.skyblocker.skyblock.itemlist;
 
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.compatibility.jei.JEICompatibility;
 import de.hysky.skyblocker.compatibility.jei.SkyblockerJEIPlugin;
@@ -34,7 +35,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import net.minecraft.client.Minecraft;
@@ -121,7 +121,7 @@ public class ItemRepository {
 
 		afterImportTasks.forEach(task -> {
 			if (task.async) {
-				CompletableFuture.runAsync(task.runnable, Executors.newVirtualThreadPerTaskExecutor()).exceptionally(e -> {
+				CompletableFuture.runAsync(task.runnable, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(e -> {
 					LOGGER.error("[Skyblocker Item Repo Loader] Encountered unknown exception while running after import tasks", e);
 					return null;
 				});
@@ -265,7 +265,7 @@ public class ItemRepository {
 	public static void runAfterImport(Runnable runnable, boolean async) {
 		if (filesImported) {
 			if (async) {
-				CompletableFuture.runAsync(runnable, Executors.newVirtualThreadPerTaskExecutor()).exceptionally(e -> {
+				CompletableFuture.runAsync(runnable, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(e -> {
 					LOGGER.error("[Skyblocker Item Repo Loader] Encountered unknown exception while running after import task", e);
 					return null;
 				});

--- a/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemStackBuilder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/itemlist/ItemStackBuilder.java
@@ -25,13 +25,13 @@ import com.mojang.logging.LogUtils;
 
 public class ItemStackBuilder {
 	private static final Logger LOGGER = LogUtils.getLogger();
-	private static Map<String, Map<Rarity, PetNumbers>> petNums;
+	private static Map<String, Map<Rarity, PetNumbers>> petNums = Map.of();
 
 	protected static void loadPetNums() {
 		try {
 			petNums = NEURepoManager.getConstants().getPetNumbers();
 		} catch (Exception _) {
-			ItemRepository.LOGGER.error("Failed to load petnums.json");
+			ItemRepository.LOGGER.error("[Skyblocker ItemStackBuilder] Failed to load petnums.json");
 		}
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/museum/MuseumItemCache.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/museum/MuseumItemCache.java
@@ -55,7 +55,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.literal;
@@ -366,7 +365,7 @@ public class MuseumItemCache {
 				if (source != null) source.sendFeedback(Constants.PREFIX.get().append(Component.translatable("skyblocker.museum.resyncFailure", Component.translatable("skyblocker.museum.resyncFailure.unknownError"))));
 				LOGGER.error(ERROR_LOG_TEMPLATE, profileId, e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static void putEmpty(UUID uuid, String profileId) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerScreen.java
@@ -100,11 +100,8 @@ public class ProfileViewerScreen extends Screen {
 		CompletableFuture<Void> collectionsFuture = CompletableFuture.runAsync(() -> profileViewerPages[4] = new CollectionsPage(hypixelProfile, playerProfile));
 
 		CompletableFuture.allOf(skillsFuture, slayersFuture, dungeonsFuture, inventoriesFuture, collectionsFuture)
-				.thenRun(() -> {
-					synchronized (this) {
-						rebuildWidgets();
-					}
-				}).exceptionally(err -> {
+				.thenRunAsync(this::rebuildWidgets, Minecraft.getInstance())
+				.exceptionally(err -> {
 					LOGGER.error("[Skyblocker Profile Viewer] An error occurred while initializing widgets!", err);
 					errorMessage = "Unable to process player data!";
 					profileNotFound = true;
@@ -114,9 +111,7 @@ public class ProfileViewerScreen extends Screen {
 
 	@Override
 	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
-		synchronized (this) {
-			super.extractRenderState(graphics, mouseX, mouseY, delta);
-		}
+		super.extractRenderState(graphics, mouseX, mouseY, delta);
 
 		int rootX = width / 2 - GUI_WIDTH / 2;
 		int rootY = height / 2 - GUI_HEIGHT / 2 + 5;

--- a/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/profileviewer/ProfileViewerScreen.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 import static net.minecraft.client.gui.screens.inventory.InventoryScreen.extractEntityInInventoryFollowsMouse;
 
@@ -207,7 +206,7 @@ public class ProfileViewerScreen extends Screen {
 				this.profileNotFound = true;
 				return null;
 			}).join();
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 
 		return CompletableFuture.allOf(profileFuture, playerFuture);
 	}
@@ -257,7 +256,7 @@ public class ProfileViewerScreen extends Screen {
 			} catch (Exception e) {
 				LOGGER.error("[Skyblocker Profile Viewer] Failed to fetch collections data", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	public static Map<String, List<Collection>> getCollections() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/profileviewer2/ProfileViewer.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/profileviewer2/ProfileViewer.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 
@@ -104,7 +103,7 @@ public class ProfileViewer {
 	/// {@return a {@link Pair} optionally containing the user's {@link ApiProfileResponse} and {@link GameProfile}}
 	private static CompletableFuture<Pair<Optional<ApiProfileResponse>, Optional<GameProfile>>> loadData(String name) {
 		Minecraft minecraft = Minecraft.getInstance();
-		CompletableFuture<Pair<Optional<ApiProfileResponse>, Optional<GameProfile>>> dataFuture = CompletableFuture.supplyAsync(() -> ApiUtils.name2Uuid(name), Executors.newVirtualThreadPerTaskExecutor())
+		CompletableFuture<Pair<Optional<ApiProfileResponse>, Optional<GameProfile>>> dataFuture = CompletableFuture.supplyAsync(() -> ApiUtils.name2Uuid(name), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR)
 				.thenComposeAsync(uuid -> {
 					if (uuid.isEmpty()) {
 						return CompletableFuture.failedStage(new IllegalStateException("Invalid username"));
@@ -117,8 +116,8 @@ public class ProfileViewer {
 							.thenApply(optional -> optional.map(PlayerSkinRenderCache.RenderInfo::gameProfile));
 
 					return skyblockProfileFuture.thenCombine(gameProfileFuture, Pair::of);
-				}, Executors.newVirtualThreadPerTaskExecutor())
-				.thenApplyAsync(pair -> Pair.of(pair.left().map(json -> GSON.fromJson(json, ApiProfileResponse.class)), pair.right()), Executors.newVirtualThreadPerTaskExecutor());
+				}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR)
+				.thenApplyAsync(pair -> Pair.of(pair.left().map(json -> GSON.fromJson(json, ApiProfileResponse.class)), pair.right()), SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 
 		return dataFuture;
 	}

--- a/src/main/java/de/hysky/skyblocker/skyblock/rift/EnigmaSouls.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/rift/EnigmaSouls.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.literal;
@@ -84,7 +83,7 @@ public class EnigmaSouls {
 			} catch (IOException e) {
 				LOGGER.error("[Skyblocker] There was an error while loading found enigma souls!", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	static void save(Minecraft client) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/rift/MirrorverseWaypoints.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/rift/MirrorverseWaypoints.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
@@ -53,7 +52,7 @@ public class MirrorverseWaypoints {
 			} catch (IOException e) {
 				LOGGER.error("[Skyblocker] Mirrorverse Waypoints failed to load ;(", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static Waypoint[] loadWaypoints(JsonArray waypointsJson) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/waypoint/Relics.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/waypoint/Relics.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommands.literal;
@@ -93,7 +92,7 @@ public class Relics {
 			} catch (IOException e) {
 				LOGGER.error("[Skyblocker] Failed to load found relics", e);
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static void saveFoundRelics(Minecraft client) {

--- a/src/main/java/de/hysky/skyblocker/utils/Http.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Http.java
@@ -16,7 +16,6 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
-import java.util.concurrent.Executors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -31,7 +30,7 @@ public class Http {
 	public static final String USER_AGENT = "Skyblocker/" + SkyblockerMod.VERSION + " (" + SharedConstants.getCurrentVersion().name() + ")";
 	private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
 			.connectTimeout(Duration.ofSeconds(10))
-			.executor(Executors.newVirtualThreadPerTaskExecutor())
+			.executor(SkyblockerMod.VIRTUAL_THREAD_EXECUTOR)
 			.followRedirects(Redirect.NORMAL)
 			.build();
 

--- a/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -157,13 +156,13 @@ public class NEURepoManager {
 				success = false;
 			}
 			return success;
-		}, Executors.newVirtualThreadPerTaskExecutor()).thenApplyAsync(success -> {
-			CompletableFuture.allOf(afterLoadTasks.stream().map(task -> CompletableFuture.runAsync(task, Executors.newVirtualThreadPerTaskExecutor())).toArray(CompletableFuture[]::new)).exceptionally(e -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).thenApplyAsync(success -> {
+			CompletableFuture.allOf(afterLoadTasks.stream().map(task -> CompletableFuture.runAsync(task, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR)).toArray(CompletableFuture[]::new)).exceptionally(e -> {
 				LOGGER.error("[Skyblocker NEU Repo] Encountered unknown exception while running after load tasks", e);
 				return null;
 			});
 			return success;
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	/**
@@ -189,7 +188,7 @@ public class NEURepoManager {
 	}
 
 	private static void deleteAndDownloadRepositoryInternal(@Nullable Player player) {
-		Function<Runnable, CompletableFuture<Void>> runner = isLoading() ? REPO_LOADING::thenRunAsync : task -> CompletableFuture.runAsync(task, Executors.newVirtualThreadPerTaskExecutor());
+		Function<Runnable, CompletableFuture<Void>> runner = isLoading() ? REPO_LOADING::thenRunAsync : task -> CompletableFuture.runAsync(task, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		REPO_LOADING = runner.apply(() -> {
 			sendMessage(player, Component.translatable("skyblocker.updateRepository.start").withStyle(ChatFormatting.AQUA));
 			try {

--- a/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
@@ -11,14 +11,14 @@ import io.github.moulberry.repo.NEUConstants;
 import io.github.moulberry.repo.NEURecipeCache;
 import io.github.moulberry.repo.NEURepoFile;
 import io.github.moulberry.repo.NEURepository;
-import io.github.moulberry.repo.data.ItemOverlays;
 import io.github.moulberry.repo.NEURepositoryException;
+import io.github.moulberry.repo.data.ItemOverlays;
+import io.github.moulberry.repo.data.ItemOverlays.ItemOverlayFile;
 import io.github.moulberry.repo.data.NEUItem;
 import io.github.moulberry.repo.data.NEURecipe;
-import io.github.moulberry.repo.data.ItemOverlays.ItemOverlayFile;
 import io.github.moulberry.repo.util.NEUId;
-import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -35,12 +35,13 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -78,7 +79,7 @@ public class NEURepoManager {
 	/**
 	 * Store after load runnables so we can execute them after each time the repository is (re)loaded.
 	 */
-	private static final List<Runnable> afterLoadTasks = new ArrayList<>();
+	private static final Queue<Runnable> afterLoadTasks = new ConcurrentLinkedQueue<>();
 	/**
 	 * A cache containing NEUItems indexed by their display name.
 	 */
@@ -102,9 +103,8 @@ public class NEURepoManager {
 		runAsyncAfterLoad(NEURepoManager::loadNameToNEUItemMap); // Loads the NEUItem name cache after the repository is loaded.
 	}
 
-
 	public static boolean isLoading() {
-		return REPO_LOADING != null && !REPO_LOADING.isDone();
+		return !REPO_LOADING.isDone();
 	}
 
 	private static CompletableFuture<Boolean> loadRepository() {
@@ -220,7 +220,7 @@ public class NEURepoManager {
 	 * @return a completable future of the given runnable
 	 */
 	public static CompletableFuture<Void> runAsyncAfterLoad(Runnable runnable) {
-		return REPO_LOADING.thenRunAsync(runnable).exceptionally(e -> {
+		return REPO_LOADING.thenRunAsync(runnable, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(e -> {
 			LOGGER.error("[Skyblocker NEU Repo] Encountered unknown exception while running after load task", e);
 			return null;
 		}).thenRun(() -> afterLoadTasks.add(runnable)); // Add to the list after so it doesn't get executed twice.

--- a/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/NEURepoManager.java
@@ -38,10 +38,9 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -79,7 +78,7 @@ public class NEURepoManager {
 	/**
 	 * Store after load runnables so we can execute them after each time the repository is (re)loaded.
 	 */
-	private static final Queue<Runnable> afterLoadTasks = new ConcurrentLinkedQueue<>();
+	private static final List<Runnable> afterLoadTasks = new CopyOnWriteArrayList<>();
 	/**
 	 * A cache containing NEUItems indexed by their display name.
 	 */

--- a/src/main/java/de/hysky/skyblocker/utils/ProfileUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ProfileUtils.java
@@ -2,7 +2,6 @@ package de.hysky.skyblocker.utils;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -47,7 +46,7 @@ public class ProfileUtils {
 			}
 
 			return null;
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	/**
@@ -58,7 +57,7 @@ public class ProfileUtils {
 			String uuid = ApiUtils.name2Uuid(name);
 
 			return !uuid.isEmpty() ? UUID_TO_PROFILES_CACHE.getUnchecked(uuid) : null;
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	/**
@@ -67,7 +66,7 @@ public class ProfileUtils {
 	public static CompletableFuture<@Nullable JsonObject> fetchFullProfileByUuid(String uuid) {
 		return CompletableFuture.supplyAsync(() -> {
 			return !uuid.isEmpty() ? UUID_TO_PROFILES_CACHE.getUnchecked(uuid) : null;
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static @Nullable JsonObject fetchProfilesInternal(String uuid) {

--- a/src/main/java/de/hysky/skyblocker/utils/data/JsonData.java
+++ b/src/main/java/de/hysky/skyblocker/utils/data/JsonData.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 public class JsonData<T> {
@@ -110,7 +109,7 @@ public class JsonData<T> {
 
 	public CompletableFuture<Void> load() {
 		if (loadAsync) {
-			loaded = CompletableFuture.runAsync(this::loadInternal, Executors.newVirtualThreadPerTaskExecutor());
+			loaded = CompletableFuture.runAsync(this::loadInternal, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		} else {
 			loadInternal();
 			loaded = CompletableFuture.completedFuture(null);
@@ -160,7 +159,7 @@ public class JsonData<T> {
 
 	public CompletableFuture<Void> save() {
 		if (saveAsync && Minecraft.getInstance().isRunning()) { // Do not save async if we are closing the game
-			return CompletableFuture.runAsync(this::saveInternal, Executors.newVirtualThreadPerTaskExecutor());
+			return CompletableFuture.runAsync(this::saveInternal, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		} else {
 			saveInternal();
 			return CompletableFuture.completedFuture(null);

--- a/src/main/java/de/hysky/skyblocker/utils/discord/DiscordRPCManager.java
+++ b/src/main/java/de/hysky/skyblocker/utils/discord/DiscordRPCManager.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.utils.discord;
 
 
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.config.configs.MiscConfig;
@@ -14,7 +15,6 @@ import org.slf4j.LoggerFactory;
 
 import java.text.DecimalFormat;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 /**
  * Manages the discord rich presence. Automatically connects to discord and displays a customizable activity when playing Skyblock.
@@ -94,7 +94,7 @@ public class DiscordRPCManager {
 				} else if (initialization) {
 					LOGGER.info("[Skyblocker] Discord RPC is currently disabled, will not connect");
 				}
-			}, Executors.newVirtualThreadPerTaskExecutor());
+			}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 		}
 	}
 

--- a/src/main/java/de/hysky/skyblocker/utils/mayor/MayorUtils.java
+++ b/src/main/java/de/hysky/skyblocker/utils/mayor/MayorUtils.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 public class MayorUtils {
@@ -123,7 +122,7 @@ public class MayorUtils {
 			} catch (Exception e) {
 				throw new RuntimeException(e); //Wrap the exception to be handled by the exceptionally block
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor()).exceptionally(throwable -> {
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR).exceptionally(throwable -> {
 			LOGGER.error("[Skyblocker] Failed to get mayor status!", throwable.getCause());
 			if (mayorTickRetryAttempts < 5) {
 				int minutes = 5 << mayorTickRetryAttempts; //5, 10, 20, 40, 80 minutes
@@ -188,7 +187,7 @@ public class MayorUtils {
 
 				return false;
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private record PerkOverride(String perk, long from, long to) {

--- a/src/main/java/de/hysky/skyblocker/utils/ws/SkyblockerWebSocket.java
+++ b/src/main/java/de/hysky/skyblocker/utils/ws/SkyblockerWebSocket.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 
 import com.mojang.logging.LogUtils;
 
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.debug.Debug;
 import de.hysky.skyblocker.events.SkyblockEvents;
@@ -35,7 +36,7 @@ public class SkyblockerWebSocket {
 	private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
 			.connectTimeout(Duration.ofSeconds(10))
 			.followRedirects(Redirect.NORMAL)
-			.executor(Executors.newVirtualThreadPerTaskExecutor())
+			.executor(SkyblockerMod.VIRTUAL_THREAD_EXECUTOR)
 			.version(Version.HTTP_2)
 			.build();
 	private static final ExecutorService MESSAGE_SEND_QUEUE = Executors.newSingleThreadExecutor(Thread.ofVirtual()
@@ -72,7 +73,7 @@ public class SkyblockerWebSocket {
 					LOGGER.error("[Skyblocker WebSocket] Failed to setup WebSocket connection!", e);
 				}
 			}
-		}, Executors.newVirtualThreadPerTaskExecutor());
+		}, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
 	}
 
 	private static void closeSocket() {

--- a/src/test/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonRoomsDFU.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/dungeon/secrets/DungeonRoomsDFU.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 import net.minecraft.util.datafix.fixes.ItemIdFix;
@@ -34,8 +35,8 @@ public class DungeonRoomsDFU {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DungeonRoomsDFU.class);
 	private static final String DUNGEONS_DATA_DIR = "/assets/skyblocker/dungeons";
 	private static final String DUNGEON_ROOMS_DATA_DIR = DUNGEONS_DATA_DIR + "/dungeonrooms";
-	private static final HashMap<String, HashMap<String, HashMap<String, long[]>>> OLD_ROOMS = new HashMap<>();
-	private static final HashMap<String, HashMap<String, HashMap<String, int[]>>> ROOMS = new HashMap<>();
+	private static final Map<String, Map<String, Map<String, long[]>>> OLD_ROOMS = new HashMap<>();
+	private static final Map<String, Map<String, Map<String, int[]>>> ROOMS = new HashMap<>();
 
 	public static void main(String[] args) {
 		load().join();
@@ -56,12 +57,12 @@ public class DungeonRoomsDFU {
 			for (Path dungeon : dungeons) {
 				try (DirectoryStream<Path> roomShapes = Files.newDirectoryStream(dungeon, Files::isDirectory)) {
 					List<CompletableFuture<Void>> roomShapeFutures = new ArrayList<>();
-					HashMap<String, HashMap<String, long[]>> roomShapesMap = new HashMap<>();
+					Map<String, Map<String, long[]>> roomShapesMap = new ConcurrentHashMap<>();
 					for (Path roomShape : roomShapes) {
 						roomShapeFutures.add(CompletableFuture.supplyAsync(() -> readRooms(roomShape, resourcePathIndex)).thenAccept(rooms -> roomShapesMap.put(roomShape.getFileName().toString().toLowerCase(Locale.ENGLISH), rooms)));
 					}
 					OLD_ROOMS.put(dungeon.getFileName().toString().toLowerCase(Locale.ENGLISH), roomShapesMap);
-					dungeonFutures.add(CompletableFuture.allOf(roomShapeFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Loaded dungeon secrets for dungeon {} with {} room shapes and {} rooms total", dungeon.getFileName(), roomShapesMap.size(), roomShapesMap.values().stream().mapToInt(HashMap::size).sum())));
+					dungeonFutures.add(CompletableFuture.allOf(roomShapeFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Loaded dungeon secrets for dungeon {} with {} room shapes and {} rooms total", dungeon.getFileName(), roomShapesMap.size(), roomShapesMap.values().stream().mapToInt(Map::size).sum())));
 				} catch (IOException e) {
 					LOGGER.error("Failed to load dungeon secrets for dungeon " + dungeon.getFileName(), e);
 				}
@@ -69,10 +70,10 @@ public class DungeonRoomsDFU {
 		} catch (IOException e) {
 			LOGGER.error("Failed to load dungeon secrets", e);
 		}
-		return CompletableFuture.allOf(dungeonFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Loaded dungeon secrets for {} dungeon(s), {} room shapes, and {} rooms total", OLD_ROOMS.size(), OLD_ROOMS.values().stream().mapToInt(HashMap::size).sum(), OLD_ROOMS.values().stream().map(HashMap::values).flatMap(Collection::stream).mapToInt(HashMap::size).sum()));
+		return CompletableFuture.allOf(dungeonFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Loaded dungeon secrets for {} dungeon(s), {} room shapes, and {} rooms total", OLD_ROOMS.size(), OLD_ROOMS.values().stream().mapToInt(Map::size).sum(), OLD_ROOMS.values().stream().map(Map::values).flatMap(Collection::stream).mapToInt(Map::size).sum()));
 	}
 
-	private static HashMap<String, long[]> readRooms(Path roomShape, int resourcePathIndex) {
+	private static Map<String, long[]> readRooms(Path roomShape, int resourcePathIndex) {
 		try (DirectoryStream<Path> rooms = Files.newDirectoryStream(roomShape, Files::isRegularFile)) {
 			HashMap<String, long[]> roomsData = new HashMap<>();
 			for (Path room : rooms) {
@@ -94,12 +95,12 @@ public class DungeonRoomsDFU {
 	}
 
 	private static void updateRooms() {
-		for (Map.Entry<String, HashMap<String, HashMap<String, long[]>>> oldDungeon : OLD_ROOMS.entrySet()) {
-			HashMap<String, HashMap<String, int[]>> dungeon = new HashMap<>();
-			for (Map.Entry<String, HashMap<String, long[]>> oldRoomShape : oldDungeon.getValue().entrySet()) {
-				HashMap<String, int[]> roomShape = new HashMap<>();
+		for (Map.Entry<String, Map<String, Map<String, long[]>>> oldDungeon : OLD_ROOMS.entrySet()) {
+			Map<String, Map<String, int[]>> dungeon = new HashMap<>();
+			for (Map.Entry<String, Map<String, long[]>> oldRoomShape : oldDungeon.getValue().entrySet()) {
+				Map<String, int[]> roomShape = new HashMap<>();
 				for (Map.Entry<String, long[]> oldRoomEntry : oldRoomShape.getValue().entrySet()) {
-					roomShape.put(oldRoomEntry.getKey().replaceAll(" ", "-"), updateRoom(oldRoomEntry.getValue()));
+					roomShape.put(oldRoomEntry.getKey().replace(" ", "-"), updateRoom(oldRoomEntry.getValue()));
 				}
 				dungeon.put(oldRoomShape.getKey(), roomShape);
 			}
@@ -142,19 +143,19 @@ public class DungeonRoomsDFU {
 
 	private static CompletableFuture<Void> save() {
 		List<CompletableFuture<Void>> dungeonFutures = new ArrayList<>();
-		for (Map.Entry<String, HashMap<String, HashMap<String, int[]>>> dungeon : ROOMS.entrySet()) {
+		for (Map.Entry<String, Map<String, Map<String, int[]>>> dungeon : ROOMS.entrySet()) {
 			Path dungeonDir = Path.of("out", "dungeons", dungeon.getKey());
 			List<CompletableFuture<Void>> roomShapeFutures = new ArrayList<>();
-			for (Map.Entry<String, HashMap<String, int[]>> roomShape : dungeon.getValue().entrySet()) {
+			for (Map.Entry<String, Map<String, int[]>> roomShape : dungeon.getValue().entrySet()) {
 				Path roomShapeDir = dungeonDir.resolve(roomShape.getKey());
 				roomShapeFutures.add(CompletableFuture.runAsync(() -> saveRooms(roomShapeDir, roomShape)));
 			}
-			dungeonFutures.add(CompletableFuture.allOf(roomShapeFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Saved dungeon secrets for dungeon {} with {} room shapes and {} rooms total", dungeon.getKey(), dungeon.getValue().size(), dungeon.getValue().values().stream().mapToInt(HashMap::size).sum())));
+			dungeonFutures.add(CompletableFuture.allOf(roomShapeFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Saved dungeon secrets for dungeon {} with {} room shapes and {} rooms total", dungeon.getKey(), dungeon.getValue().size(), dungeon.getValue().values().stream().mapToInt(Map::size).sum())));
 		}
-		return CompletableFuture.allOf(dungeonFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Saved dungeon secrets for {} dungeon(s), {} room shapes, and {} rooms total", ROOMS.size(), ROOMS.values().stream().mapToInt(HashMap::size).sum(), ROOMS.values().stream().map(HashMap::values).flatMap(Collection::stream).mapToInt(HashMap::size).sum()));
+		return CompletableFuture.allOf(dungeonFutures.toArray(CompletableFuture[]::new)).thenRun(() -> LOGGER.info("Saved dungeon secrets for {} dungeon(s), {} room shapes, and {} rooms total", ROOMS.size(), ROOMS.values().stream().mapToInt(Map::size).sum(), ROOMS.values().stream().map(Map::values).flatMap(Collection::stream).mapToInt(Map::size).sum()));
 	}
 
-	private static void saveRooms(Path roomShapeDir, Map.Entry<String, HashMap<String, int[]>> roomShape) {
+	private static void saveRooms(Path roomShapeDir, Map.Entry<String, Map<String, int[]>> roomShape) {
 		try {
 			Files.createDirectories(roomShapeDir);
 		} catch (IOException e) {


### PR DESCRIPTION
Use a common virtual thread executor, even though it doesn't impact things much. Plus lots of completable future fixes. `then(Run|Accept|Apply)` does not run on the main thread!