### PR TITLE
Add chat filter for safari critter capture messages

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/ChatCategory.java
@@ -187,6 +187,14 @@ public class ChatCategory {
 										newValue -> config.chat.hideDungeonBreaker = newValue)
 								.controller(ConfigUtils.createEnumController())
 								.build())
+						.option(Option.<ChatFilterResult>createBuilder()
+								.name(Component.translatable("skyblocker.config.chat.filter.hideCritterCapture"))
+								.description(Component.translatable("skyblocker.config.chat.filter.hideCritterCapture.@Tooltip"))
+								.binding(defaults.chat.hideCritterCapture,
+										() -> config.chat.hideCritterCapture,
+										newValue -> config.chat.hideCritterCapture = newValue)
+								.controller(ConfigUtils.createEnumController())
+								.build())
 						.build())
 
 				//chat rules options

--- a/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/ChatConfig.java
@@ -48,6 +48,8 @@ public class ChatConfig {
 
 	public ChatFilterResult hideDungeonBreaker = ChatFilterResult.PASS;
 
+	public ChatFilterResult hideCritterCapture = ChatFilterResult.PASS;
+
 	public ChatRuleConfig chatRuleConfig = new ChatRuleConfig();
 
 	public static class ChatRuleConfig {

--- a/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/CritterCaptureFilter.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/chat/filters/CritterCaptureFilter.java
@@ -1,0 +1,17 @@
+package de.hysky.skyblocker.skyblock.chat.filters;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.Utils;
+import de.hysky.skyblocker.utils.chat.ChatFilterResult;
+
+
+public class CritterCaptureFilter extends SimpleChatFilter {
+	public CritterCaptureFilter() {
+		super("^(CAPTURE|LOOT SHARE)! .*$");
+	}
+
+	@Override
+	public ChatFilterResult state() {
+		return Utils.isInSafari() ? SkyblockerConfigManager.get().chat.hideCritterCapture : ChatFilterResult.PASS;
+	}
+}

--- a/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
+++ b/src/main/java/de/hysky/skyblocker/utils/chat/ChatMessageListener.java
@@ -18,6 +18,7 @@ import de.hysky.skyblocker.skyblock.chat.filters.AdFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.AoteFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.AutopetFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.ComboFilter;
+import de.hysky.skyblocker.skyblock.chat.filters.CritterCaptureFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.DeathFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.DungeonBreakerFilter;
 import de.hysky.skyblocker.skyblock.chat.filters.HealFilter;
@@ -78,6 +79,7 @@ public interface ChatMessageListener {
 				new AdFilter(),
 				new AoteFilter(),
 				new ComboFilter(),
+				new CritterCaptureFilter(),
 				new HealFilter(),
 				new ImplosionFilter(),
 				new SpiritSceptreFilter(),

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -161,6 +161,8 @@
   "skyblocker.config.chat.filter.hideAds": "Hide Ads From Public Chat",
   "skyblocker.config.chat.filter.hideAutopet": "Hide Autopet Messages",
   "skyblocker.config.chat.filter.hideCombo": "Hide Combo Messages",
+  "skyblocker.config.chat.filter.hideCritterCapture": "Hide Critter Capture Messages",
+  "skyblocker.config.chat.filter.hideCritterCapture.@Tooltip": "Hides critter capture and loot share message spam.",
   "skyblocker.config.chat.filter.hideDeath": "Hide Player Death Messages",
   "skyblocker.config.chat.filter.hideDeath.@Tooltip": "Filters the player death messages from chat.",
   "skyblocker.config.chat.filter.hideDungeonBreaker": "Hide Dungeonbreaker Messages",


### PR DESCRIPTION
See title. These messages are extremely spammy and often bury important communication from other party members during a safari.