### PR TITLE
Improve Slot Text API

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
@@ -118,7 +118,7 @@ public class SlotTextManager {
 	@Init
 	public static void init() {
 		ScreenEvents.AFTER_INIT.register((_, screen, _, _) -> {
-			if ((screen instanceof AbstractContainerScreen<?> && Utils.isOnSkyblock()) || screen instanceof ProfileViewerScreen || screen instanceof RadialMenuScreen) {
+			if (screen instanceof AbstractContainerScreen<?> || screen instanceof ProfileViewerScreen || screen instanceof RadialMenuScreen) {
 				onScreenChange(screen);
 				ScreenEvents.remove(screen).register(_ -> currentScreenAdders.clear());
 			}
@@ -138,7 +138,7 @@ public class SlotTextManager {
 
 	private static void onScreenChange(Screen screen) {
 		for (SlotTextAdder adder : adders) {
-			if (adder.isEnabled() && adder.test(screen)) {
+			if ((Utils.isOnSkyblock() || !adder.skyblockOnly()) && adder.isEnabled() && adder.test(screen)) {
 				currentScreenAdders.add(adder);
 			}
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/SlotTextManager.java
@@ -1,8 +1,9 @@
 package de.hysky.skyblocker.skyblock.item.slottext;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import com.mojang.blaze3d.platform.InputConstants;
@@ -65,7 +66,7 @@ import de.hysky.skyblocker.utils.Utils;
 import de.hysky.skyblocker.utils.container.SlotTextAdder;
 
 public class SlotTextManager {
-	private static final SlotTextAdder[] adders = new SlotTextAdder[]{
+	private static final List<SlotTextAdder> adders = new ArrayList<>(List.of(
 			new EssenceShopAdder(),
 			new EnchantmentAbbreviationAdder(),
 			new EnchantmentLevelAdder(),
@@ -101,13 +102,17 @@ public class SlotTextManager {
 			new HuntingToolkitIndicatorAdder(),
 			new ChipLevelAdder(),
 			new CropMilestonesAdder(),
-			new GardenUpgradesAdder(),
-	};
-	private static final ArrayList<SlotTextAdder> currentScreenAdders = new ArrayList<>();
+			new GardenUpgradesAdder()
+	));
+	private static final Set<SlotTextAdder> currentScreenAdders = new HashSet<>();
 	public static final KeyMapping KEY_MAPPING = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.skyblocker.slottext", InputConstants.KEY_LALT, SkyblockerMod.KEYBINDING_CATEGORY));
 	private static boolean keyHeld = false;
 
-	private SlotTextManager() {
+	private SlotTextManager() {}
+
+	@SuppressWarnings("unused")
+	public static void registerAdder(SlotTextAdder adder) {
+		adders.add(adder);
 	}
 
 	@Init
@@ -189,7 +194,7 @@ public class SlotTextManager {
 	}
 
 	public static Stream<SlotTextAdder> getAdderStream() {
-		return Arrays.stream(adders);
+		return adders.stream();
 	}
 
 	public static boolean isEnabled(String adderId) {

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerMatcher.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerMatcher.java
@@ -16,4 +16,9 @@ public interface ContainerMatcher extends Predicate<Screen> {
 	 * @return {@code true} if this matcher is enabled, {@code false} otherwise
 	 */
 	boolean isEnabled();
+
+	/// @return true if this solver should only work in Skyblock.
+	default boolean skyblockOnly() {
+		return true;
+	}
 }

--- a/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolver.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/ContainerSolver.java
@@ -59,11 +59,6 @@ public interface ContainerSolver extends ContainerMatcher, Resettable {
 		}
 	}
 
-	/// @return true if this solver should only work in Skyblock.
-	default boolean skyblockOnly() {
-		return true;
-	}
-
 	/// Override and return false to make this solver work in the inventory screen and
 	/// other {@link net.minecraft.client.gui.screens.inventory.AbstractContainerScreen AbstractContainerScreen}s.
 	default boolean chestScreensOnly() {

--- a/src/main/java/de/hysky/skyblocker/utils/container/SlotTextAdder.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/SlotTextAdder.java
@@ -35,11 +35,6 @@ public interface SlotTextAdder extends ContainerMatcher {
 		return SlotTextManager.isEnabled(getConfigInformation().id());
 	}
 
-	/// @return true if this solver should only work in Skyblock.
-	default boolean skyblockOnly() {
-		return true;
-	}
-
 	default @Nullable ConfigInformation getConfigInformation() {
 		return null;
 	}

--- a/src/main/java/de/hysky/skyblocker/utils/container/SlotTextAdder.java
+++ b/src/main/java/de/hysky/skyblocker/utils/container/SlotTextAdder.java
@@ -35,6 +35,11 @@ public interface SlotTextAdder extends ContainerMatcher {
 		return SlotTextManager.isEnabled(getConfigInformation().id());
 	}
 
+	/// @return true if this solver should only work in Skyblock.
+	default boolean skyblockOnly() {
+		return true;
+	}
+
 	default @Nullable ConfigInformation getConfigInformation() {
 		return null;
 	}

--- a/src/main/resources/skyblocker.classtweaker
+++ b/src/main/resources/skyblocker.classtweaker
@@ -67,6 +67,6 @@ accessible	class	net/minecraft/client/resources/server/ServerPackManager$ServerP
 accessible	field	net/minecraft/client/resources/server/ServerPackManager$ServerPackData	url	Ljava/net/URL;
 
 # Interface Injections
-inject-interface	net/minecraft/world/entity/Entity	de/hysky/skyblocker/injected/SkyblockerEntity
-inject-interface	net/minecraft/world/item/ItemStack	de/hysky/skyblocker/injected/SkyblockerStack
-inject-interface	net/minecraft/client/gui/screens/inventory/InventoryScreen	de/hysky/skyblocker/injected/RecipeBookHolder
+transitive-inject-interface	net/minecraft/world/entity/Entity	de/hysky/skyblocker/injected/SkyblockerEntity
+transitive-inject-interface	net/minecraft/world/item/ItemStack	de/hysky/skyblocker/injected/SkyblockerStack
+transitive-inject-interface	net/minecraft/client/gui/screens/inventory/InventoryScreen	de/hysky/skyblocker/injected/RecipeBookHolder


### PR DESCRIPTION
Add support for registering slot text adders and non-skyblock-only option.  
Make interface injections transitive, should not change conflicts, etc.  

Slot text still works fine:
<img width="966" height="620" alt="Skyblock skills menu with slot text" src="https://github.com/user-attachments/assets/965ca4d0-2856-4a0b-a78b-253a80b8f24e" />
