### PR TITLE
Register an exclusion zone for the Accessory Bag Helper widget

### DIFF
--- a/src/main/java/de/hysky/skyblocker/compatibility/ItemListCompatibility.java
+++ b/src/main/java/de/hysky/skyblocker/compatibility/ItemListCompatibility.java
@@ -18,6 +18,7 @@ import net.minecraft.client.renderer.Rect2i;
 
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
 import de.hysky.skyblocker.mixins.accessors.AbstractContainerScreenAccessor;
+import de.hysky.skyblocker.skyblock.accessories.AccessoriesHelper;
 import de.hysky.skyblocker.skyblock.auction.AuctionBrowserScreen;
 import de.hysky.skyblocker.skyblock.garden.GardenPlots;
 import de.hysky.skyblocker.skyblock.garden.visitor.VisitorHelper;
@@ -47,6 +48,8 @@ public class ItemListCompatibility implements Plugin {
 			if (!VisitorHelper.shouldRender()) return List.of();
 			return VisitorHelper.getExclusionZones();
 		});
+
+		zones.addProvider(Screen.class, _ -> AccessoriesHelper.getExclusionZone().map(List::of).orElseGet(List::of));
 
 		zones.addProvider(AuctionBrowserScreen.class, screen -> {
 			AbstractContainerScreenAccessor accessor = (AbstractContainerScreenAccessor) screen;

--- a/src/main/java/de/hysky/skyblocker/skyblock/accessories/AccessoriesHelper.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/accessories/AccessoriesHelper.java
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.gui.screens.inventory.ContainerScreen;
+import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
@@ -45,6 +46,13 @@ public class AccessoriesHelper {
 	private static final ToIntFunction<Accessory> ACCESSORY_TIER = Accessory::tier;
 
 	public static Map<String, Accessory> ACCESSORY_DATA = new Object2ObjectOpenHashMap<>();
+
+	/**
+	 * @return the bounds of the accessory bag helper widget, if it's currently open, for use as an item list exclusion zone
+	 */
+	public static Optional<Rect2i> getExclusionZone() {
+		return Optional.ofNullable(AccessoriesHelperWidget.getExclusionZone());
+	}
 
 	@Init
 	public static void init() {

--- a/src/main/java/de/hysky/skyblocker/skyblock/accessories/AccessoriesHelperWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/accessories/AccessoriesHelperWidget.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableList;
 import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import org.jspecify.annotations.Nullable;
 
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.client.screen.v1.Screens;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -40,6 +41,7 @@ import net.minecraft.client.gui.screens.recipebook.RecipeBookTabButton;
 import net.minecraft.client.input.InputWithModifiers;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.CommonComponents;
@@ -90,11 +92,22 @@ class AccessoriesHelperWidget extends AbstractContainerWidget implements Hovered
 	private static boolean open;
 	private static boolean showHighestTierOnly;
 
+	// Tracks the widget attached to the currently open screen, if any, so its bounds can be
+	// exposed as an item list (REI/EMI/JEI) exclusion zone.
+	private static @Nullable AccessoriesHelperWidget currentWidget;
+
+	static @Nullable Rect2i getExclusionZone() {
+		if (currentWidget == null || !currentWidget.visible) return null;
+		return new Rect2i(currentWidget.getX(), currentWidget.getY(), currentWidget.getWidth(), currentWidget.getHeight());
+	}
+
 	static void attachToScreen(ContainerScreen screen) {
 		if (!SkyblockerConfigManager.get().general.itemTooltip.enableAccessoriesHelper || !SkyblockerConfigManager.get().helpers.enableAccessoriesHelperWidget) return;
 		final AccessoriesHelperWidget widget = new AccessoriesHelperWidget();
 		widget.setY((screen.height - widget.getHeight()) / 2);
 		Screens.getWidgets(screen).add(widget);
+		currentWidget = widget;
+		ScreenEvents.remove(screen).register(_ -> currentWidget = null);
 		final int previousX = ((AbstractContainerScreenAccessor) screen).getX();
 		final int offset = Math.max(180 - previousX, 0);
 		TabButton tabButton = new TabButton(button -> {


### PR DESCRIPTION
## Summary
- Fixes #2523 — the Accessory Bag Helper panel never registered its bounds with the item list (REI/EMI/JEI) exclusion zone system, so those mods' search overlay can render on top of it.
- Every other Skyblocker overlay widget (Museum overlay, Garden Plots widget, Visitor Helper, Storage Overlay, Auction Browser) already has a corresponding provider in `ItemListCompatibility.registerExclusionZones()`. The Accessory Bag Helper widget (`AccessoriesHelperWidget`, attached in `AccessoriesHelper.init()`) was simply missing from that list.

## Fix
- `AccessoriesHelperWidget`: track the widget instance currently attached to a screen in a static field, cleared via `ScreenEvents.remove(screen)` when that screen closes (mirroring the cleanup pattern already used for similar per-screen state elsewhere, e.g. `SlotTextManager`). Added `getExclusionZone()` returning its bounds as a `Rect2i` only while it's actually visible (the panel can be toggled closed while the accessory bag itself stays open).
- `AccessoriesHelper`: expose this through a public `getExclusionZone()` returning an `Optional<Rect2i>`.
- `ItemListCompatibility`: register it with `zones.addProvider(Screen.class, ...)`, following the exact same pattern already used for `VisitorHelper.getExclusionZones()` just above it.

## Test plan
- [x] Verified the widget's `visible` field and `getX()/getY()/getWidth()/getHeight()` are the same accessors already used elsewhere in the class (e.g. `widget.visible = open = toggled;`), so the new zone tracks the widget's real, current position/size and toggled state.
- [x] Cleanup on screen close prevents a stale exclusion zone from leaking into unrelated screens after the accessory bag is closed while the panel was left open (`open` persists as a static UI preference).
- Not able to visually confirm the REI/EMI/JEI overlay no longer covers the panel in a live game session in this environment — please double-check before merging.