### PR TITLE
Merge dungeon messages into single category

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java
@@ -830,9 +830,9 @@ public class DungeonsCategory {
 								.build())
 						.build())
 
-				// Mimic Message
+				// Dungeon Messages
 				.group(OptionGroup.createBuilder()
-						.name(Component.translatable("skyblocker.config.dungeons.mimicMessage"))
+						.name(Component.translatable("skyblocker.config.dungeons.dungeonMessages"))
 						.collapsed(true)
 						.option(Option.<Boolean>createBuilder()
 								.name(Component.translatable("skyblocker.config.dungeons.mimicMessage.sendMimicMessage"))
@@ -842,12 +842,6 @@ public class DungeonsCategory {
 										newValue -> config.dungeons.mimicMessage.sendMimicMessage = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
-						.build())
-
-				// Prince Message
-				.group(OptionGroup.createBuilder()
-						.name(Component.translatable("skyblocker.config.dungeons.princeMessage"))
-						.collapsed(true)
 						.option(Option.<Boolean>createBuilder()
 								.name(Component.translatable("skyblocker.config.dungeons.princeMessage.sendPrinceMessage"))
 								.description(Component.translatable("skyblocker.config.dungeons.princeMessage.sendPrinceMessage.@Tooltip"))
@@ -856,12 +850,6 @@ public class DungeonsCategory {
 										newValue -> config.dungeons.princeMessage.sendPrinceMessage = newValue)
 								.controller(ConfigUtils.createBooleanController())
 								.build())
-						.build())
-
-				// Bat Message
-				.group(OptionGroup.createBuilder()
-						.name(Component.translatable("skyblocker.config.dungeons.batMessage"))
-						.collapsed(false)
 						.option(Option.<Boolean>createBuilder()
 								.name(Component.translatable("skyblocker.config.dungeons.batMessage.sendBatMessage"))
 								.description(Component.translatable("skyblocker.config.dungeons.batMessage.sendBatMessage.@Tooltip"))

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -232,7 +232,6 @@
   "skyblocker.config.dungeons.allowDroppingProtectedItems": "Enabled Dropping Protected Items & on Locked Slots",
   "skyblocker.config.dungeons.allowDroppingProtectedItems.@Tooltip": "Allows the use of class abilities in Dungeons on a locked slot or while holding an item which has been protected using /skyblocker protectItem.",
 
-  "skyblocker.config.dungeons.batMessage": "Bat Message",
   "skyblocker.config.dungeons.batMessage.sendBatMessage": "Enable Bat Message",
   "skyblocker.config.dungeons.batMessage.sendBatMessage.@Tooltip": "Sends a message in the chat upon killing a bat for other players' score calculation mods.",
 
@@ -280,6 +279,8 @@
   "skyblocker.config.dungeons.dungeonChestProfit.neutralThreshold": "Neutral Threshold",
   "skyblocker.config.dungeons.dungeonChestProfit.neutralThreshold.@Tooltip": "The threshold below which the profit is considered neutral.",
   "skyblocker.config.dungeons.dungeonChestProfit.profitColor": "Profit Color",
+
+  "skyblocker.config.dungeons.dungeonMessages": "Dungeon Messages",
 
   "skyblocker.config.dungeons.dungeonScore": "Dungeon Score",
   "skyblocker.config.dungeons.dungeonScore.dungeonCryptsMessage": "Dungeon Crypts Message",
@@ -349,14 +350,12 @@
   "skyblocker.config.dungeons.map.showSelfHead": "Show Self Head",
   "skyblocker.config.dungeons.map.showSelfHead.@Tooltip": "This feature will not work if a user uses /nick, making it hard to determine their identity.",
 
-  "skyblocker.config.dungeons.mimicMessage": "Mimic Message",
   "skyblocker.config.dungeons.mimicMessage.sendMimicMessage": "Enable Mimic Message",
   "skyblocker.config.dungeons.mimicMessage.sendMimicMessage.@Tooltip": "Sends a message in the chat upon killing a Mimic for other players' score calculation mods.",
 
   "skyblocker.config.dungeons.playerSecretsTracker": "Player Secrets Tracker",
   "skyblocker.config.dungeons.playerSecretsTracker.@Tooltip": "Tracks the number of secrets people in your dungeon run are doing.",
 
-  "skyblocker.config.dungeons.princeMessage": "Prince Message",
   "skyblocker.config.dungeons.princeMessage.sendPrinceMessage": "Enable Prince Message",
   "skyblocker.config.dungeons.princeMessage.sendPrinceMessage.@Tooltip": "Sends a message in the chat upon killing a Prince for other players' score calculation mods.",
 


### PR DESCRIPTION
It doesn't make sense that three extremely similar config options are all given their own groups for a single option, so I just merged them all into one group. They were even already next to each other.

### Before
<img width="658" height="455" alt="image" src="https://github.com/user-attachments/assets/8ab23a31-e4dd-4646-a3bd-086fa14998eb" />

### After
<img width="618" height="435" alt="image" src="https://github.com/user-attachments/assets/bcbd27cc-cc86-4d89-bb00-f14648f73217" />
