### PR TITLE
Fix chat filters missing formatting in action bar

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/AutopetFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/AutopetFilter.java
@@ -6,7 +6,6 @@ import de.hysky.skyblocker.utils.FlexibleItemStack;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.chat.ChatFilterResult;
 import de.hysky.skyblocker.utils.chat.ChatPatternListener;
-import java.util.Objects;
 import java.util.regex.Matcher;
 
 import de.hysky.skyblocker.utils.render.gui.BasicToast;
@@ -23,10 +22,10 @@ public class AutopetFilter extends ChatPatternListener {
 	@Override
 	public boolean onMatch(Component message, Matcher matcher) {
 		if (SkyblockerConfigManager.get().chat.hideAutopet == ChatFilterResult.ACTION_BAR) {
-			Objects.requireNonNull(Minecraft.getInstance().player).sendOverlayMessage(
+			Minecraft.getInstance().gui.hud.setOverlayMessage(
 					Component.literal(
 							message.getString().replace("VIEW RULE", "")
-					));
+					), true);
 		} else if (SkyblockerConfigManager.get().chat.hideAutopet == ChatFilterResult.TOAST) {
 			Minecraft.getInstance().gui.toastManager().addToast(new BasicToast(Component.literal(message.getString().replace("VIEW RULE", "")), (long) (SkyblockerConfigManager.get().chat.toastDisplayDuration * 1000L), ICON.getStack()));
 		}

--- a/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
+++ b/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
@@ -115,7 +115,7 @@ public interface ChatMessageListener {
 					LocalPlayer player = Minecraft.getInstance().player;
 
 					if (player != null) {
-						player.sendOverlayMessage(message);
+						Minecraft.getInstance().gui.hud.setOverlayMessage(message, true);
 
 						return false;
 					}

--- a/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
+++ b/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
@@ -37,7 +37,6 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 
 @FunctionalInterface
@@ -112,13 +111,8 @@ public interface ChatMessageListener {
 						return true;
 					}
 
-					LocalPlayer player = Minecraft.getInstance().player;
-
-					if (player != null) {
-						Minecraft.getInstance().gui.hud.setOverlayMessage(message, true);
-
-						return false;
-					}
+					Minecraft.getInstance().gui.hud.setOverlayMessage(message, true);
+					return false;
 				}
 
 				case TOAST -> {


### PR DESCRIPTION
When chat filters are disabled or show as toasts, messages have formatting as expected:
<img width="549" height="63" alt="image" src="https://github.com/user-attachments/assets/849cfe40-fc3f-4cca-a22e-477ca8b74431" />
<img width="327" height="72" alt="image" src="https://github.com/user-attachments/assets/ef90b50a-6278-4aed-90ab-c4efc3d99154" />
But formatting from components sent to the action bar is ignored. This results in chat filters that redirect to the action bar losing all coloring in a very noticeable (and ugly IMO) way:
<img width="569" height="113" alt="image" src="https://github.com/user-attachments/assets/a5c0a66a-3429-4ad8-a037-5c867f3b960d" />

That's because `player.sendOverlayMessage(msg)` is just a wrapper that calls `hud.setOverlayMessage(msg, false)` where `false` indicates colors shouldn't be rendered. So this PR directly calls `hud.setOverlayMessage(msg, true)` instead to render colors:
<img width="544" height="114" alt="image" src="https://github.com/user-attachments/assets/623a5ca3-d5fb-4dc1-99bc-e8803ec9da79" />
