### PR TITLE
Add outline options to teleport overlay highlight

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/UIAndVisualsCategory.java
@@ -676,6 +676,14 @@ public class UIAndVisualsCategory {
 										})
 								.controller(ColourController.createBuilder().hasAlpha(true).build())
 								.build())
+						.option(Option.<UIAndVisualsConfig.TeleportOverlay.HighlightType>createBuilder()
+								.name(Component.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.highlightType"))
+								.description(Component.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.highlightType.@Tooltip"))
+								.binding(defaults.uiAndVisuals.teleportOverlay.highlightType,
+										() -> config.uiAndVisuals.teleportOverlay.highlightType,
+										newValue -> config.uiAndVisuals.teleportOverlay.highlightType = newValue)
+								.controller(ConfigUtils.createEnumController())
+								.build())
 						.option(Option.<Boolean>createBuilder()
 								.name(Component.translatable("skyblocker.config.uiAndVisuals.teleportOverlay.enableWeirdTransmission"))
 								.description(Component.translatable("skyblocker.config.uiAndVisuals.smoothAOTE.enableWeirdTransmission.@Tooltip"))

--- a/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/UIAndVisualsConfig.java
@@ -393,6 +393,19 @@ public class UIAndVisualsConfig {
 
 		public Color teleportOverlayColor = new Color(0x7F761594, true);
 
+		public HighlightType highlightType = HighlightType.HIGHLIGHT;
+
+		public enum HighlightType {
+			HIGHLIGHT,
+			OUTLINED_HIGHLIGHT,
+			OUTLINE;
+
+			@Override
+			public String toString() {
+				return I18n.get("skyblocker.config.uiAndVisuals.teleportOverlay.highlightType." + name());
+			}
+		}
+
 		public boolean enableWeirdTransmission = false;
 
 		public boolean enableInstantTransmission = false;

--- a/src/main/java/de/hysky/skyblocker/skyblock/teleport/TeleportOverlay.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/teleport/TeleportOverlay.java
@@ -10,6 +10,7 @@ import net.minecraft.world.phys.Vec3;
 
 import de.hysky.skyblocker.annotations.Init;
 import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.config.configs.UIAndVisualsConfig;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.render.LevelRenderExtractionCallback;
@@ -102,8 +103,15 @@ public class TeleportOverlay {
 			} else {
 				target = target.below();
 			}
-			if (!SkyblockerConfigManager.get().uiAndVisuals.teleportOverlay.showWhenInAir && client.level.getBlockState(target).isAir()) return;
-			collector.submitFilledBox(target, colorComponents, colorComponents[3], false);
+
+			UIAndVisualsConfig.TeleportOverlay config = SkyblockerConfigManager.get().uiAndVisuals.teleportOverlay;
+			if (!config.showWhenInAir && client.level.getBlockState(target).isAir()) return;
+			if (config.highlightType != UIAndVisualsConfig.TeleportOverlay.HighlightType.OUTLINE) {
+				collector.submitFilledBox(target, colorComponents, colorComponents[3], false);
+			}
+			if (config.highlightType != UIAndVisualsConfig.TeleportOverlay.HighlightType.HIGHLIGHT) {
+				collector.submitOutlinedBox(target, colorComponents, 4f, false);
+			}
 		}
 	}
 

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -1642,6 +1642,11 @@
   "skyblocker.config.uiAndVisuals.teleportOverlay.enableTeleportOverlays": "Enable Teleport Overlays",
   "skyblocker.config.uiAndVisuals.teleportOverlay.enableWeirdTransmission": "Enable Weird Transmission Overlay",
   "skyblocker.config.uiAndVisuals.teleportOverlay.enableWitherImpact": "Enable Wither Impact Overlay",
+  "skyblocker.config.uiAndVisuals.teleportOverlay.highlightType": "Overlay Highlight Type",
+  "skyblocker.config.uiAndVisuals.teleportOverlay.highlightType.@Tooltip": "Highlight: Only displays a highlight.\n\nOutlined Highlight: Displays both a highlight and an outline.\n\nOutline: Only displays an outline.",
+  "skyblocker.config.uiAndVisuals.teleportOverlay.highlightType.HIGHLIGHT": "Highlight",
+  "skyblocker.config.uiAndVisuals.teleportOverlay.highlightType.OUTLINE": "Outline",
+  "skyblocker.config.uiAndVisuals.teleportOverlay.highlightType.OUTLINED_HIGHLIGHT": "Outlined Highlight",
   "skyblocker.config.uiAndVisuals.teleportOverlay.showWhenInAir": "Show Overlay Mid Air",
   "skyblocker.config.uiAndVisuals.teleportOverlay.teleportOverlayColor": "Teleport Overlay Color",
 


### PR DESCRIPTION
See title and tests, pretty self explanatory.

### Testing
<details>
<summary>Default Highlight option works same as before</summary>

Option selected:
<img width="579" height="204" alt="image" src="https://github.com/user-attachments/assets/1cd22c83-08e0-4c14-8bf4-a2d9247d3a3e" />

Instant Transmission:
<img width="882" height="503" alt="image" src="https://github.com/user-attachments/assets/3e824af9-8c26-4596-bede-12ded2f80055" />

Ether Transmission:
<img width="830" height="558" alt="image" src="https://github.com/user-attachments/assets/111f4daa-255d-4812-8c37-be2e6a4c8c83" />
</details>
<details>
<summary>Outline option works</summary>

Option selected:
<img width="575" height="203" alt="image" src="https://github.com/user-attachments/assets/6d711a31-f39c-490f-abc2-baada955060d" />

Instant Transmission:
<img width="861" height="524" alt="image" src="https://github.com/user-attachments/assets/655f77e3-a59d-4e85-bcd0-fa1d548d1485" />

Ether Transmission:
<img width="969" height="580" alt="image" src="https://github.com/user-attachments/assets/17fb5413-2a00-4241-9133-c69347bbb1fe" />
</details>
<details>
<summary>Outlined Highlight option works</summary>

Option selected:
<img width="579" height="201" alt="image" src="https://github.com/user-attachments/assets/1dd18d82-4100-4507-ac05-2d36329a6d26" />

Instant Transmission:
<img width="978" height="611" alt="image" src="https://github.com/user-attachments/assets/fe18b2e1-a776-42f2-bbd0-830bed35b958" />

Ether Transmission:
<img width="796" height="498" alt="image" src="https://github.com/user-attachments/assets/1c0b0f58-0c14-4c4e-abf7-3293e575cbba" />
</details>