### PR TITLE
Fix of exhausting buffer space

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfo.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfo.java
@@ -1,6 +1,7 @@
 package de.hysky.skyblocker.skyblock.item.tooltip.info;
 
 import java.net.http.HttpHeaders;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -11,6 +12,7 @@ import com.google.gson.JsonParser;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 
+import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.configs.GeneralConfig;
 import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.utils.Http;
@@ -24,6 +26,7 @@ public final class DataTooltipInfo<T> extends SimpleTooltipInfo implements DataT
 	private final BiPredicate<T, String> contains;
 	private final Predicate<GeneralConfig.ItemTooltip> dataEnabled;
 	private final @Nullable Consumer<T>[] callbacks;
+	private CompletableFuture<Void> download = CompletableFuture.completedFuture(null);
 
 	@SafeVarargs
 	protected DataTooltipInfo(String address, Codec<T> codec, boolean cacheable, BiPredicate<T, String> contains, Predicate<GeneralConfig.ItemTooltip> tooltipEnabled, Predicate<GeneralConfig.ItemTooltip> dataEnabled, Consumer<T>... callbacks) {
@@ -62,6 +65,19 @@ public final class DataTooltipInfo<T> extends SimpleTooltipInfo implements DataT
 		} else {
 			return contains.test(data, memberName);
 		}
+	}
+
+	/**
+	 * Starts a download unless one is already in progress.
+	 * @return a non-null future mirroring the active download, which may have been started by an earlier caller; mutating the returned future does not affect the active download
+	 */
+	@Override
+	public synchronized CompletableFuture<Void> download() {
+		if (download.isDone()) {
+			download = CompletableFuture.runAsync(this, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
+		}
+
+		return download.copy();
 	}
 
 	@Override

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfo.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfo.java
@@ -12,7 +12,6 @@ import com.google.gson.JsonParser;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 
-import de.hysky.skyblocker.SkyblockerMod;
 import de.hysky.skyblocker.config.configs.GeneralConfig;
 import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.utils.Http;
@@ -74,7 +73,7 @@ public final class DataTooltipInfo<T> extends SimpleTooltipInfo implements DataT
 	@Override
 	public synchronized CompletableFuture<Void> download() {
 		if (download.isDone()) {
-			download = super.download();
+			download = DataTooltipInfoType.super.download();
 		}
 
 		return download.copy();

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfo.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/info/DataTooltipInfo.java
@@ -74,7 +74,7 @@ public final class DataTooltipInfo<T> extends SimpleTooltipInfo implements DataT
 	@Override
 	public synchronized CompletableFuture<Void> download() {
 		if (download.isDone()) {
-			download = CompletableFuture.runAsync(this, SkyblockerMod.VIRTUAL_THREAD_EXECUTOR);
+			download = super.download();
 		}
 
 		return download.copy();

--- a/src/main/java/de/hysky/skyblocker/utils/Http.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Http.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.Nullable;
 public class Http {
 	private static final String NAME_2_UUID = "https://api.minecraftservices.com/minecraft/profile/lookup/name/";
 	private static final String HYPIXEL_PROXY = "https://hysky.de/api/hypixel/v2/";
-	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(60);
 	public static final String USER_AGENT = "Skyblocker/" + SkyblockerMod.VERSION + " (" + SharedConstants.getCurrentVersion().name() + ")";
 	private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
 			.connectTimeout(Duration.ofSeconds(10))

--- a/src/main/java/de/hysky/skyblocker/utils/Http.java
+++ b/src/main/java/de/hysky/skyblocker/utils/Http.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.Nullable;
 public class Http {
 	private static final String NAME_2_UUID = "https://api.minecraftservices.com/minecraft/profile/lookup/name/";
 	private static final String HYPIXEL_PROXY = "https://hysky.de/api/hypixel/v2/";
+	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
 	public static final String USER_AGENT = "Skyblocker/" + SkyblockerMod.VERSION + " (" + SharedConstants.getCurrentVersion().name() + ")";
 	private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
 			.connectTimeout(Duration.ofSeconds(10))
@@ -37,6 +38,7 @@ public class Http {
 	public static ApiResponse sendCacheableGetRequest(String url, @Nullable String token) throws IOException, InterruptedException {
 		HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
 				.GET()
+				.timeout(REQUEST_TIMEOUT)
 				.header("Accept", "application/json")
 				.header("Accept-Encoding", "gzip, deflate")
 				.header("User-Agent", USER_AGENT)
@@ -59,6 +61,7 @@ public class Http {
 	public static InputStream downloadContent(String url) throws IOException, InterruptedException {
 		HttpRequest request = HttpRequest.newBuilder()
 				.GET()
+				.timeout(REQUEST_TIMEOUT)
 				.header("Accept", "*/*")
 				.header("Accept-Encoding", "gzip, deflate")
 				.header("User-Agent", USER_AGENT)
@@ -78,6 +81,7 @@ public class Http {
 	public static HttpHeaders sendHeadRequest(String url) throws IOException, InterruptedException {
 		HttpRequest request = HttpRequest.newBuilder()
 				.method("HEAD", BodyPublishers.noBody())
+				.timeout(REQUEST_TIMEOUT)
 				.header("User-Agent", USER_AGENT)
 				.version(Version.HTTP_2)
 				.uri(URI.create(url))
@@ -90,6 +94,7 @@ public class Http {
 	public static String sendPostRequest(String url, String requestBody, String contentType) throws IOException, InterruptedException {
 		HttpRequest request = HttpRequest.newBuilder()
 				.POST(BodyPublishers.ofString(requestBody))
+				.timeout(REQUEST_TIMEOUT)
 				.header("Accept", contentType)
 				.header("Accept-Encoding", "gzip, deflate")
 				.header("Content-Type", contentType)


### PR DESCRIPTION
When the game is open with Skyblocker for days (24h+), it eventually exhausts the available connection buffer space. 
This causes the entire internet connection to become unusable (`ERR_NO_BUFFER_SPACE`).

My fix introduces a timeout for HTTP requests and prevents multiple download futures for the same dataset from running at once.
I verified through TCP monitoring over a longer session that, with this fix, the number of open connections stabilizes instead of increasing indefinitely.

Applied spotless checks and all contribution guidelines.