### PR TITLE
Fix status bar tracker stripping formatting

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -46,7 +46,7 @@ public class StatusBarTracker {
 	private static final Minecraft MINECRAFT = Minecraft.getInstance();
 
 	/// Caches the last message to avoid parsing the same message multiple times.
-	private static String lastMessage = "";
+	private static Component lastMessage = Component.empty();
 	/// Caches the last return value of {@link #onOverlayMessage(Component, boolean)}.
 	private static Component lastReturn = Component.empty();
 	private static long lastMessageTime = 0;
@@ -128,21 +128,20 @@ public class StatusBarTracker {
 		if (!overlay || !Utils.isOnSkyblock()) {
 			return text;
 		}
-		String stringified = text.getString();
 
 		long now = System.currentTimeMillis();
-		if (lastMessage.equals(stringified) && lastMessageTime + 367 > now) { // Prime ms for a prime 7 ticks
+		if (lastMessage.equals(text) && lastMessageTime + 367 > now) { // Prime ms for a prime 7 ticks
 			return lastReturn;
 		}
-		lastMessage = stringified;
+		lastMessage = text;
 		lastMessageTime = now;
+		String stringified = text.getString();
 
 		try {
-			if (FancyStatusBars.isEnabled()) {
-				return lastReturn = Component.literal(update(stringified, SkyblockerConfigManager.get().chat.hideMana));
-			} else {
-				// Still update values for other parts of the mod to use
-				update(stringified, SkyblockerConfigManager.get().chat.hideMana);
+			String returned = update(stringified, SkyblockerConfigManager.get().chat.hideMana);
+
+			if (FancyStatusBars.isEnabled() && !stringified.equals(returned)) {
+				return lastReturn = Component.literal(returned);
 			}
 		} catch (Exception e) {
 			String stripped = ChatFormatting.stripFormatting(stringified);

--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -130,7 +130,7 @@ public class StatusBarTracker {
 		}
 
 		long now = System.currentTimeMillis();
-		if (lastMessage.equals(text) && lastMessageTime + 367 > now) { // Prime ms for a prime 7 ticks
+		if (lastMessage.equals(text) && lastMessageTime + 337 > now) { // Prime ms for a prime 7 ticks
 			return lastReturn;
 		}
 		lastMessage = text;
@@ -138,9 +138,11 @@ public class StatusBarTracker {
 		String stringified = text.getString();
 
 		try {
+			// Always update values for other parts of the mod to use
 			String returned = update(stringified, SkyblockerConfigManager.get().chat.hideMana);
 
 			if (FancyStatusBars.isEnabled() && !stringified.equals(returned)) {
+				// TODO This may still strip formatting from partially consumed message
 				return lastReturn = Component.literal(returned);
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
See #2582 for context.

### Testing
<details>
<summary>Fancy status bars still work as intended</summary>
<img width="590" height="115" alt="image" src="https://github.com/user-attachments/assets/ea8f1e84-12de-470c-b138-a207a1546b23" />
</details>
<details>
<summary>Still works with fancy status bars disabled</summary>
<img width="635" height="115" alt="image" src="https://github.com/user-attachments/assets/fe4200c8-3c81-45a4-ae1c-670d9189bf1f" />
</details>
<details>
<summary>Formatting is no longer stripped from the action bar</summary>
<img width="550" height="115" alt="image" src="https://github.com/user-attachments/assets/688ca90d-45fe-4915-a701-873a2003c312" />
</details>
