### PR TITLE
feat: update Timber message

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/foraging/TreeFelledNotification.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/foraging/TreeFelledNotification.java
@@ -1,5 +1,8 @@
 package de.hysky.skyblocker.skyblock.foraging;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -11,9 +14,7 @@ import de.hysky.skyblocker.utils.render.title.Title;
 import de.hysky.skyblocker.utils.render.title.TitleContainer;
 
 public class TreeFelledNotification {
-	private static final String PETALFALL_MESSAGE = "PETALFALL! You felled the entire Tree!";
-	private static final String WOODPECKER_MESSAGE = "WOODPECKER! You felled the entire Tree!";
-	private static final String TIMBER_MESSAGE = "TIMBER! You felled the entire Tree!";
+	private static final Pattern TIMBER_PATTERN = Pattern.compile("TIMBER! You felled the entire \\w+ Tree!");
 	private static final Title TITLE = new Title("skyblocker.foraging.treeFelled", ChatFormatting.AQUA);
 
 	@Init
@@ -25,7 +26,8 @@ public class TreeFelledNotification {
 		if (Utils.isOnSkyblock() && Utils.isInForagingIsland() && SkyblockerConfigManager.get().foraging.enableTreeFelledNotification) {
 			String stringified = message.getString();
 
-			if (stringified.equals(PETALFALL_MESSAGE) || stringified.equals(WOODPECKER_MESSAGE) || stringified.equals(TIMBER_MESSAGE)) {
+			Matcher matcher = TIMBER_PATTERN.matcher(stringified);
+			if (matcher.matches()) {
 				// Show title for 3 seconds (same as mining ability chat rule preset)
 				TitleContainer.addTitle(TITLE, 3 * 20);
 			}


### PR DESCRIPTION
It's a single stat now, but the message includes the tree type:
<img width="451" height="51" alt="image" src="https://github.com/user-attachments/assets/86f506fe-6dc6-4723-b279-2f6dc6ffbb48" />
