### PR TITLE
Add Helix Tree support to Sweep Details Widget

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/galatea/SweepDetailsHudWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/galatea/SweepDetailsHudWidget.java
@@ -27,6 +27,7 @@ public class SweepDetailsHudWidget extends ElementBasedWidget {
 	private static final Map<String, FlexibleItemStack> LOG_TO_ITEM = Map.of(
 			"Fig", new FlexibleItemStack(Items.STRIPPED_SPRUCE_LOG),
 			"Mangrove", new FlexibleItemStack(Items.MANGROVE_LOG),
+			"Helix", new FlexibleItemStack(Items.STRIPPED_MANGROVE_WOOD),
 			"Jungle", new FlexibleItemStack(Items.JUNGLE_LOG),
 			"Acacia", new FlexibleItemStack(Items.ACACIA_LOG),
 			"Dark Oak", new FlexibleItemStack(Items.DARK_OAK_LOG),
@@ -34,7 +35,7 @@ public class SweepDetailsHudWidget extends ElementBasedWidget {
 			"Birch", new FlexibleItemStack(Items.BIRCH_LOG),
 			"Oak", new FlexibleItemStack(Items.OAK_LOG)
 	);
-	public static final Set<Location> LOCATIONS = Set.of(Location.GALATEA, Location.HUB, Location.THE_PARK, Location.GARDEN);
+	public static final Set<Location> LOCATIONS = Set.of(Location.GALATEA, Location.HUB, Location.THE_PARK, Location.GARDEN, Location.TORRHUS_CANYON);
 
 	public SweepDetailsHudWidget() {
 		super(Component.translatable("skyblocker.galatea.hud.sweepDetails"), 0xFF6E37CC, "sweepDetails");
@@ -64,6 +65,7 @@ public class SweepDetailsHudWidget extends ElementBasedWidget {
 				case HUB -> ItemRepository.getItemStack("SWEET_AXE", new FlexibleItemStack(Items.IRON_AXE));
 				case THE_PARK -> ItemRepository.getItemStack("TREECAPITATOR_AXE", new FlexibleItemStack(Items.GOLDEN_AXE));
 				case GALATEA -> ItemRepository.getItemStack("FIGSTONE_AXE", new FlexibleItemStack(Items.STONE_AXE));
+				case TORRHUS_CANYON -> ItemRepository.getItemStack("HELIX_CHOPPER", new FlexibleItemStack(Items.GOLDEN_AXE));
 				default -> Ico.RED_CONCRETE;
 			};
 			addComponent(Elements.iconTextComponent(axeIcon, Component.translatable("skyblocker.galatea.hud.sweepDetails.inactive")));


### PR DESCRIPTION
This adds support for the Helix Tree for the Sweep Details widget. For the Torrhus Canyon, the axe sprite displayed is the Helix Chopper.

![](https://github.com/user-attachments/assets/47466aa0-7cb2-4499-832a-23de0e22708d)