### PR TITLE
Disable livid color text and title options by default

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/DungeonsConfig.java
@@ -151,9 +151,9 @@ public class DungeonsConfig {
 
 		public boolean enableLividColorBoundingBox = true;
 
-		public boolean enableLividColorText = true;
+		public boolean enableLividColorText = false;
 
-		public boolean enableLividColorTitle = true;
+		public boolean enableLividColorTitle = false;
 
 		public String lividColorText = "The livid color is [color]";
 	}


### PR DESCRIPTION
Disable the livid title text & chat by default as they are frankly unhelpful and the title text blocking your vision is frankly counterproductive.
AI usage disclosure: Yes, for coding help and tying my shoelaces