### PR TITLE
Correctly detect high sweep values

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/foraging/galatea/SweepDetailsListener.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/foraging/galatea/SweepDetailsListener.java
@@ -17,7 +17,7 @@ import net.minecraft.network.chat.Component;
 public class SweepDetailsListener implements ChatMessageListener {
 	// Used to keep cancelled sweep messages in logs
 	private static final Logger LOGGER = LogUtils.getLogger();
-	protected static final Pattern SWEEP_DETAILS = Pattern.compile(String.format("Sweep Details: ([\\d.]+)[∮%s] Sweep", SkyBlockIcons.SWEEP));
+	protected static final Pattern SWEEP_DETAILS = Pattern.compile(String.format("Sweep Details: ([\\d,.]+)[∮%s] Sweep", SkyBlockIcons.SWEEP));
 	protected static final Pattern TREE_TOUGHNESS = Pattern.compile("  (.+?) Tree Toughness: ([\\d.]+) ([\\d.]+) Logs");
 	protected static final Pattern AXE_THROW_PENALTY = Pattern.compile("  Axe throw: (-\\d+)% Sweep ([\\d.]+) Logs");
 	protected static final Pattern WRONG_STYLE_PENALTY = Pattern.compile("  Wrong Style: (-\\d+)% Sweep ([\\d.]+) Logs ([a-zA-Z ]*)!!");
@@ -79,7 +79,7 @@ public class SweepDetailsListener implements ChatMessageListener {
 			active = true;
 			lastMatch = System.currentTimeMillis();
 
-			String rawMaxSweep = sweepDetails.group(1);
+			String rawMaxSweep = sweepDetails.group(1).replace(",", "");
 			if (NumberUtils.isCreatable(rawMaxSweep)) {
 				maxSweep = Float.parseFloat(rawMaxSweep);
 			} else {


### PR DESCRIPTION
Max sweep is around 1,300 now I believe, but even just reaching 1,000 I saw the issue:
<img width="605" height="240" alt="image" src="https://github.com/user-attachments/assets/73517e13-3413-4665-9dcc-1675ddded989" />

I tested this, sweep details messages aren't sending anymore when running this PR locally.