### PR TITLE
vitality fixes and tilde option

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -543,7 +543,14 @@ public class UIAndVisualsCategory {
 										newValue -> config.uiAndVisuals.bars.intelligenceDisplay = newValue)
 								.controller(ConfigUtils.createEnumController(intelligenceDisplay -> Component.translatable("skyblocker.config.uiAndVisuals.bars.intelligenceDisplay." + intelligenceDisplay.name())))
 								.build()
-						)
+						).option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.uiAndVisuals.bars.showEstimatedTilde"))
+								.description(Component.translatable("skyblocker.config.uiAndVisuals.bars.showEstimatedTilde.@Tooltip"))
+								.binding(defaults.uiAndVisuals.bars.showEstimatedTilde,
+										() -> config.uiAndVisuals.bars.showEstimatedTilde,
+										newValue -> config.uiAndVisuals.bars.showEstimatedTilde = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
 						.build())
 
 				//Waypoints

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -298,6 +298,10 @@ public class UIAndVisualsConfig {
 
 		public IntelligenceDisplay intelligenceDisplay = IntelligenceDisplay.ORIGINAL;
 
+		public boolean showEstimatedTilde = true;
+
+		public boolean hasSeenVitalityAtLeastOnce = false;
+
 		// Kept in for backwards compatibility, remove if needed
 		@SuppressWarnings("DeprecatedIsStillUsed")
 		@Deprecated

--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -46,17 +46,14 @@ public class StatusBarTracker {
 
 	private static final Minecraft MINECRAFT = Minecraft.getInstance();
 	private static Resource health = new Resource(100, 100, 0);
-	private static @Nullable Resource vitality = null;
-	private static Resource mana = new Resource(100, 100, 0);
+	private static final EstimatedResource vitality = new EstimatedResource(new Resource(100, 100, 0));
+	private static final EstimatedResource mana = new EstimatedResource(new Resource(100, 100, 0));
 	private static Resource speed = new Resource(100, 400, 0);
 	private static Resource air = new Resource(100, 300, 0);
 	private static int defense = 0;
 	private static int absorption = 0;
 
 	private static int ticks;
-	private static int lastManaTick;
-	private static int lastMana;
-	private static int manaPerSecond;
 
 	@Init
 	public static void init() {
@@ -70,16 +67,12 @@ public class StatusBarTracker {
 		return health;
 	}
 
-	public static @Nullable Resource getVitality() {
+	public static EstimatedResource getVitality() {
 		return vitality;
 	}
 
-	public static Resource getMana() {
+	public static EstimatedResource getMana() {
 		return mana;
-	}
-
-	public static boolean isManaEstimated() {
-		return ticks - lastManaTick > 30;
 	}
 
 	public static int getDefense() {
@@ -100,9 +93,8 @@ public class StatusBarTracker {
 		updateHealth(health.value, health.max);
 		updateSpeed();
 		updateAir();
-		if (ticks - lastManaTick > 0 && (ticks - lastManaTick) % 20 == 0) {
-			mana = new Resource(Math.min(mana.value() + manaPerSecond, mana.max()), mana.max(), mana.overflow());
-		}
+		mana.tick();
+		vitality.tick();
 	}
 
 	@SuppressWarnings("SameReturnValue")
@@ -116,8 +108,8 @@ public class StatusBarTracker {
 				break;
 			}
 		}
-		if (manaCost > 0 && manaCost <= mana.value()) {
-			mana = new Resource(Math.max(mana.value() - manaCost, 0), mana.max(), mana.overflow());
+		if (manaCost > 0 && manaCost <= mana.resource().value()) {
+			mana.resource = new Resource(Math.max(mana.resource().value() - manaCost, 0), mana.resource().max(), mana.resource().overflow());
 		}
 		return InteractionResult.PASS;
 	}
@@ -194,17 +186,13 @@ public class StatusBarTracker {
 						statuses.appendReplacement(output, "");
 					else
 						statuses.appendReplacement(output, "$0");
-				} else {
-					if (status.usePattern(VITALITY_STATUS).find()) {
-						updateVitality(status);
-						if (FancyStatusBars.isBarEnabled(StatusBarType.VITALITY))
-							statuses.appendReplacement(output, "");
-						else
-							statuses.appendReplacement(output, "$0");
-					} else {
-						vitality = null;
-					}
-
+				// Vitality
+				} else if (status.usePattern(VITALITY_STATUS).find()) {
+					updateVitality(status);
+					if (FancyStatusBars.isBarEnabled(StatusBarType.VITALITY))
+						statuses.appendReplacement(output, "");
+					else
+						statuses.appendReplacement(output, "$0");
 				}
 			}
 			// Mana use
@@ -251,17 +239,18 @@ public class StatusBarTracker {
 	}
 
 	private static void updateVitality(Matcher m) {
-		vitality = new Resource(RegexUtils.parseIntFromMatcher(m, "vitality"), RegexUtils.parseIntFromMatcher(m, "max"), 0);
+		if (!SkyblockerConfigManager.get().uiAndVisuals.bars.hasSeenVitalityAtLeastOnce) {
+			SkyblockerConfigManager.updateOnly(config -> config.uiAndVisuals.bars.hasSeenVitalityAtLeastOnce = true);
+			FancyStatusBars.makeVitalityVisible();
+		}
+		vitality.update(new Resource(RegexUtils.parseIntFromMatcher(m, "vitality"), RegexUtils.parseIntFromMatcher(m, "max"), 0));
 	}
 
 	private static void updateMana(Matcher m) {
 		int mana = RegexUtils.parseIntFromMatcher(m, "mana");
 		int max = RegexUtils.parseIntFromMatcher(m, "max");
 		int overflow = m.group("overflow") == null ? 0 : RegexUtils.parseIntFromMatcher(m, "overflow");
-		StatusBarTracker.mana = new Resource(mana, max, overflow);
-		if (mana != max && lastMana < mana) manaPerSecond = Math.max(mana - lastMana, 0);
-		if (lastMana != mana || mana == max) lastManaTick = ticks;
-		lastMana = mana;
+		StatusBarTracker.mana.update(new Resource(mana, max, overflow));
 	}
 
 	private static void updateSpeed() {
@@ -304,4 +293,46 @@ public class StatusBarTracker {
 	}
 
 	public record Resource(int value, int max, int overflow) {}
+
+	public static class EstimatedResource {
+		private Resource resource;
+		private int perSecond;
+		private int lastTick;
+		private int lastValue;
+
+		public EstimatedResource(Resource baseValue) {
+			this.resource = baseValue;
+		}
+
+		private void update(Resource newValue) {
+			this.resource = newValue;
+			if (resource.value() != resource.max() && lastValue < resource.value()) perSecond = Math.max(resource.value() - lastValue, 0);
+			if (lastValue != resource.value() || resource.value() == resource.max()) lastTick = ticks;
+			lastValue = resource.value();
+		}
+
+		private void tick() {
+			if (ticks - lastTick > 0 && (ticks - lastTick) % 20 == 0) {
+				resource = new Resource(Math.min(resource.value() + perSecond, resource.max()), resource.max(), resource.overflow());
+			}
+		}
+
+		public boolean isEstimated() {
+			return ticks - lastTick > 30;
+		}
+
+		public Resource resource() {
+			return resource;
+		}
+
+		public int value() {
+			return resource.value();
+		}
+		public int max() {
+			return resource.max();
+		}
+		public int overflow() {
+			return resource.overflow();
+		}
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/FancyStatusBars.java
@@ -66,6 +66,14 @@ public class FancyStatusBars {
 		return Debug.isTestEnvironment() || statusBar.enabled || statusBar.inMouse;
 	}
 
+	/**
+	 * Called when vitality is first discovered.
+	 */
+	public static void makeVitalityVisible() {
+		statusBars.get(StatusBarType.VITALITY).visible = true;
+		updatePositionsNextFrame = true;
+	}
+
 	@SuppressWarnings("deprecation")
 	@Init
 	public static void init() {
@@ -110,6 +118,7 @@ public class FancyStatusBars {
 		for (StatusBarType type : StatusBarType.values()) {
 			statusBars.put(type, type.newStatusBar());
 		}
+		statusBars.get(StatusBarType.VITALITY).visible = SkyblockerConfigManager.get().uiAndVisuals.bars.hasSeenVitalityAtLeastOnce;
 		// Fill defaults
 		resetBarPositions();
 
@@ -392,11 +401,11 @@ public class FancyStatusBars {
 			defenseBar.updateValues(defense / (defense + 100.f), 0, defense, null, null);
 		}
 
-		StatusBarTracker.Resource intelligence = StatusBarTracker.getMana();
+		StatusBarTracker.EstimatedResource intelligence = StatusBarTracker.getMana();
 		if (SkyblockerConfigManager.get().uiAndVisuals.bars.intelligenceDisplay == UIAndVisualsConfig.IntelligenceDisplay.ACCURATE) {
 			float totalIntelligence = (float) intelligence.max() + intelligence.overflow();
 			statusBars.get(StatusBarType.INTELLIGENCE).updateValues(intelligence.value() / totalIntelligence + intelligence.overflow() / totalIntelligence, intelligence.overflow() / totalIntelligence, intelligence.value(), intelligence.max(), intelligence.overflow());
-		} else statusBars.get(StatusBarType.INTELLIGENCE).updateWithResource(intelligence);
+		} else statusBars.get(StatusBarType.INTELLIGENCE).updateWithResource(intelligence.resource());
 
 		StatusBarTracker.Resource speed = StatusBarTracker.getSpeed();
 		statusBars.get(StatusBarType.SPEED).updateWithResource(speed);
@@ -409,13 +418,8 @@ public class FancyStatusBars {
 			updatePositionsNextFrame = true;
 		}
 		StatusBar vitality = statusBars.get(StatusBarType.VITALITY);
-		StatusBarTracker.Resource vitalityResource = StatusBarTracker.getVitality();
-		boolean hasVitality = vitalityResource != null;
-		if (hasVitality != vitality.visible) {
-			vitality.visible = hasVitality;
-			updatePositionsNextFrame = true;
-		}
-		if (hasVitality) vitality.updateWithResource(vitalityResource);
+		StatusBarTracker.EstimatedResource vitalityResource = StatusBarTracker.getVitality();
+		vitality.updateWithResource(vitalityResource.resource());
 		if (updatePositionsNextFrame) {
 			updatePositions(false);
 			updatePositionsNextFrame = false;

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBar.java
@@ -486,7 +486,7 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 	public static class ManaStatusBar extends StatusBar {
 
 		public ManaStatusBar(StatusBarType type) {
-			super(type, mana -> StatusBarTracker.isManaEstimated() ? "~" + mana : mana.toString());
+			super(type, mana -> StatusBarTracker.getMana().isEstimated() && SkyblockerConfigManager.get().uiAndVisuals.bars.showEstimatedTilde ? "~" + mana : mana.toString());
 		}
 
 		@Override
@@ -562,6 +562,12 @@ public class StatusBar implements LayoutElement, Renderable, GuiEventListener, N
 				else if (client.player.hasEffect(MobEffects.POISON)) return POISON_ICON;
 			}
 			return super.getIcon();
+		}
+	}
+
+	public static class VitalityStatusBar extends StatusBar {
+		public VitalityStatusBar(StatusBarType type) {
+			super(type, vitality -> StatusBarTracker.getVitality().isEstimated() && SkyblockerConfigManager.get().uiAndVisuals.bars.showEstimatedTilde ? "~" + vitality : vitality.toString());
 		}
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBarType.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/StatusBarType.java
@@ -79,6 +79,7 @@ public enum StatusBarType implements StringRepresentable {
 	public StatusBar newStatusBar() {
 		return switch (this) {
 			case HEALTH -> new StatusBar.HealthStatusBar(this);
+			case VITALITY -> new StatusBar.VitalityStatusBar(this);
 			case INTELLIGENCE -> new StatusBar.ManaStatusBar(this);
 			case EXPERIENCE -> new StatusBar.ExperienceStatusBar(this);
 			default -> new StatusBar(this);

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/VanillaStyleManaBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/VanillaStyleManaBar.java
@@ -95,7 +95,7 @@ public class VanillaStyleManaBar {
 	}
 
 	public static boolean extractRenderState(GuiGraphicsExtractor graphics) {
-		StatusBarTracker.Resource mana = StatusBarTracker.getMana();
+		StatusBarTracker.EstimatedResource mana = StatusBarTracker.getMana();
 
 		// Detect loss of mana to start blinking
 		long currentTime = Util.getMillis();

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1206,6 +1206,8 @@
   "skyblocker.config.uiAndVisuals.bars.openScreen": "Status Bars Config screen",
   "skyblocker.config.uiAndVisuals.bars.riftHealthHP": "Rift Health: HP instead of hearts",
   "skyblocker.config.uiAndVisuals.bars.riftHealthHP.@Tooltip": "In the rift, if enabled, the health status bar will display HP (20, 19, 18, ...) instead of Hearts (10, 9.5, 9, ...)",
+  "skyblocker.config.uiAndVisuals.bars.showEstimatedTilde": "Show Estimated Value Tilde",
+  "skyblocker.config.uiAndVisuals.bars.showEstimatedTilde.@Tooltip": "Displays a tilde (~) before a bar's value when it is estimated by skyblocker because it is not visible in the action bar.",
   "skyblocker.config.uiAndVisuals.bars.useHungerBarSprites": "Use Vanilla Hunger Bar Sprites",
 
   "skyblocker.config.uiAndVisuals.bazaarQuickQuantities": "Bazaar Quick Quantities",

--- a/src/test/java/de/hysky/skyblocker/skyblock/StatusBarTrackerTest.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/StatusBarTrackerTest.java
@@ -20,7 +20,7 @@ class StatusBarTrackerTest {
 		if (def != -1) {
 			assertEquals(def, StatusBarTracker.getDefense());
 		}
-		assertEquals(new StatusBarTracker.Resource(mana, maxMana, overflowMana), StatusBarTracker.getMana());
+		assertEquals(new StatusBarTracker.Resource(mana, maxMana, overflowMana), StatusBarTracker.getMana().resource());
 	}
 
 	@Test


### PR DESCRIPTION
- fix vitality bar leaving when in a dungeon room with secrets (it was cuz the secrets thing in action bar made the vitality matcher fail and the resource null)
- estimate vitality if it gets hidden by something in action bar
  - so this refactors the estimated stuff with an inner class
  - the bar will still not show up until the player discovers the stat, no way to force it to show up in-game, you have to edit the config file manually.
- adds an option to hide the tilde because someone asked and I know damn well I will forget if I don't do it now