### PR TITLE
fix: solve Boulder puzzles on the final row

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/boulder/BoulderSolver.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/boulder/BoulderSolver.java
@@ -159,12 +159,20 @@ public class BoulderSolver {
 		}
 
 		/**
-		 * Checks if the puzzle is solved, i.e., if the player is positioned on the target BoulderObject.
+		 * Checks if the puzzle is solved, i.e., if the player has reached the row containing the target
+		 * BoulderObject. The player can walk past the remaining blocks on that final row.
 		 *
 		 * @return true if the theoretical puzzle is solved, false otherwise.
 		 */
 		public boolean isSolved() {
-			return grid[playerX][playerY] == 'T';
+			for (int row = 0; row < grid.length; row++) {
+				for (char cell : grid[row]) {
+					if (cell == 'T') {
+						return playerX == row;
+					}
+				}
+			}
+			return false;
 		}
 
 		/**

--- a/src/test/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/boulder/BoulderSolverTest.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/dungeon/puzzle/boulder/BoulderSolverTest.java
@@ -1,0 +1,30 @@
+package de.hysky.skyblocker.skyblock.dungeon.puzzle.boulder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BoulderSolverTest {
+	@Test
+	void anyPositionOnTheLastRowSolvesThePuzzle() {
+		char[][] board = {
+				{'B', 'T', 'B'},
+				{'.', '.', '.'}
+		};
+
+		assertTrue(new BoulderSolver.GameState(board, 0, 0).isSolved());
+		assertTrue(new BoulderSolver.GameState(board, 0, 1).isSolved());
+		assertTrue(new BoulderSolver.GameState(board, 0, 2).isSolved());
+	}
+
+	@Test
+	void rowsBeforeTheLastRowAreNotSolved() {
+		char[][] board = {
+				{'B', 'T', 'B'},
+				{'.', '.', '.'}
+		};
+
+		assertFalse(new BoulderSolver.GameState(board, 1, 0).isSolved());
+	}
+}


### PR DESCRIPTION
## What changed

Boulder now treats any player position on the row containing the target as solved. Reaching that final row is enough because the remaining blocks on the row can be walked past.

## Why

The solver previously required the player to stand on the target cell itself, so valid solutions on another column were rejected.

## Validation

- `./gradlew.bat test --tests de.hysky.skyblocker.skyblock.dungeon.puzzle.boulder.BoulderSolverTest`
- `./gradlew.bat spotlessCheck`
- `git diff --check`

Checkstyle could not complete locally because its remote DTD fetch timed out.

Fixes #2660