### PR TITLE
Fix Oxygenbar and Vanilla Mana Bar Overlap

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/HudMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/HudMixin.java
@@ -1,11 +1,13 @@
 package de.hysky.skyblocker.mixins;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.skyblock.hunting.safari.SafariUtils;
+import de.hysky.skyblocker.skyblock.fancybars.VanillaStyleManaBar;
 import de.hysky.skyblocker.skyblock.item.HotbarSlotLock;
 import de.hysky.skyblocker.skyblock.item.ItemCooldowns;
 import de.hysky.skyblocker.skyblock.item.ItemProtection;
@@ -130,5 +132,11 @@ public abstract class HudMixin {
 	@ModifyExpressionValue(method = "extractCameraOverlays", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getTicksFrozen()I"))
 	private int skyblocker$hideSafariColdOverlay(int original) {
 		return Utils.isOnSkyblock() && SafariUtils.isInIcyBiome() && SkyblockerConfigManager.get().hunting.icyBiome.hideColdOverlay ? 0 : original;
+	}
+
+	// Workaround, can be removed when https://github.com/FabricMC/fabric-api/issues/5517 is fixed. See VanillaStylemanaBar.java for proper fix
+	@ModifyReturnValue(method = "getAirBubbleYLine", at = @At("RETURN"))
+	private int skyblocker$adjustAirBubbleHeight(int original) {
+		return VanillaStyleManaBar.isEnabled() ? original - 10 : original;
 	}
 }

--- a/src/main/java/de/hysky/skyblocker/skyblock/fancybars/VanillaStyleManaBar.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/fancybars/VanillaStyleManaBar.java
@@ -69,10 +69,23 @@ public class VanillaStyleManaBar {
 		HudElementRegistry.attachElementBefore(VanillaHudElements.MOUNT_HEALTH, MANABAR_MOUNT_HUD_ID, (context, _) -> {
 			if (isEnabled()) extractRenderState(context);
 		});
+
+		/*
+		Proper implementation of height for bars, broken due to https://github.com/FabricMC/fabric-api/issues/5517
+		When fixed uncomment this and remove corresponding mixin from HudMixn.java
+
+		// 10 pixels is the spacing for a single bar, the mana bar always has 2 bars so has a height of 20 pixels
+		HudStatusBarHeightRegistry.addRight(VanillaHudElements.FOOD_BAR, (player) -> isEnabled() ? 0 : 10);
+		HudStatusBarHeightRegistry.addRight(VanillaHudElements.MOUNT_HEALTH, (player) -> isEnabled() ? 0 : 10);
+		// Only height for one bar needs to be registered, since the height for both bars is always enabled even when not visible.
+		// This could be changed if we had a condition like "isEnabled() && isHungerBarVisible()" for each individual bar,
+		// but as far as I am aware that condition is not easily available
+		HudStatusBarHeightRegistry.addRight(MANABAR_MOUNT_HUD_ID, (player) -> isEnabled() ? 20 : 0);
+		 */
 	}
 
-	private static boolean isEnabled() {
-		return Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.bars.enableVanillaStyleManaBar  && !FancyStatusBars.isEnabled();
+	public static boolean isEnabled() {
+		return Utils.isOnSkyblock() && SkyblockerConfigManager.get().uiAndVisuals.bars.enableVanillaStyleManaBar && !FancyStatusBars.isEnabled();
 	}
 
 	private static void extractNotch(GuiGraphicsExtractor graphics, int column, int row, NotchType notchtype, boolean isHalf, boolean isBlinking) {


### PR DESCRIPTION
Uses workaround to fix vanilla mana bar overlap without breaking bars height. Includes proper fix and comments referencing https://github.com/FabricMC/fabric-api/issues/5517 so it can be implemented properly when the bug is fixed