### PR TITLE
feat(rei): allow loading rei recipes on game launch

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/rei/SkyblockerREIClientPlugin.java
@@ -55,7 +55,8 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
 
 	@Override
 	public void registerCategories(CategoryRegistry categoryRegistry) {
-		if (!Utils.isOnSkyblock()) return;
+		if (!SkyblockerConfigManager.get().general.itemList.enableLoadOnGameLaunch)
+			if (!Utils.isOnSkyblock()) return;
 		if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
 		categoryRegistry.addWorkstations(CategoryIdentifier.of(SkyblockCraftingRecipe.ID), EntryStacks.of(Items.CRAFTING_TABLE));
 		categoryRegistry.addWorkstations(CategoryIdentifier.of(SkyblockForgeRecipe.ID), EntryStacks.of(Items.ANVIL));
@@ -71,7 +72,8 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
 
 	@Override
 	public void registerDisplays(DisplayRegistry displayRegistry) {
-		if (!Utils.isOnSkyblock()) return;
+		if (!SkyblockerConfigManager.get().general.itemList.enableLoadOnGameLaunch)
+			if (!Utils.isOnSkyblock()) return;
 		if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
 		if (displayRegistry.getGlobalDisplayGenerators().stream().noneMatch(generator -> generator instanceof SkyblockRecipeDisplayGenerator))
 			displayRegistry.registerGlobalDisplayGenerator(new SkyblockRecipeDisplayGenerator());
@@ -87,7 +89,8 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
 
 	@Override
 	public void registerEntries(EntryRegistry entryRegistry) {
-		if (!Utils.isOnSkyblock()) return;
+		if (!SkyblockerConfigManager.get().general.itemList.enableLoadOnGameLaunch)
+			if (!Utils.isOnSkyblock()) return;
 		if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
 		entryRegistry.removeEntryIf(_ -> true);
 		entryRegistry.addEntries(ItemRepository.getItemsStream().map(FlexibleItemStack::getStackOrThrow).map(EntryStacks::of).toList());
@@ -164,7 +167,8 @@ public class SkyblockerREIClientPlugin implements REIClientPlugin {
 
 	@Override
 	public void registerTransferHandlers(TransferHandlerRegistry registry) {
-		if (!Utils.isOnSkyblock()) return;
+		if (!SkyblockerConfigManager.get().general.itemList.enableLoadOnGameLaunch)
+			if (!Utils.isOnSkyblock()) return;
 		if (!SkyblockerConfigManager.get().general.itemList.enableItemList) return;
 		registry.register(new SkyblockTransferHandler());
 	}

--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -206,6 +206,14 @@ public class GeneralCategory {
 										newValue -> config.general.itemList.enableCollapsibleEntries = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
+						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.general.itemList.enableLoadOnGameLaunch"))
+								.description(Component.translatable("skyblocker.config.general.itemList.enableLoadOnGameLaunch.@Tooltip"))
+								.binding(defaults.general.itemList.enableLoadOnGameLaunch,
+										() -> config.general.itemList.enableLoadOnGameLaunch,
+										newValue -> config.general.itemList.enableLoadOnGameLaunch = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.build())
 
 				//Item Tooltip

--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -96,6 +96,8 @@ public class GeneralConfig {
 		public boolean enableItemList = true;
 
 		public boolean enableCollapsibleEntries = true;
+
+		public boolean enableLoadOnGameLaunch = false;
 	}
 
 	public static class ItemTooltip {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -593,6 +593,8 @@
   "skyblocker.config.general.itemList.enableCollapsibleEntries.@Tooltip": "Group together similar items into one entry which can be expanded by clicking on it.\n\nRequires rejoining or reloading REI plugins to apply!",
   "skyblocker.config.general.itemList.enableItemList": "Enable Item List Compatibility",
   "skyblocker.config.general.itemList.enableItemList.@Tooltip": "Adds the SkyBlock items and recipes in supported item list mods (REI and JEI).",
+  "skyblocker.config.general.itemList.enableLoadOnGameLaunch": "Enable Loading Items On Game Launch",
+  "skyblocker.config.general.itemList.enableLoadOnGameLaunch.@Tooltip": "Make Skyblocker load the items into the item list once when launching the game",
   "skyblocker.config.general.itemList.enableRecipeBook": "Enable Recipe Book",
   "skyblocker.config.general.itemList.enableRecipeBook.@Tooltip": "Adds the SkyBlock items and recipes into the recipe book in the inventory.",
   "skyblocker.config.general.itemList.filter.all": "All",


### PR DESCRIPTION
Allows REI recipes to load on client startup when `enableLoadOnGameLaunch` is enabled in the config