### PR TITLE
fix keybind shortcut conflicts

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/shortcut/ShortcutsConfigListWidget.java
@@ -441,7 +441,7 @@ public class ShortcutsConfigListWidget extends ContainerObjectSelectionList<Shor
 
 		@Override
 		protected String key() {
-			return keyBinding.getBoundKeysText().getString();
+			return keyBinding.getBoundKeysTranslationKey().toString();
 		}
 
 		/**


### PR DESCRIPTION
quite a lazy fix
previous one caused problems with keys that have the same translation like the period on the numpad and the one in the main keyboard