### PR TITLE
Add option to switch to old NEU style for price-related tooltip additions

### DIFF
--- a/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
+++ b/src/main/java/de/hysky/skyblocker/config/categories/GeneralCategory.java
@@ -214,6 +214,14 @@ public class GeneralCategory {
 						.name(Component.translatable("skyblocker.config.general.itemTooltip"))
 						.collapsed(true)
 						.option(Option.<Boolean>createBuilder()
+								.name(Component.translatable("skyblocker.config.general.itemTooltip.oldNeuItemValueStyle"))
+								.description(Component.translatable("skyblocker.config.general.itemTooltip.oldNeuItemValueStyle.@Tooltip"))
+								.binding(defaults.general.itemTooltip.oldNeuItemValueStyle,
+										() -> config.general.itemTooltip.oldNeuItemValueStyle,
+										newValue -> config.general.itemTooltip.oldNeuItemValueStyle = newValue)
+								.controller(ConfigUtils.createBooleanController())
+								.build())
+						.option(Option.<Boolean>createBuilder()
 								.name(Component.translatable("skyblocker.config.general.itemTooltip.enableNPCPrice"))
 								.description(Component.translatable("skyblocker.config.general.itemTooltip.enablePrice.@Tooltip"))
 								.binding(defaults.general.itemTooltip.enableNPCPrice,

--- a/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
+++ b/src/main/java/de/hysky/skyblocker/config/configs/GeneralConfig.java
@@ -102,6 +102,8 @@ public class GeneralConfig {
 	}
 
 	public static class ItemTooltip {
+		public boolean oldNeuItemValueStyle = false;
+
 		public boolean enableNPCPrice = true;
 
 		public boolean enableGeorgePrice = true;

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/AvgBinTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/AvgBinTooltip.java
@@ -13,7 +13,7 @@ import de.hysky.skyblocker.config.configs.GeneralConfig.Average;
 import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
-import de.hysky.skyblocker.utils.render.text.GridComponent;
+import de.hysky.skyblocker.utils.SkyBlockTooltipStyles;
 
 public class AvgBinTooltip extends SimpleTooltipAdder {
 	public AvgBinTooltip(int priority) {
@@ -30,12 +30,12 @@ public class AvgBinTooltip extends SimpleTooltipAdder {
 		} else {
 			// "No data" line because of API not keeping old data, it causes NullPointerException
 			if ((type == Average.ONE_DAY || type == Average.BOTH) && TooltipInfoType.ONE_DAY_AVERAGE.hasOrNullWarning(skyblockApiId)) {
-				lines.add(GridComponent.of(
+				lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 						Component.literal("1 Day Avg. Price:").withStyle(ChatFormatting.GOLD),
 						ItemTooltip.getCoinsMessage(TooltipInfoType.ONE_DAY_AVERAGE.getData().getDouble(skyblockApiId), stack.getCount())));
 			}
 			if ((type == Average.THREE_DAY || type == Average.BOTH) && TooltipInfoType.THREE_DAY_AVERAGE.hasOrNullWarning(skyblockApiId)) {
-				lines.add(GridComponent.of(
+				lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 						Component.literal("3 Day Avg. Price:").withStyle(ChatFormatting.GOLD),
 						ItemTooltip.getCoinsMessage(TooltipInfoType.THREE_DAY_AVERAGE.getData().getDouble(skyblockApiId), stack.getCount())));
 			}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/BazaarPriceTooltip.java
@@ -14,7 +14,7 @@ import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
 import de.hysky.skyblocker.utils.BazaarProduct;
 import de.hysky.skyblocker.utils.ItemUtils;
-import de.hysky.skyblocker.utils.render.text.GridComponent;
+import de.hysky.skyblocker.utils.SkyBlockTooltipStyles;
 
 public class BazaarPriceTooltip extends SimpleTooltipAdder {
 	public BazaarPriceTooltip(int priority) {
@@ -29,12 +29,12 @@ public class BazaarPriceTooltip extends SimpleTooltipAdder {
 			int count = Math.max(ItemUtils.getItemCountInSack(stack, stack.skyblocker$getLoreStrings()).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(ItemUtils.getItemCountInSuperpairs(stack).orElse(ItemUtils.getCompostCountInComposter(stack.skyblocker$getLoreStrings()).orElse(stack.getCount())))), 1);
 
 			BazaarProduct product = TooltipInfoType.BAZAAR.getData().get(skyblockApiId);
-			lines.add(GridComponent.of(
+			lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 					Component.literal("Bazaar Buy Price:").withStyle(ChatFormatting.GOLD),
 					product.buyPrice().isEmpty()
 							? Component.literal("No data").withStyle(ChatFormatting.RED)
 							: ItemTooltip.getCoinsMessage(product.buyPrice().getAsDouble(), count)));
-			lines.add(GridComponent.of(
+			lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 					Component.literal("Bazaar Sell Price:").withStyle(ChatFormatting.GOLD),
 					product.sellPrice().isEmpty()
 							? Component.literal("No data").withStyle(ChatFormatting.RED)

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/CraftPriceTooltip.java
@@ -32,7 +32,7 @@ import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
 import de.hysky.skyblocker.utils.BazaarProduct;
 import de.hysky.skyblocker.utils.ItemUtils;
 import de.hysky.skyblocker.utils.NEURepoManager;
-import de.hysky.skyblocker.utils.render.text.GridComponent;
+import de.hysky.skyblocker.utils.SkyBlockTooltipStyles;
 
 public class CraftPriceTooltip extends SimpleTooltipAdder {
 	protected static final Logger LOGGER = LoggerFactory.getLogger(CraftPriceTooltip.class.getName());
@@ -55,7 +55,7 @@ public class CraftPriceTooltip extends SimpleTooltipAdder {
 			double craftPrice = cachedCraftCosts.computeIfAbsent(itemId, CraftPriceTooltip::getItemCost);
 			if (craftPrice <= 0) return;
 			int count = Math.max(ItemUtils.getItemCountInSack(stack, stack.skyblocker$getLoreStrings()).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(stack.getCount())), 1);
-			lines.add(GridComponent.of(
+			lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 					Component.literal("Crafting Price:").withStyle(ChatFormatting.GOLD),
 					ItemTooltip.getCoinsMessage(craftPrice, count)));
 		} catch (Exception e) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/EstimatedItemValueTooltip.java
@@ -14,8 +14,8 @@ import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
 import de.hysky.skyblocker.utils.ItemUtils;
+import de.hysky.skyblocker.utils.SkyBlockTooltipStyles;
 import de.hysky.skyblocker.utils.networth.NetworthCalculator;
-import de.hysky.skyblocker.utils.render.text.GridComponent;
 
 public class EstimatedItemValueTooltip extends SimpleTooltipAdder {
 
@@ -34,7 +34,7 @@ public class EstimatedItemValueTooltip extends SimpleTooltipAdder {
 		NetworthResult result = NetworthCalculator.getItemNetworth(stack, count);
 
 		if (result.price() > 0) {
-			lines.add(GridComponent.of(
+			lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 					Component.literal("Est. Item Value:").withStyle(ChatFormatting.GOLD),
 					ItemTooltip.getCoinsMessage(result.price(), count, true)));
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/LBinTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/LBinTooltip.java
@@ -12,7 +12,7 @@ import net.minecraft.world.item.ItemStack;
 import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
-import de.hysky.skyblocker.utils.render.text.GridComponent;
+import de.hysky.skyblocker.utils.SkyBlockTooltipStyles;
 
 public class LBinTooltip extends SimpleTooltipAdder {
 	public LBinTooltip(int priority) {
@@ -30,7 +30,7 @@ public class LBinTooltip extends SimpleTooltipAdder {
 
 		// Check for whether the item exist in bazaar price data, because Skytils keeps some bazaar item data in lbin api
 		if (TooltipInfoType.LOWEST_BINS.hasOrNullWarning(skyblockApiId) && !TooltipInfoType.BAZAAR.hasOrNullWarning(skyblockApiId)) {
-			lines.add(GridComponent.of(
+			lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 					Component.literal("Lowest BIN Price:").withStyle(ChatFormatting.GOLD),
 					ItemTooltip.getCoinsMessage(TooltipInfoType.LOWEST_BINS.getData().getDouble(skyblockApiId), stack.getCount())));
 		}

--- a/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/tooltip/adders/NpcPriceTooltip.java
@@ -13,7 +13,7 @@ import de.hysky.skyblocker.skyblock.item.tooltip.ItemTooltip;
 import de.hysky.skyblocker.skyblock.item.tooltip.SimpleTooltipAdder;
 import de.hysky.skyblocker.skyblock.item.tooltip.info.TooltipInfoType;
 import de.hysky.skyblocker.utils.ItemUtils;
-import de.hysky.skyblocker.utils.render.text.GridComponent;
+import de.hysky.skyblocker.utils.SkyBlockTooltipStyles;
 
 public class NpcPriceTooltip extends SimpleTooltipAdder {
 
@@ -39,7 +39,7 @@ public class NpcPriceTooltip extends SimpleTooltipAdder {
 
 		int count = Math.max(ItemUtils.getItemCountInSack(stack, stack.skyblocker$getLoreStrings()).orElse(ItemUtils.getItemCountInStash(lines.getFirst()).orElse(ItemUtils.getCompostCountInComposter(stack.skyblocker$getLoreStrings()).orElse(stack.getCount()))), 1);
 
-		lines.add(GridComponent.of(
+		lines.add(SkyBlockTooltipStyles.applyCoinStyle(
 				Component.literal("NPC Sell Price:").withStyle(ChatFormatting.YELLOW),
 				ItemTooltip.getCoinsMessage(price, count)));
 	}

--- a/src/main/java/de/hysky/skyblocker/utils/SkyBlockTooltipStyles.java
+++ b/src/main/java/de/hysky/skyblocker/utils/SkyBlockTooltipStyles.java
@@ -1,6 +1,12 @@
 package de.hysky.skyblocker.utils;
 
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
+
+import de.hysky.skyblocker.config.SkyblockerConfigManager;
+import de.hysky.skyblocker.utils.render.text.GridComponent;
 
 public final class SkyBlockTooltipStyles {
 	public static final Identifier COMMON = Identifier.fromNamespaceAndPath(Utils.HYPIXEL_SKYBLOCK_NAMESPACE, "common");
@@ -14,4 +20,13 @@ public final class SkyBlockTooltipStyles {
 	public static final Identifier VERY_SPECIAL = Identifier.fromNamespaceAndPath(Utils.HYPIXEL_SKYBLOCK_NAMESPACE, "very_special");
 	public static final Identifier ULTIMATE = Identifier.fromNamespaceAndPath(Utils.HYPIXEL_SKYBLOCK_NAMESPACE, "ultimate");
 	public static final Identifier ADMIN = Identifier.fromNamespaceAndPath(Utils.HYPIXEL_SKYBLOCK_NAMESPACE, "admin");
+
+	public static Component applyCoinStyle(Component label, Component value) {
+		if (SkyblockerConfigManager.get().general.itemTooltip.oldNeuItemValueStyle) {
+			MutableComponent legacyLabel = Component.literal(label.getString()).withStyle(ChatFormatting.YELLOW, ChatFormatting.BOLD);
+			MutableComponent legacyValue = Component.literal(value.getString()).withStyle(ChatFormatting.GOLD, ChatFormatting.BOLD);
+			return Component.empty().append(legacyLabel).append(" ").append(legacyValue);
+		}
+		return GridComponent.of(label, value);
+	}
 }

--- a/src/main/resources/assets/skyblocker/lang/en_us.json
+++ b/src/main/resources/assets/skyblocker/lang/en_us.json
@@ -673,6 +673,8 @@
   "skyblocker.config.general.itemTooltip.enablePrice.@Tooltip": "Price data is loaded via API. If the network fails to load data, please try manually refreshing the data using /skyblocker refreshPrices, or check if the network can access https://hysky.de/ and https://api.azureaaron.net/.",
   "skyblocker.config.general.itemTooltip.enableStackingEnchantProgress": "Enable Stacking Enchant Progress",
   "skyblocker.config.general.itemTooltip.enableStackingEnchantProgress.@Tooltip": "Displays the progress to the next level of a stacking enchantment if it hasn't been maxed.",
+  "skyblocker.config.general.itemTooltip.oldNeuItemValueStyle": "Old NEU Item Value Style",
+  "skyblocker.config.general.itemTooltip.oldNeuItemValueStyle.@Tooltip": "Reverts to using old NEU item value tooltip styles.",
   "skyblocker.config.general.itemTooltip.showEssenceCost": "Show Essence Cost",
 
   "skyblocker.config.general.quiverWarning": "Quiver Warning",


### PR DESCRIPTION
Addresses #2161.
Changes Made:
- Added a function that handles price formatting based on old NEU formatting & routed all price related stuff through it.
- Disables grid formatting for more authenticity.

<img width="657" height="295" alt="image" src="https://github.com/user-attachments/assets/5c84308f-8faf-4c35-90f9-73e95efcf87b" />
