### PR TITLE
Storage overlay fixes

### DIFF
--- a/src/main/java/de/hysky/skyblocker/mixins/AbstractContainerMenuMixin.java
+++ b/src/main/java/de/hysky/skyblocker/mixins/AbstractContainerMenuMixin.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.ItemStack;
 import de.hysky.skyblocker.skyblock.InventorySearch;
 import de.hysky.skyblocker.skyblock.ItemPickupWidget;
 import de.hysky.skyblocker.skyblock.dungeon.partyfinder.PartyFinderScreen;
+import de.hysky.skyblocker.skyblock.storageoverlay.StorageOverlayScreen;
 import de.hysky.skyblocker.utils.container.ContainerSolverManager;
 
 @Mixin(AbstractContainerMenu.class)
@@ -37,8 +38,10 @@ public abstract class AbstractContainerMenuMixin {
 
 		// instanceof check to prevent changing behavior from old ChestMenuMixin
 		if ((Object) this instanceof ChestMenu) {
-			if (Minecraft.getInstance().gui.screen() instanceof PartyFinderScreen screen) {
-				screen.markDirty();
+			switch (Minecraft.getInstance().gui.screen()) {
+				case PartyFinderScreen screen -> screen.markDirty();
+				case StorageOverlayScreen screen -> screen.refreshSearch();
+				case null, default -> {}
 			}
 			broadcastChanges();
 		}
@@ -50,8 +53,10 @@ public abstract class AbstractContainerMenuMixin {
 
 		// instanceof check to prevent changing behavior from old ChestMenuMixin
 		if ((Object) this instanceof ChestMenu) {
-			if (Minecraft.getInstance().gui.screen() instanceof PartyFinderScreen screen) {
-				screen.markDirty();
+			switch (Minecraft.getInstance().gui.screen()) {
+				case PartyFinderScreen screen -> screen.markDirty();
+				case StorageOverlayScreen screen -> screen.refreshSearch();
+				case null, default -> {}
 			}
 			broadcastChanges();
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/ArmorTab.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/ArmorTab.java
@@ -77,6 +77,10 @@ public class ArmorTab extends GridLayoutTab implements Closeable {
 		}
 	};
 
+	// TODO: The layout always calculates sizes based on all widgets in the layout, even if they are not visible.
+	//  For example, in helmet customization, the layout uses the color selection widget's width
+	//  as the head selection widget's width, even though the color selection widget is not visible.
+	//  This results in the head selection widgets not being centered correctly on small screen widths.
 	public ArmorTab(CustomizeScreen parent) {
 		super(Component.translatable("skyblocker.customization.armor"));
 		this.parent = parent;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/HeadSelectionWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/HeadSelectionWidget.java
@@ -44,7 +44,7 @@ public class HeadSelectionWidget extends SearchableGridWidget {
 	private HeadButton selectedButton;
 
 	public HeadSelectionWidget(int x, int y, int width, int height) {
-		super(x + 2, y + 2, width - 4, height - 4, Component.nullToEmpty("HeadSelection"), 20);
+		super(x + 2, y + 2, width - 4, height - 4, Component.nullToEmpty("HeadSelection"), 20, true);
 
 		for (CustomHelmetTextures.NamedTexture tex : CustomHelmetTextures.getTextures()) {
 			ItemStack head = ProfileViewerUtils.createSkull(tex.texture()).getStackOrThrow();

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/TrimSelectionWidget.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/custom/screen/TrimSelectionWidget.java
@@ -83,6 +83,7 @@ public class TrimSelectionWidget extends AbstractContainerWidget {
 		// minus 9 because 3 pixels of left padding, right padding, and gap
 		int buttonsPerRow = (width - 9) / 20;
 		// Try to allocate more buttons to patterns since there are more patterns than materials
+		// TODO: Clamping these alone does not fix crash at small screen widths
 		int patternButtonsPerRow = Math.min(Math.ceilDiv(buttonsPerRow, 2), MAX_BUTTONS_PER_ROW_PATTERN);
 		int materialButtonsPerRow = Math.min(Math.floorDiv(buttonsPerRow, 2), MAX_BUTTONS_PER_ROW_MATERIAL);
 

--- a/src/main/java/de/hysky/skyblocker/skyblock/storageoverlay/StorageOverlayScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/storageoverlay/StorageOverlayScreen.java
@@ -136,6 +136,11 @@ public class StorageOverlayScreen extends AbstractContainerScreen<StorageOverlay
 		saveMousePosition = SkyblockerConfigManager.get().uiAndVisuals.storageOverlay.doNotResetCursor;
 	}
 
+	public void refreshSearch() {
+		if (grid == null) return;
+		grid.refreshSearch();
+	}
+
 	private static String getCommandForIndex(int index) {
 		if (index <= 8) {
 			return "/echest " + (index + 1);

--- a/src/main/java/de/hysky/skyblocker/skyblock/storageoverlay/StorageOverlayScreen.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/storageoverlay/StorageOverlayScreen.java
@@ -367,20 +367,14 @@ public class StorageOverlayScreen extends AbstractContainerScreen<StorageOverlay
 		@Nullable
 		private final Button reloadButton;
 
-		private BackpackGridWidget(int x, int y, int width, int height, int storagesPerRow, int internalCols, boolean packed) {
+		private BackpackGridWidget(int x, int y, int width, int height, int maxStoragesPerRow, int internalCols, boolean packed) {
 			// cut down number of columns if it will not fit on to the current gui size
 			int expectedWidth = internalCols * SLOT_SIZE + EDGE_PADDING * 2;
 			while (expectedWidth > width - AbstractScrollArea.SCROLLBAR_WIDTH) {
 				expectedWidth = --internalCols * SLOT_SIZE + EDGE_PADDING * 2;
 			}
 
-			if (packed) {
-				storagesPerRow = Math.min((width - AbstractScrollArea.SCROLLBAR_WIDTH) / expectedWidth, storagesPerRow);
-				width = storagesPerRow * expectedWidth + AbstractScrollArea.SCROLLBAR_WIDTH;
-				x = (StorageOverlayScreen.this.width - width) / 2;
-			}
-
-			super(x, y, width, height, Component.literal("BackPack grid"), expectedWidth, true);
+			super(x, y, width, height, Component.literal("BackPack grid"), expectedWidth, maxStoragesPerRow, packed, true);
 
 			//add backpacks
 			boolean storageLoaded = false;

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/AbstractSelectionPopup.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/AbstractSelectionPopup.java
@@ -31,7 +31,8 @@ public abstract class AbstractSelectionPopup<W extends AbstractWidget> extends A
 	@Override
 	public void init() {
 		GridLayout.RowHelper adder = gridWidget.createRowHelper(2);
-		addRenderableWidget(adder.addChild(new ItemList(300, (int) (height * 0.8f)), 2));
+		adder.defaultCellSetting().alignHorizontallyCenter();
+		addRenderableWidget(adder.addChild(new ItemList(326, (int) (height * 0.8f)), 2));
 		addRenderableWidget(adder.addChild(Button.builder(CommonComponents.GUI_CANCEL, _ -> {
 			onClose();
 			onDone.accept(Optional.empty());
@@ -68,7 +69,7 @@ public abstract class AbstractSelectionPopup<W extends AbstractWidget> extends A
 	private class ItemList extends SearchableGridWidget {
 
 		private ItemList(int width, int height) {
-			super(0, 0, width, height, Component.literal("Item List"), expectedWidgetWidth);
+			super(0, 0, width, height, Component.literal("Item List"), expectedWidgetWidth, true);
 			setSearch("");
 		}
 

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/SearchableGridWidget.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/SearchableGridWidget.java
@@ -83,6 +83,10 @@ public abstract class SearchableGridWidget extends AbstractContainerWidget {
 		searchField.setValue(search);
 	}
 
+	public void refreshSearch() {
+		searchField.setValue(searchField.getValue());
+	}
+
 	public void setScrollAmount(double amount) {
 		widgetsContainer.setScrollAmount(amount);
 	}

--- a/src/main/java/de/hysky/skyblocker/utils/render/gui/SearchableGridWidget.java
+++ b/src/main/java/de/hysky/skyblocker/utils/render/gui/SearchableGridWidget.java
@@ -29,16 +29,26 @@ public abstract class SearchableGridWidget extends AbstractContainerWidget {
 	private final WidgetsContainer widgetsContainer;
 
 	private final int expectedWidgetWidth;
+	private final int maxPerRow;
+	private final boolean packed;
 	private final boolean spaceElementsOut;
 
 	/// A grid of searchable widgets
 	/// @param expectedWidgetWidth The expected width of each widget in the grid. This class may place multiple grid widgets in the same row.
-	public SearchableGridWidget(int x, int y, int width, int height, Component message, int expectedWidgetWidth, boolean spaceElementsOut) {
+	/// @param maxPerRow The maximum number of widgets to place in a single row. This class may place fewer widgets in a row if the width of this grid is too small.
+	/// @param packed If true, the width of this grid will be reduced to fit as many widgets as possible in a row tightly.
+	/// If false, the width of this grid will be the same as the width passed to the constructor, and there may be space between widgets in the grid.
+	/// @param spaceElementsOut If true, the widgets in the grid will be spaced out to fill the entire width of the grid.
+	/// If false, the widgets will be placed next to each other with no space between them.
+	/// This parameter is essentially ignored if packed is true.
+	public SearchableGridWidget(int x, int y, int width, int height, Component message, int expectedWidgetWidth, int maxPerRow, boolean packed, boolean spaceElementsOut) {
 		super(x, y, width, height, message, AbstractScrollArea.defaultSettings(8));
 		searchField = new EditBox(Minecraft.getInstance().font, width, TEXT_FIELD_HEIGHT, Component.translatable("gui.recipebook.search_hint"));
 		searchField.setHint(Component.translatable("gui.recipebook.search_hint").withStyle(ChatFormatting.ITALIC).withStyle(ChatFormatting.GRAY));
 		searchField.setResponder(this::filterInternal);
 		this.expectedWidgetWidth = expectedWidgetWidth;
+		this.maxPerRow = maxPerRow;
+		this.packed = packed;
 		this.spaceElementsOut = spaceElementsOut;
 
 		widgetsContainer = new WidgetsContainer();
@@ -46,8 +56,22 @@ public abstract class SearchableGridWidget extends AbstractContainerWidget {
 		layoutWidget.addChild(widgetsContainer);
 		layoutWidget.arrangeElements();
 		layoutWidget.setPosition(x, y);
+
+		setWidth(getWidth()); // Trigger width calculation for packed grids
 	}
 
+	/// @see SearchableGridWidget#SearchableGridWidget(int, int, int, int, Component, int, int, boolean, boolean)
+	public SearchableGridWidget(int x, int y, int width, int height, Component message, int expectedWidgetWidth, int maxPerRow, boolean packed) {
+		this(x, y, width, height, message, expectedWidgetWidth, maxPerRow, packed, false);
+	}
+
+	/// @see SearchableGridWidget#SearchableGridWidget(int, int, int, int, Component, int, int, boolean, boolean)
+	public SearchableGridWidget(int x, int y, int width, int height, Component message, int expectedWidgetWidth, boolean packed) {
+		this(x, y, width, height, message, expectedWidgetWidth, Integer.MAX_VALUE, packed);
+	}
+
+	/// You probably want packed to be true.
+	/// @see SearchableGridWidget#SearchableGridWidget(int, int, int, int, Component, int, int, boolean, boolean)
 	public SearchableGridWidget(int x, int y, int width, int height, Component message, int expectedWidgetWidth) {
 		this(x, y, width, height, message, expectedWidgetWidth, false);
 	}
@@ -66,6 +90,12 @@ public abstract class SearchableGridWidget extends AbstractContainerWidget {
 
 	@Override
 	public void setWidth(int width) {
+		if (packed) {
+			int perRow = Math.min((width - AbstractScrollArea.SCROLLBAR_WIDTH) / expectedWidgetWidth, maxPerRow);
+			int newWidth = perRow * expectedWidgetWidth + AbstractScrollArea.SCROLLBAR_WIDTH;
+			setX(getX() + (width - newWidth) / 2);
+			width = newWidth;
+		}
 		super.setWidth(width);
 		searchField.setWidth(width);
 		widgetsContainer.setWidth(width);


### PR DESCRIPTION
Fixes storage overlay search not highlighting properly after opening a storage.  

Makes some other searchable grid widgets packed. Tested storage overlay (no changes), skyblocker custom helmet item selection (now packed), and quick nav item selection (now packed). All work as expected, including resizing.