### PR TITLE
Remove the redundant word 'show' from showTerminalStatus tooltip

### DIFF
--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -453,7 +453,7 @@
   "skyblocker.config.dungeons.terminalHud.showGate": "Show Gate",
   "skyblocker.config.dungeons.terminalHud.showLevers": "Show Levers",
   "skyblocker.config.dungeons.terminalHud.showTerminalStatus": "Show Task Status",
-  "skyblocker.config.dungeons.terminalHud.showTerminalStatus.@Tooltip": "If disabled, only show incomplete tasks will be shown.",
+  "skyblocker.config.dungeons.terminalHud.showTerminalStatus.@Tooltip": "If disabled, only incomplete tasks will be shown.",
   "skyblocker.config.dungeons.terminalHud.showTerminals": "Show Terminals",
 
   "skyblocker.config.dungeons.terminals": "Terminal Solvers (F7/M7)",


### PR DESCRIPTION
This is not a PR farm thumbsup emoji