### PR TITLE
Wait for the tab list to load before warning that Sweep stat is missing

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/foraging/SweepOverlay.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/foraging/SweepOverlay.java
@@ -46,6 +46,9 @@ public class SweepOverlay {
 	private static final int MAX_WOOD_CAP = 35;
 	private static final Pattern SWEEP_VALUE_PATTERN = Pattern.compile(String.format("Sweep:\\s*(?:[∮%s])*(\\d+)", SkyBlockIcons.SWEEP));
 	private static boolean sweepStatNoticeShown = false;
+	// Grace period so we don't warn before the tab list has actually loaded on higher-ping connections (see #2673).
+	private static final long SWEEP_STAT_MISSING_GRACE_PERIOD_MS = 5_000;
+	private static long sweepStatFirstMissingTime = -1;
 	private static final Set<String> VALID_AXES = Set.of(
 			"JUNGLE_AXE", "TREECAPITATOR_AXE", "FIG_AXE", "FIGSTONE_AXE", "HELIX_CHOPPER",
 			"ROOKIE_AXE", "PROMISING_AXE", "SWEET_AXE", "EFFICIENT_AXE"
@@ -186,9 +189,9 @@ public class SweepOverlay {
 	/**
 	 * Retrieves the player's Sweep stat.
 	 * <p>
-	 * The value is parsed from the tab list when available. If it cannot be
-	 * found, an informational chat message is sent once asking the player to
-	 * update their tab list using <code>/tablist</code>.
+	 * The value is parsed from the tab list when available. If it's still missing after the tab
+	 * list has had a few seconds to load, an informational chat message is sent once asking the
+	 * player to update their tab list using <code>/tablist</code>.
 	 *
 	 * @return the Sweep stat as a float
 	 */
@@ -203,6 +206,7 @@ public class SweepOverlay {
 				Matcher matcher = SWEEP_VALUE_PATTERN.matcher(entry);
 				if (matcher.find()) {
 					try {
+						sweepStatFirstMissingTime = -1;
 						return Float.parseFloat(matcher.group(1));
 					} catch (NumberFormatException e) {
 						LOGGER.warn("Failed to parse Sweep stat from tab list: {}. Error: {}", entry, e.getMessage());
@@ -211,10 +215,17 @@ public class SweepOverlay {
 			}
 		}
 		if (!sweepStatNoticeShown && Utils.isInForagingIsland() && CLIENT.player != null) {
-			CLIENT.player.sendSystemMessage(Constants.PREFIX.get().append(
-							Component.translatable("skyblocker.config.foraging.sweepOverlay.sweepStatMissingMessage")
-									.withStyle(ChatFormatting.RED)));
-			sweepStatNoticeShown = true;
+			long now = System.currentTimeMillis();
+			if (sweepStatFirstMissingTime == -1) {
+				// Tab list may not have loaded yet on higher-ping connections, especially right on join.
+				// Wait for the missing state to persist before assuming it's actually missing.
+				sweepStatFirstMissingTime = now;
+			} else if (now - sweepStatFirstMissingTime >= SWEEP_STAT_MISSING_GRACE_PERIOD_MS) {
+				CLIENT.player.sendSystemMessage(Constants.PREFIX.get().append(
+								Component.translatable("skyblocker.config.foraging.sweepOverlay.sweepStatMissingMessage")
+										.withStyle(ChatFormatting.RED)));
+				sweepStatNoticeShown = true;
+			}
 		}
 
 		return 0.0f;


### PR DESCRIPTION
## Summary
- Fixes #2673 — players get an incorrect "Sweep Missing: Add the Sweep stat to your player list with /tablist" warning immediately on joining a Foraging island, even though Sweep *is* correctly configured in their tab list. Higher-ping connections are more affected since the server hasn't finished sending the tab list's custom text yet when the check first runs.
- `getSweepStat()` sends this warning the very first time it fails to find a `Sweep:` line in `PlayerListManager.getPlayerStringList()`, and only ever sends it once per session (`sweepStatNoticeShown`). If that first call happens to land before the tab list has populated, the one-shot warning is "used up" on a false negative and never corrects itself even once the real data arrives a moment later.

## Fix
- Added a grace period: the first time the stat is missing, just record the timestamp instead of warning immediately. Only send the warning once the missing state has persisted for 5 seconds straight. If the stat is found at any point before that, the timer resets.
- `getSweepStat()` is called every time the sweep overlay tries to render (i.e. repeatedly while looking at a tree), so this only delays the check by a few seconds on higher-ping joins — it doesn't skip or weaken it for players who actually don't have Sweep in their tablist.

## Test plan
- [x] Traced the call site (`submitConnectedLogs`) to confirm `getSweepStat()` runs repeatedly during normal play (whenever the sweep overlay renders), so the retry/grace-period logic gets multiple chances to observe the tab list once it's loaded, rather than being a one-shot check.
- [x] Change is scoped to `SweepOverlay.java` only, no changes to the tab list parsing itself.
- Not able to reproduce the original race (which depends on connection timing) in this environment, so please confirm the false-positive warning no longer appears on a normal/high-ping join before merging.