### PR TITLE
Fix Museum Button Crash

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/museum/DonationButton.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/museum/DonationButton.java
@@ -58,7 +58,8 @@ public class DonationButton extends AbstractWidget {
 		FlexibleItemStack flexible = !donation.isSet()
 				? ItemRepository.getItemStack(donation.getId())
 				: ItemRepository.getItemStack(MuseumItemCache.ARMOR_TO_ID.get(donation.getId()));
-		this.itemStack = flexible == null ? null : flexible.getStackOrThrow();
+		if (flexible == null) flexible = ItemUtils.getItemIdPlaceholder(donation.getId());
+		this.itemStack = flexible.getStackOrEmpty();
 		buildTooltip();
 	}
 


### PR DESCRIPTION
If the stack is null and it was hovered over