### PR TITLE
Fix beacon solver in torrhus canyon

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/foraging/galatea/TunerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/foraging/galatea/TunerSolver.java
@@ -326,7 +326,7 @@ public class TunerSolver extends SimpleContainerSolver implements SlotTextAdder 
 
 	private void onSound(ClientboundSoundPacket packet) {
 		if (!SkyblockerConfigManager.get().foraging.moongladeMarsh.enableTunerSolver
-				|| pitchSolved || (!Utils.isInGalatea() && !Utils.isInTorrhusCanyon()) || !isInMenu
+				|| pitchSolved || !Utils.isInForagingIsland() || !isInMenu
 				|| !packet.getSound().value().location().equals(SoundEvents.NOTE_BLOCK_BASS.value().location())) {
 			return;
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/foraging/galatea/TunerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/foraging/galatea/TunerSolver.java
@@ -326,7 +326,7 @@ public class TunerSolver extends SimpleContainerSolver implements SlotTextAdder 
 
 	private void onSound(ClientboundSoundPacket packet) {
 		if (!SkyblockerConfigManager.get().foraging.moongladeMarsh.enableTunerSolver
-				|| pitchSolved || !Utils.isInGalatea() || !isInMenu
+				|| pitchSolved || (!Utils.isInGalatea() && !Utils.isInTorrhusCanyon()) || !isInMenu
 				|| !packet.getSound().value().location().equals(SoundEvents.NOTE_BLOCK_BASS.value().location())) {
 			return;
 		}


### PR DESCRIPTION
Turns out it was only failing to work because the `onSound()` method had a strict location check for just the moonglade marsh. Changed that and now it works:
<img width="339" height="250" alt="image" src="https://github.com/user-attachments/assets/964a50ef-4bc8-4c26-995e-1598c25bc235" />
