### PR TITLE
Ability to disable fairy soul highlighter on Ⓑ Bingo profiles

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/HelperCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/HelperCategory.java
@@ -367,6 +367,14 @@ public class HelperCategory {
 								.controller(ConfigUtils.createBooleanController())
 								.build())
 						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.helpers.fairySouls.highlightOnBingo"))
+								.description(Component.translatable("skyblocker.config.helpers.fairySouls.highlightOnBingo.@Tooltip"))
+								.binding(defaults.helpers.fairySouls.highlightOnBingo,
+										() -> config.helpers.fairySouls.highlightOnBingo,
+										newValue -> config.helpers.fairySouls.highlightOnBingo = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
 								.name(Component.translatable("skyblocker.config.helpers.fairySouls.highlightOnlyNearbySouls"))
 								.description(Component.translatable("skyblocker.config.helpers.fairySouls.highlightOnlyNearbySouls.@Tooltip"))
 								.binding(defaults.helpers.fairySouls.highlightOnlyNearbySouls,

--- a/src/main/java/de/hysky/skyblocker/config/configs/HelperConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/HelperConfig.java
@@ -132,6 +132,8 @@ public class HelperConfig {
 
 		public boolean highlightFoundSouls = true;
 
+		public boolean highlightOnBingo = true;
+
 		public boolean highlightOnlyNearbySouls = false;
 	}
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/waypoint/FairySouls.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/waypoint/FairySouls.java
@@ -157,7 +157,7 @@ public class FairySouls {
 	private static void extractRendering(PrimitiveCollector collector) {
 		HelperConfig.FairySouls fairySoulsConfig = SkyblockerConfigManager.get().helpers.fairySouls;
 
-		if (fairySoulsConfig.enableFairySoulsHelper && fairySoulsLoaded.isDone() && fairySouls.containsKey(Utils.getLocationRaw())) {
+		if (fairySoulsConfig.enableFairySoulsHelper && (fairySoulsConfig.highlightOnBingo || !Utils.isOnBingo()) && fairySoulsLoaded.isDone() && fairySouls.containsKey(Utils.getLocationRaw())) {
 			for (Waypoint fairySoul : fairySouls.get(Utils.getLocationRaw()).values()) {
 				boolean fairySoulNotFound = fairySoul.shouldRender();
 				if (!fairySoulsConfig.highlightFoundSouls && !fairySoulNotFound || fairySoulsConfig.highlightOnlyNearbySouls && fairySoul.pos.distToCenterSqr(RenderHelper.getCamera().position()) > 2500) {

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -782,6 +782,8 @@
   "skyblocker.config.helpers.fairySouls": "Fairy Souls Helper",
   "skyblocker.config.helpers.fairySouls.enableFairySoulsHelper": "Enable Fairy Souls Helper",
   "skyblocker.config.helpers.fairySouls.highlightFoundSouls": "Highlight found fairy souls",
+  "skyblocker.config.helpers.fairySouls.highlightOnBingo": "Highlight souls on Ⓑ Bingo profiles",
+  "skyblocker.config.helpers.fairySouls.highlightOnBingo.@Tooltip": "When disabled souls are not highlighted on Ⓑ Bingo profiles",
   "skyblocker.config.helpers.fairySouls.highlightOnlyNearbySouls": "Only highlight nearby fairy souls",
   "skyblocker.config.helpers.fairySouls.highlightOnlyNearbySouls.@Tooltip": "When enabled only fairy souls in a radius of 50 blocks are highlighted",
 


### PR DESCRIPTION
This adds a setting to disable the fairy soul highlighter when on a bingo profile. Fairy souls aren't always necessary for a bingo run, and when they are, well you can just toggle the setting back on again. The highlighting can be a tad annoying if you have it on solely for your main profile.

By default the setting is on, meaning the souls will highlight when on a bingo profile just like it does already.