### PR TITLE
Track glowing mushrooms near the cave entrance, not just inside it

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/barn/GlowingMushrooms.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/barn/GlowingMushrooms.java
@@ -18,7 +18,6 @@ import net.minecraft.world.phys.AABB;
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.events.ParticleEvents;
-import de.hysky.skyblocker.utils.Area;
 import de.hysky.skyblocker.utils.ColorUtils;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.LevelRenderExtractionCallback;
@@ -77,7 +76,11 @@ public class GlowingMushrooms {
 	}
 
 	private static boolean shouldProcess() {
-		return SkyblockerConfigManager.get().otherLocations.barn.enableGlowingMushroomHelper && Utils.isInFarm() && Utils.getArea() == Area.TheFarmingIslands.GLOWING_MUSHROOM_CAVE;
+		// Don't also require Area.TheFarmingIslands.GLOWING_MUSHROOM_CAVE here: that area is only
+		// detected once well inside the cave, so mushrooms glowing just outside the entrance were
+		// never tracked (#2630). Particle events are already specific to actual mushroom blocks,
+		// so gating on the whole island is enough to avoid false positives elsewhere.
+		return SkyblockerConfigManager.get().otherLocations.barn.enableGlowingMushroomHelper && Utils.isInFarm();
 	}
 
 	private static void reset() {


### PR DESCRIPTION
## Summary
- Fixes #2630 — the glowing mushroom helper's overlay only appears once you're well inside the Glowing Mushroom Cave, even though mushrooms can visibly glow just around the corner from the entrance.
- Root cause: `GlowingMushrooms.shouldProcess()` gates particle handling, waypoint updates, *and* rendering on `Utils.getArea() == Area.TheFarmingIslands.GLOWING_MUSHROOM_CAVE`. That area value comes from `Area.from(name)` matching Hypixel's own server-sent area display name (see `Area.java`), which only switches to "Glowing Mushroom Cave" once the player is far enough inside per Hypixel's own server-side logic. Mushroom particle events firing near the entrance, while still technically outside that exact area label, were silently dropped in `onParticle()` before ever being tracked.

## Fix
- Drop the `Area.TheFarmingIslands.GLOWING_MUSHROOM_CAVE` requirement from `shouldProcess()`, keeping `Utils.isInFarm()` (the whole island) plus the config toggle.
- This is safe from false positives: `onParticle()` already independently verifies the particle is `ENTITY_EFFECT` *and* the block at that position is `RED_MUSHROOM`/`BROWN_MUSHROOM` before ever tracking it, so nothing new gets picked up elsewhere on the island — this change only removes the extra gate that was blocking legitimate detections near the cave boundary.
- Removed the now-unused `Area` import.

## Test plan
- [x] Traced `Area.TheFarmingIslands` (single enum value, matched by exact server-sent display name) to confirm the area label is Hypixel-server-driven and not a client-side polygon, supporting the "detected late" theory.
- [x] Confirmed `onParticle()`'s existing particle-type + block-type checks are sufficient to prevent false positives without the area gate.
- Not able to reproduce inside a live Hypixel Skyblock session in this environment, so please confirm the overlay now shows up right at the cave entrance before merging.