### PR TITLE
Fix filtering empty chat messages

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -120,8 +120,9 @@ public class StatusBarTracker {
 		return InteractionResult.PASS;
 	}
 
-	private static boolean allowOverlayMessage(Component text, boolean overlay) {
-		return !onOverlayMessage(text, overlay).getString().isEmpty();
+	@VisibleForTesting
+	protected static boolean allowOverlayMessage(Component text, boolean overlay) {
+		return !overlay || !onOverlayMessage(text, true).getString().isEmpty();
 	}
 
 	private static Component onOverlayMessage(Component text, boolean overlay) {

--- a/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/StatusBarTracker.java
@@ -122,7 +122,7 @@ public class StatusBarTracker {
 
 	@VisibleForTesting
 	protected static boolean allowOverlayMessage(Component text, boolean overlay) {
-		return !overlay || !onOverlayMessage(text, true).getString().isEmpty();
+		return !overlay || !onOverlayMessage(text, overlay).getString().isEmpty();
 	}
 
 	private static Component onOverlayMessage(Component text, boolean overlay) {

--- a/src/test/java/de/hysky/skyblocker/skyblock/StatusBarTrackerTest.java
+++ b/src/test/java/de/hysky/skyblocker/skyblock/StatusBarTrackerTest.java
@@ -2,6 +2,8 @@ package de.hysky.skyblocker.skyblock;
 
 import org.junit.jupiter.api.Test;
 
+import net.minecraft.network.chat.Component;
+
 import de.hysky.skyblocker.utils.Location;
 import de.hysky.skyblocker.utils.Utils;
 
@@ -9,6 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StatusBarTrackerTest {
+	@Test
+	void emptyChatMessage() {
+		assertTrue(StatusBarTracker.allowOverlayMessage(Component.empty(), false));
+	}
 
 	void assertStats(int hp, int maxHp, int def, int mana, int maxMana, int overflowMana) {
 		int absorption = 0;


### PR DESCRIPTION
## What changed

- Preserve empty regular chat messages in `StatusBarTracker`
- Continue filtering empty action bar messages
- Add a regression test for empty non-overlay messages

## Why

`allowOverlayMessage` checked whether every game message was empty without first checking the `overlay` flag. As a result, empty regular chat packets were rejected by `ClientReceiveMessageEvents.ALLOW_GAME`. Hypixel uses those packets to add vertical spacing around multi-line messages such as Tree Gift rewards.

## Testing

- `./gradlew spotlessCheck checkstyleMain checkstyleTest test --tests de.hysky.skyblocker.skyblock.StatusBarTrackerTest`